### PR TITLE
Modular Fault System Rupture Set/Solution

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -697,9 +697,9 @@ private Table<Region, Boolean, double[]> fractRupsInsideRegions = HashBasedTable
 				faultSectionData, sectSlipRates, sectSlipRateStdDevs, sectAreas, sectionForRups,
 				mags, rakes, rupAreas, rupLengths, info);
 		if (hasModule(PlausibilityConfigurationModule.class))
-			old.setPlausibilityConfiguration(getModule(PlausibilityConfigurationModule.class).getConfiguration());
+			old.setPlausibilityConfiguration(getModule(PlausibilityConfigurationModule.class).get());
 		if (hasModule(ClusterRuptures.class))
-			old.setClusterRuptures(getModule(ClusterRuptures.class).getClusterRuptures());
+			old.setClusterRuptures(getModule(ClusterRuptures.class).get());
 		return old;
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
@@ -8,7 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionModule;
 import com.google.common.base.Preconditions;
 
 /**
- * This class is represents an Earthquake Rate Model solution for a fault system, possibly coming from an Inversion
+ * This class represents an Earthquake Rate Model solution for a fault system, possibly coming from an Inversion
  * or from a physics-based earthquake simulator.
  * <p>
  * It adds rate information to a FaultSystemRupSet.

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
@@ -1,0 +1,141 @@
+package org.opensha.sha.earthquake.faultSysSolution;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.modules.ModuleManager;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionModule;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This class is represents an Earthquake Rate Model solution for a fault system, possibly coming from an Inversion
+ * or from a physics-based earthquake simulator.
+ * <p>
+ * It adds rate information to a FaultSystemRupSet.
+ * 
+ * @author Field, Milner, Page, and Powers
+ *
+ */
+public final class FaultSystemSolution {
+	// TODO: should this be final?
+	// TODO: add MFD calculation methods, or throw them in a utility class instead?
+
+	private FaultSystemRupSet rupSet;
+	private double[] rates;
+	// this is separate from the rupSet info string as you can have multiple solutions with one rupSet
+	private String infoString;
+	
+	private ModuleManager<SolutionModule> moduleManager;
+	
+	public FaultSystemSolution(FaultSystemRupSet rupSet, double[] rates) {
+		this.rupSet = rupSet;
+		this.rates = rates;
+		Preconditions.checkArgument(rates.length == rupSet.getNumRuptures(), "# rates and ruptures is inconsistent!");
+		
+		moduleManager = new ModuleManager<>(SolutionModule.class);
+	}
+	
+	/**
+	 * Returns the fault system rupture set for this solution
+	 * @return
+	 */
+	public FaultSystemRupSet getRupSet() {
+		return rupSet;
+	}
+	
+	/**
+	 * These gives the long-term rate (events/yr) of the rth rupture
+	 * @param rupIndex
+	 * @return
+	 */
+	public double getRateForRup(int rupIndex) {
+		return rates[rupIndex];
+	}
+	
+	/**
+	 * This gives the long-term rate (events/yr) of all ruptures
+	 * @param rupIndex
+	 * @return
+	 */
+	public double[] getRateForAllRups() {
+		return rates;
+	}
+	
+	/**
+	 * This returns the total long-term rate (events/yr) of all fault-based ruptures
+	 * (fault based in case off-fault ruptures are added to subclass)
+	 * @return
+	 */
+	public double getTotalRateForAllFaultSystemRups() {
+		double totRate=0;
+		for(double rate:getRateForAllRups())
+			totRate += rate;
+		return totRate;
+	}
+	
+	public String getInfoString() {
+		return infoString;
+	}
+
+	public void setInfoString(String infoString) {
+		this.infoString = infoString;
+	}
+	
+	/*
+	 * Modules
+	 */
+	
+	/**
+	 * Adds the given module to this rupture set
+	 * 
+	 * @param module
+	 */
+	public void addModule(SolutionModule module) {
+		Preconditions.checkNotNull(module.getSolution());
+		Preconditions.checkState(module.getSolution() == this || module.getSolution().getRupSet() == getRupSet()
+				|| getRupSet().areRupturesEquivalent(module.getSolution().getRupSet()),
+				"This module was created with a different solution, and that solution's rupture set is not equivalent.");
+		moduleManager.addModule(module);
+	}
+	
+	/**
+
+	 * @param clazz
+	 * @return true if this rupture set has a module of the given type
+	 */
+	public boolean hasModule(Class<? extends SolutionModule> clazz) {
+		return moduleManager.hasModule(clazz);
+	}
+	
+	/**
+	 * Retrieve a module matching the given type
+	 * 
+	 * @param <M>
+	 * @param clazz type of module to get
+	 * @return module matching that type, or null if none exist
+	 */
+	public <M extends SolutionModule> M getModule(Class<M> clazz) {
+		return moduleManager.getModule(clazz);
+	}
+	
+	/**
+	 * 
+	 * @return unmodifiable view of all modules added to this solution
+	 */
+	public List<SolutionModule> getModules() {
+		return moduleManager.getModules();
+	}
+	
+	/**
+	 * Temporary method to transform this to the old version, to reduce compile errors during initial refactoring
+	 * 
+	 * @return
+	 */
+	@Deprecated
+	public scratch.UCERF3.FaultSystemSolution toOldSol() {
+		scratch.UCERF3.FaultSystemSolution old = new scratch.UCERF3.FaultSystemSolution(
+				rupSet.toOldRupSet(), rates);
+		return old;
+	}
+	
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
@@ -16,7 +16,7 @@ import com.google.common.base.Preconditions;
  * @author Field, Milner, Page, and Powers
  *
  */
-public final class FaultSystemSolution {
+public final class FaultSystemSolution extends ModuleManager<SolutionModule> {
 	// TODO: should this be final?
 	// TODO: add MFD calculation methods, or throw them in a utility class instead?
 
@@ -25,14 +25,11 @@ public final class FaultSystemSolution {
 	// this is separate from the rupSet info string as you can have multiple solutions with one rupSet
 	private String infoString;
 	
-	private ModuleManager<SolutionModule> moduleManager;
-	
 	public FaultSystemSolution(FaultSystemRupSet rupSet, double[] rates) {
+		super(SolutionModule.class);
 		this.rupSet = rupSet;
 		this.rates = rates;
 		Preconditions.checkArgument(rates.length == rupSet.getNumRuptures(), "# rates and ruptures is inconsistent!");
-		
-		moduleManager = new ModuleManager<>(SolutionModule.class);
 	}
 	
 	/**
@@ -90,40 +87,13 @@ public final class FaultSystemSolution {
 	 * 
 	 * @param module
 	 */
+	@Override
 	public void addModule(SolutionModule module) {
 		Preconditions.checkNotNull(module.getSolution());
 		Preconditions.checkState(module.getSolution() == this || module.getSolution().getRupSet() == getRupSet()
 				|| getRupSet().areRupturesEquivalent(module.getSolution().getRupSet()),
 				"This module was created with a different solution, and that solution's rupture set is not equivalent.");
-		moduleManager.addModule(module);
-	}
-	
-	/**
-
-	 * @param clazz
-	 * @return true if this rupture set has a module of the given type
-	 */
-	public boolean hasModule(Class<? extends SolutionModule> clazz) {
-		return moduleManager.hasModule(clazz);
-	}
-	
-	/**
-	 * Retrieve a module matching the given type
-	 * 
-	 * @param <M>
-	 * @param clazz type of module to get
-	 * @return module matching that type, or null if none exist
-	 */
-	public <M extends SolutionModule> M getModule(Class<M> clazz) {
-		return moduleManager.getModule(clazz);
-	}
-	
-	/**
-	 * 
-	 * @return unmodifiable view of all modules added to this solution
-	 */
-	public List<SolutionModule> getModules() {
-		return moduleManager.getModules();
+		super.addModule(module);
 	}
 	
 	/**

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/CSV_BackedModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/CSV_BackedModule.java
@@ -1,0 +1,62 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.opensha.commons.data.CSVFile;
+
+import com.google.common.base.Preconditions;
+
+public interface CSV_BackedModule extends StatefulModule {
+	
+	/**
+	 * File name to use for the CSV file that represents this module
+	 * 
+	 * @return
+	 */
+	public String getCSV_FileName();
+
+	@Override
+	default void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+		String entryName = StatefulModule.getEntryName(entryPrefix, getCSV_FileName());
+		
+		ZipEntry entry = new ZipEntry(entryName);
+		zout.putNextEntry(entry);
+		
+		BufferedOutputStream out = new BufferedOutputStream(zout);
+		getCSV().writeToStream(out);
+		out.flush();
+		zout.closeEntry();
+	}
+
+	@Override
+	default void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
+		String entryName = StatefulModule.getEntryName(entryPrefix, getCSV_FileName());
+		ZipEntry entry = zip.getEntry(entryName);
+		Preconditions.checkNotNull(entry, "Entry not found in zip archive: %s", entryName);
+		
+		BufferedInputStream zin = new BufferedInputStream(zip.getInputStream(entry));
+		
+		CSVFile<String> csv = CSVFile.readStream(zin, false);
+		initFromCSV(csv);
+		
+		zin.close();
+	}
+	
+	/**
+	 * @return CSV representation of this Module
+	 */
+	public CSVFile<?> getCSV();
+	
+	/**
+	 * Loads this module from a CSVFile instance.
+	 * @param csv
+	 */
+	public void initFromCSV(CSVFile<String> csv);
+
+	
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/JSON_BackedModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/JSON_BackedModule.java
@@ -1,0 +1,95 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public interface JSON_BackedModule extends StatefulModule {
+	
+	/**
+	 * File name to use for the JSON that represents this module
+	 * 
+	 * @return
+	 */
+	public String getJSON_FileName();
+
+	@Override
+	public default void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+		String entryName = StatefulModule.getEntryName(entryPrefix, getJSON_FileName());
+		
+		ZipEntry entry = new ZipEntry(entryName);
+		zout.putNextEntry(entry);
+		
+		Gson gson = buildGson();
+		
+		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(zout));
+		JsonWriter out = gson.newJsonWriter(writer);
+		writeToJSON(out, gson);
+		out.flush();
+		writer.write("\n");
+		writer.flush();
+		zout.closeEntry();
+	}
+
+	@Override
+	public default void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
+		String entryName = StatefulModule.getEntryName(entryPrefix, getJSON_FileName());
+		ZipEntry entry = zip.getEntry(entryName);
+		Preconditions.checkNotNull(entry, "Entry not found in zip archive: %s", entryName);
+		
+		Gson gson = buildGson();
+		
+		InputStream zin = zip.getInputStream(entry);
+		BufferedReader reader = new BufferedReader(new InputStreamReader(zin));
+		JsonReader in = gson.newJsonReader(reader);
+		initFromJSON(in, gson);
+		in.close();
+		
+		zin.close();
+	}
+	
+	/**
+	 * Writes this module to the given JsonWriter instance
+	 * 
+	 * @param out
+	 * @param gson
+	 * @throws IOException
+	 */
+	public void writeToJSON(JsonWriter out, Gson gson) throws IOException;
+	
+	/**
+	 * Initializes this writer from the given JsonReader instance
+	 * 
+	 * @param in
+	 * @param gson
+	 * @throws IOException
+	 */
+	public void initFromJSON(JsonReader in, Gson gson) throws IOException;
+	
+	/**
+	 * Initializes a Gson instance for [de]serialization of this module. Default implementation just enables
+	 * pretty printing. Intercept this method if you need to add any custom TypeAdapters for use during
+	 * [de]serialization.
+	 * 
+	 * @return
+	 */
+	public default Gson buildGson() {
+		GsonBuilder builder = new GsonBuilder();
+		builder.setPrettyPrinting();
+		
+		return builder.create();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
@@ -11,6 +11,13 @@ import org.opensha.commons.data.Named;
 
 import com.google.common.base.Preconditions;
 
+/**
+ * This class handles modules and mapping them to any assignable super classes.
+ * 
+ * @author kevin
+ *
+ * @param <E>
+ */
 public class ModuleManager<E extends Named> {
 	
 	private Class<E> baseClass;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
@@ -1,0 +1,99 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.opensha.commons.data.Named;
+
+import com.google.common.base.Preconditions;
+
+public class ModuleManager<E extends Named> {
+	
+	private Class<E> baseClass;
+	
+	private List<E> modules;
+	private Map<Class<? extends E>, E> mappings;
+
+	public ModuleManager(Class<E> baseClass) {
+		this.baseClass = baseClass;
+		
+		modules = new ArrayList<>();
+		mappings = new HashMap<>();
+	}
+	
+	/**
+	 * Adds the given module and maps it as the value to any eligible super-classes
+	 * 
+	 * @param module
+	 */
+	public void addModule(E module) {
+		for (int m=modules.size(); --m>=0;) {
+			E oModule = modules.get(m);
+			if (oModule.getClass().equals(module.getClass())) {
+				System.out.println("Overriding previous modlue: "+oModule.getName());
+				modules.remove(m);
+				List<Class<? extends E>> oldMappings = new ArrayList<>();
+				for (Class<? extends E> clazz : mappings.keySet())
+					if (mappings.get(clazz).equals(oModule))
+						oldMappings.add(clazz);
+				for (Class<? extends E> oldMapping : oldMappings)
+					mappings.remove(oldMapping);
+			}
+		}
+		modules.add(module);
+		mapModule(module, module.getClass());
+		
+		// add any super-classes
+		for (Class<?> clazz : ClassUtils.getAllSuperclasses(module.getClass())) {
+			if (baseClass.isAssignableFrom(clazz) && !clazz.equals(baseClass)) {
+				// this is a super-interface
+				mapModule(module, clazz);
+			}
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private void mapModule(E module, Class<?> clazz) {
+		if (mappings.containsKey(clazz))
+			System.out.println("Warning: overriding module "+clazz.getName()+" with "+module.getName());
+		else
+			System.out.println("Mapping "+clazz.getName()+" to "+module.getName());
+		Preconditions.checkState(baseClass.isAssignableFrom(clazz));
+		mappings.put((Class<E>)clazz, module);
+	}
+	
+	/**
+	 * 
+	 * @param clazz
+	 * @return true if a module exists for the given class
+	 */
+	public boolean hasModule(Class<? extends E> clazz) {
+		return mappings.containsKey(clazz);
+	}
+	
+	/**
+	 * Retrieve a module matching the given type
+	 * 
+	 * @param <M>
+	 * @param clazz type of module to get
+	 * @return module matching that type, or null if no matches exist
+	 */
+	@SuppressWarnings("unchecked")
+	public <M extends E> M getModule(Class<M> clazz) throws IllegalStateException {
+		E module = mappings.get(clazz);
+		return (M)module;
+	}
+	
+	/**
+	 * 
+	 * @return unmodifiable view of the current modules
+	 */
+	public List<E> getModules() {
+		return Collections.unmodifiableList(modules);
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModuleManager.java
@@ -42,13 +42,7 @@ public class ModuleManager<E extends Named> {
 			E oModule = modules.get(m);
 			if (oModule.getClass().equals(module.getClass())) {
 				System.out.println("Overriding previous modlue: "+oModule.getName());
-				modules.remove(m);
-				List<Class<? extends E>> oldMappings = new ArrayList<>();
-				for (Class<? extends E> clazz : mappings.keySet())
-					if (mappings.get(clazz).equals(oModule))
-						oldMappings.add(clazz);
-				for (Class<? extends E> oldMapping : oldMappings)
-					mappings.remove(oldMapping);
+				removeMappings(modules.remove(m));
 			}
 		}
 		modules.add(module);
@@ -83,7 +77,7 @@ public class ModuleManager<E extends Named> {
 	}
 	
 	/**
-	 * Retrieve a module matching the given type
+	 * Retrieve a module matching the given type, or null if no match exists
 	 * 
 	 * @param <M>
 	 * @param clazz type of module to get
@@ -101,6 +95,55 @@ public class ModuleManager<E extends Named> {
 	 */
 	public List<E> getModules() {
 		return Collections.unmodifiableList(modules);
+	}
+	
+	/**
+	 * Remove the given module and any mappings to that module.
+	 * 
+	 * @param module
+	 * @return true if the module was present
+	 */
+	public boolean removeModule(E module) {
+		boolean ret = modules.remove(module);
+		if (ret)
+			removeMappings(module);
+		return ret;
+	}
+	
+	/**
+	 * Remove any mappings to the given module class (or its subclasses)
+	 * 
+	 * @param clazz
+	 * @return
+	 */
+	public boolean removeModuleInstances(Class<? extends E> clazz) {
+		boolean ret = false;
+		for (int m=modules.size(); --m>=0;) {
+			E module = modules.get(m);
+			if (clazz.isAssignableFrom(module.getClass())) {
+				ret = true;
+				modules.remove(m);
+				removeMappings(module);
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * Removes all modules
+	 */
+	public void clearModules() {
+		modules.clear();
+		mappings.clear();
+	}
+	
+	private void removeMappings(E module) {
+		List<Class<? extends E>> oldMappings = new ArrayList<>();
+		for (Class<? extends E> clazz : mappings.keySet())
+			if (mappings.get(clazz).equals(module))
+				oldMappings.add(clazz);
+		for (Class<? extends E> oldMapping : oldMappings)
+			mappings.remove(oldMapping);
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
@@ -1,0 +1,53 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.lang.reflect.Constructor;
+
+import org.opensha.commons.data.Named;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Abstract base class for a rupture that can be attached to a FaultSystemRupSet
+ * 
+ * @author kevin
+ *
+ */
+public abstract class RupSetModule implements Named {
+	
+	private FaultSystemRupSet rupSet;
+	
+	public RupSetModule(FaultSystemRupSet rupSet) {
+		this.rupSet = rupSet;
+	}
+	
+	protected void setRupSet(FaultSystemRupSet rupSet) {
+		Preconditions.checkState(this.rupSet == null, "Rupture set should only be set once");
+		this.rupSet = rupSet;
+	}
+	
+	public final FaultSystemRupSet getRupSet() {
+		Preconditions.checkNotNull(rupSet, "Rupture set is null, module not initialized?");
+		return rupSet;
+	}
+	
+	/**
+	 * Returns an un-initialized instance of this module, with only the rupture set initialized
+	 * 
+	 * @param <M>
+	 * @param clazz
+	 * @param rupSet
+	 * @return
+	 * @throws Exception
+	 */
+	public static <M extends RupSetModule> M instance(Class<M> clazz, FaultSystemRupSet rupSet) throws Exception {
+		Constructor<M> constructor = clazz.getConstructor();
+		
+		M module = constructor.newInstance();
+		
+		module.setRupSet(rupSet);
+		
+		return module;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
@@ -42,7 +42,13 @@ public abstract class RupSetModule implements Named {
 	 * @throws Exception
 	 */
 	public static <M extends RupSetModule> M instance(Class<M> clazz, FaultSystemRupSet rupSet) throws Exception {
-		Constructor<M> constructor = clazz.getConstructor();
+		Constructor<M> constructor = clazz.getDeclaredConstructor();
+		
+		try {
+			constructor.setAccessible(true);
+		} catch (Exception e) {
+			System.err.println("WANRING: couldn't make constructor accessible: "+e.getMessage());
+		}
 		
 		M module = constructor.newInstance();
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java
@@ -8,7 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import com.google.common.base.Preconditions;
 
 /**
- * Abstract base class for a rupture that can be attached to a FaultSystemRupSet
+ * Abstract base class for a module that can be attached to a FaultSystemRupSet
  * 
  * @author kevin
  *
@@ -22,6 +22,7 @@ public abstract class RupSetModule implements Named {
 	}
 	
 	protected void setRupSet(FaultSystemRupSet rupSet) {
+		Preconditions.checkNotNull(rupSet, "Rupture set cannot be null");
 		Preconditions.checkState(this.rupSet == null, "Rupture set should only be set once");
 		this.rupSet = rupSet;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
@@ -7,6 +7,12 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 
 import com.google.common.base.Preconditions;
 
+/**
+ * Abstract base class for a module that can be attached to a fault system solution
+ * 
+ * @author kevin
+ *
+ */
 public abstract class SolutionModule implements Named {
 	
 	private FaultSystemSolution sol;
@@ -16,6 +22,7 @@ public abstract class SolutionModule implements Named {
 	}
 	
 	protected void setSolution(FaultSystemSolution sol) {
+		Preconditions.checkNotNull(sol, "Solution cannot be null");
 		Preconditions.checkState(this.sol == null, "Solution should only be set once");
 		this.sol = sol;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
@@ -1,0 +1,47 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.lang.reflect.Constructor;
+
+import org.opensha.commons.data.Named;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+
+import com.google.common.base.Preconditions;
+
+public abstract class SolutionModule implements Named {
+	
+	private FaultSystemSolution sol;
+	
+	public SolutionModule(FaultSystemSolution sol) {
+		this.sol = sol;
+	}
+	
+	protected void setSolution(FaultSystemSolution sol) {
+		Preconditions.checkState(this.sol == null, "Solution should only be set once");
+		this.sol = sol;
+	}
+	
+	public final FaultSystemSolution getSolution() {
+		Preconditions.checkNotNull(sol, "Solution is null, module not initialized?");
+		return sol;
+	}
+	
+	/**
+	 * Returns an un-initialized instance of this module, with only the solution initialized
+	 * 
+	 * @param <M>
+	 * @param clazz
+	 * @param sol
+	 * @return
+	 * @throws Exception
+	 */
+	public static <M extends SolutionModule> M instance(Class<M> clazz, FaultSystemSolution sol) throws Exception {
+		Constructor<M> constructor = clazz.getConstructor();
+		
+		M module = constructor.newInstance();
+		
+		module.setSolution(sol);
+		
+		return module;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java
@@ -42,7 +42,13 @@ public abstract class SolutionModule implements Named {
 	 * @throws Exception
 	 */
 	public static <M extends SolutionModule> M instance(Class<M> clazz, FaultSystemSolution sol) throws Exception {
-		Constructor<M> constructor = clazz.getConstructor();
+		Constructor<M> constructor = clazz.getDeclaredConstructor();
+		
+		try {
+			constructor.setAccessible(true);
+		} catch (Exception e) {
+			System.err.println("WANRING: couldn't make constructor accessible: "+e.getMessage());
+		}
 		
 		M module = constructor.newInstance();
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/StatefulModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/StatefulModule.java
@@ -1,0 +1,57 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.io.IOException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.opensha.commons.data.Named;
+
+/**
+ * Interface that makes a RupSetModule or SolutionModule stateful, i.e., allows it to be written to and loaded
+ * from a zip file. Classes that implement this interface *must* have a public no-argument constructor that will be
+ * called to instantiate the class upon load. Then, the rupture set or solution will be set, and then finally the
+ * initFromArchive(...) class will be called.
+ * 
+ * @author kevin
+ *
+ */
+public interface StatefulModule extends Named {
+	
+	/**
+	 * Stores any information needed to re-instantiate this module to the fault system zip file
+	 * 
+	 * @param zout zip output stream for the fault system (rupture set or solution) archive
+	 * @param entryPrefix prefix for entries, used in a compound solution file that bundles multiple solutions per
+	 * zip file. If non-empty, then each asset should be stored with this prefix
+	 * @throws IOException
+	 */
+	public abstract void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException;
+	
+	/**
+	 * Initializes this module from the given fault system zip file
+	 * 
+	 * @param archive fault system (rupture set or solution) zip file archive
+	 * @param entryPrefix prefix for entries, used in a compound solution file that bundles multiple solutions per
+	 * zip file. If non-empty, then each asset should be stored with this prefix
+	 * @throws IOException
+	 */
+	public abstract void initFromArchive(ZipFile zip, String entryPrefix) throws IOException;
+	
+	/**
+	 * Modules can have different implementations when they are created vs when they are loaded from a zip file
+	 * (e.g., gridded seismicity). This specifies the module class that should be used to load this information from
+	 * a zip file, and defaults to the module itself. 
+	 * 
+	 * @return the class that should be used to load this module from an archive
+	 */
+	public default Class<? extends StatefulModule> getLoadingClass() {
+		return this.getClass();
+	}
+	
+	public static String getEntryName(String entryPrefix, String fileName) {
+		if (entryPrefix == null)
+			return fileName;
+		return entryPrefix+fileName;
+	}
+	
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/AveSlipModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/AveSlipModule.java
@@ -1,0 +1,136 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
+
+import java.io.IOException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.opensha.commons.data.CSVFile;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.CSV_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.StatefulModule;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+
+public abstract class AveSlipModule extends RupSetModule {
+	
+	protected AveSlipModule(FaultSystemRupSet rupSet) {
+		super(rupSet);
+	}
+	
+	public static AveSlipModule forModel(FaultSystemRupSet rupSet, ScalingRelationships scale) {
+		return new ModelBased(rupSet, scale);
+	}
+	
+	public static AveSlipModule precomputed(FaultSystemRupSet rupSet, double[] aveSlips) {
+		return new Precomputed(rupSet, aveSlips);
+	}
+
+	/**
+	 * Returns average slip for the given rupture in SI units (m)
+	 * @param rupIndex
+	 * @return rupture average slip
+	 */
+	public abstract double getAveSlip(int rupIndex);
+	
+	public static class ModelBased extends AveSlipModule implements StatefulModule {
+
+		private ScalingRelationships scale;
+
+		protected ModelBased(FaultSystemRupSet rupSet, ScalingRelationships scale) {
+			super(rupSet);
+			this.scale = scale;
+		}
+
+		@Override
+		public void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+			new Precomputed(this).writeToArchive(zout, entryPrefix);
+		}
+
+		@Override
+		public void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
+			throw new IllegalStateException("Only pre-computed average slip modules can be loaded");
+		}
+
+		@Override
+		public Class<? extends StatefulModule> getLoadingClass() {
+			return Precomputed.class;
+		}
+
+		@Override
+		public double getAveSlip(int rupIndex) {
+			FaultSystemRupSet rupSet = getRupSet();
+			double totOrigArea = 0d;
+			for (FaultSection sect : rupSet.getFaultSectionDataForRupture(rupIndex))
+				totOrigArea += sect.getTraceLength()*1e3*sect.getOrigDownDipWidth()*1e3;
+			double origDDW = totOrigArea/rupSet.getLengthForRup(rupIndex);
+			double aveSlip = scale.getAveSlip(rupSet.getAreaForRup(rupIndex),
+					rupSet.getLengthForRup(rupIndex), origDDW);
+			return aveSlip;
+		}
+		
+	}
+	
+	public static class Precomputed extends AveSlipModule implements CSV_BackedModule {
+		
+		private double[] aveSlips;
+
+		public Precomputed() {
+			super(null);
+		}
+
+		public Precomputed(AveSlipModule module) {
+			super(module.getRupSet());
+			aveSlips = new double[module.getRupSet().getNumRuptures()];
+			for (int r=0; r<aveSlips.length; r++)
+				aveSlips[r] = module.getAveSlip(r);
+		}
+
+		public Precomputed(FaultSystemRupSet rupSet, double[] aveSlips) {
+			super(rupSet);
+			this.aveSlips = aveSlips;
+		}
+
+		@Override
+		public double getAveSlip(int rupIndex) {
+			return aveSlips[rupIndex];
+		}
+
+		@Override
+		public String getCSV_FileName() {
+			return "ave_slips.csv";
+		}
+
+		@Override
+		public CSVFile<?> getCSV() {
+			CSVFile<String> csv = new CSVFile<>(true);
+			csv.addLine("Rupture Index", "Average Slip (m)");
+			int numRups = getRupSet().getNumRuptures();
+			for (int r=0; r<numRups; r++)
+				csv.addLine(r+"", getAveSlip(r)+"");
+			return csv;
+		}
+
+		@Override
+		public void initFromCSV(CSVFile<String> csv) {
+			int numRups = getRupSet().getNumRuptures();
+			Preconditions.checkState(csv.getNumRows() == numRups+1,
+					"Expected 1 header row and %s rupture rows, have %s", numRups, csv.getNumRows());
+			
+			double[] aveSlips = new double[numRups];
+			for (int r=0; r<numRups; r++)
+				aveSlips[r] = csv.getDouble(r+1, 1);
+			this.aveSlips = aveSlips;
+		}
+		
+	}
+
+	@Override
+	public String getName() {
+		return "Rupture Average Slips";
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/AveSlipModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/AveSlipModule.java
@@ -78,7 +78,7 @@ public abstract class AveSlipModule extends RupSetModule {
 		
 		private double[] aveSlips;
 
-		public Precomputed() {
+		private Precomputed() {
 			super(null);
 		}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/ClusterRuptures.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/ClusterRuptures.java
@@ -2,12 +2,17 @@ package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
 
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.modules.JSON_BackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.StatefulModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -15,52 +20,127 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
-public class ClusterRuptures extends RupSetModule implements JSON_BackedModule {
-	
-	private List<ClusterRupture> clusterRuptures;
+public abstract class ClusterRuptures extends RupSetModule {
 
-	public ClusterRuptures() {
-		super(null);
-	}
-	
-	public ClusterRuptures(FaultSystemRupSet rupSet, List<ClusterRupture> clusterRuptures) {
+	public ClusterRuptures(FaultSystemRupSet rupSet) {
 		super(rupSet);
-		Preconditions.checkState(clusterRuptures.size() == rupSet.getNumRuptures());
-		this.clusterRuptures = clusterRuptures;
-	}
-
-	@Override
-	public String getName() {
-		return "Cluster Ruptures";
-	}
-
-	@Override
-	public String getJSON_FileName() {
-		return "cluster_ruptures.json";
-	}
-
-	@Override
-	public Gson buildGson() {
-		return ClusterRupture.buildGson(getRupSet().getFaultSectionDataList(), false);
 	}
 	
-	public List<ClusterRupture> getClusterRuptures() {
-		return clusterRuptures;
+	public abstract List<ClusterRupture> get();
+	
+	public static ClusterRuptures instance(FaultSystemRupSet rupSet, List<ClusterRupture> clusterRuptures) {
+		boolean singleStrand = true;
+		for (ClusterRupture rup : clusterRuptures) {
+			if (!rup.singleStrand) {
+				singleStrand = false;
+				break;
+			}
+		}
+		if (singleStrand)
+			return new SingleStranded(rupSet, clusterRuptures);
+		return new Precomputed(rupSet, clusterRuptures);
 	}
+	
+	private static class SingleStranded extends ClusterRuptures implements StatefulModule {
+		
+		private List<ClusterRupture> clusterRuptures;
+		
+		private SingleStranded() {
+			super(null);
+		}
 
-	@Override
-	public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
-		// TODO make JSON more compact
-		Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
-		gson.toJson(clusterRuptures, listType, out);
+		public SingleStranded(FaultSystemRupSet rupSet, List<ClusterRupture> clusterRuptures) {
+			super(rupSet);
+			this.clusterRuptures = clusterRuptures;
+		}
+
+		@Override
+		public String getName() {
+			return "Single-Strand Cluster Ruptures";
+		}
+
+		@Override
+		public void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+			// do nothing
+		}
+
+		@Override
+		public void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
+			// do nothing
+		}
+
+		@Override
+		public List<ClusterRupture> get() {
+			if (clusterRuptures == null) {
+				synchronized (this) {
+					if (clusterRuptures == null) {
+						// build them
+						FaultSystemRupSet rupSet = getRupSet();
+						SectionDistanceAzimuthCalculator distAzCalc = null;
+						if (rupSet.hasModule(PlausibilityConfigurationModule.class))
+							distAzCalc = rupSet.getModule(PlausibilityConfigurationModule.class).get().getDistAzCalc();
+						if (distAzCalc == null)
+							distAzCalc = new SectionDistanceAzimuthCalculator(getRupSet().getFaultSectionDataList());
+						List<ClusterRupture> rups = new ArrayList<>(rupSet.getNumRuptures());
+						for (int r=0; r<rupSet.getNumRuptures(); r++)
+							rups.add(ClusterRupture.forOrderedSingleStrandRupture(rupSet.getFaultSectionDataForRupture(r), distAzCalc));
+						this.clusterRuptures = rups;
+					}
+				}
+			}
+			return clusterRuptures;
+		}
+		
 	}
+	
+	private static class Precomputed extends ClusterRuptures implements JSON_BackedModule {
+		
+		private List<ClusterRupture> clusterRuptures;
+		
+		private Precomputed() {
+			super(null);
+		}
 
-	@Override
-	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
-		Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
-		List<ClusterRupture> ruptures = gson.fromJson(in, listType);
-		Preconditions.checkState(ruptures.size() == getRupSet().getNumRuptures());
-		this.clusterRuptures = ruptures;
+		public Precomputed(FaultSystemRupSet rupSet, List<ClusterRupture> clusterRuptures) {
+			super(rupSet);
+			Preconditions.checkState(clusterRuptures.size() == rupSet.getNumRuptures());
+			this.clusterRuptures = clusterRuptures;
+		}
+
+		@Override
+		public String getName() {
+			return "Precomputed Cluster Ruptures";
+		}
+		
+		@Override
+		public String getJSON_FileName() {
+			return "cluster_ruptures.json";
+		}
+
+		@Override
+		public Gson buildGson() {
+			return ClusterRupture.buildGson(getRupSet().getFaultSectionDataList(), false);
+		}
+
+		@Override
+		public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
+			// TODO make JSON more compact
+			Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
+			gson.toJson(clusterRuptures, listType, out);
+		}
+
+		@Override
+		public void initFromJSON(JsonReader in, Gson gson) throws IOException {
+			Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
+			List<ClusterRupture> ruptures = gson.fromJson(in, listType);
+			Preconditions.checkState(ruptures.size() == getRupSet().getNumRuptures());
+			this.clusterRuptures = ruptures;
+		}
+
+		@Override
+		public List<ClusterRupture> get() {
+			return clusterRuptures;
+		}
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/ClusterRuptures.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/ClusterRuptures.java
@@ -1,0 +1,66 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.JSON_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class ClusterRuptures extends RupSetModule implements JSON_BackedModule {
+	
+	private List<ClusterRupture> clusterRuptures;
+
+	public ClusterRuptures() {
+		super(null);
+	}
+	
+	public ClusterRuptures(FaultSystemRupSet rupSet, List<ClusterRupture> clusterRuptures) {
+		super(rupSet);
+		Preconditions.checkState(clusterRuptures.size() == rupSet.getNumRuptures());
+		this.clusterRuptures = clusterRuptures;
+	}
+
+	@Override
+	public String getName() {
+		return "Cluster Ruptures";
+	}
+
+	@Override
+	public String getJSON_FileName() {
+		return "cluster_ruptures.json";
+	}
+
+	@Override
+	public Gson buildGson() {
+		return ClusterRupture.buildGson(getRupSet().getFaultSectionDataList(), false);
+	}
+	
+	public List<ClusterRupture> getClusterRuptures() {
+		return clusterRuptures;
+	}
+
+	@Override
+	public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
+		// TODO make JSON more compact
+		Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
+		gson.toJson(clusterRuptures, listType, out);
+	}
+
+	@Override
+	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
+		Type listType = new TypeToken<List<ClusterRupture>>(){}.getType();
+		List<ClusterRupture> ruptures = gson.fromJson(in, listType);
+		Preconditions.checkState(ruptures.size() == getRupSet().getNumRuptures());
+		this.clusterRuptures = ruptures;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/LogicTreeBranchModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/LogicTreeBranchModule.java
@@ -22,7 +22,7 @@ public class LogicTreeBranchModule extends RupSetModule implements JSON_BackedMo
 	
 	private LogicTreeBranch branch;
 
-	public LogicTreeBranchModule() {
+	private LogicTreeBranchModule() {
 		super(null);
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/LogicTreeBranchModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/LogicTreeBranchModule.java
@@ -1,0 +1,141 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.JSON_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import scratch.UCERF3.logicTree.LogicTreeBranch;
+import scratch.UCERF3.logicTree.LogicTreeBranchNode;
+
+public class LogicTreeBranchModule extends RupSetModule implements JSON_BackedModule {
+	
+	private LogicTreeBranch branch;
+
+	public LogicTreeBranchModule() {
+		super(null);
+	}
+	
+	public LogicTreeBranchModule(FaultSystemRupSet rupSet, LogicTreeBranch branch) {
+		super(rupSet);
+		this.branch = branch;
+	}
+
+	@Override
+	public String getName() {
+		return "Logic Tree Branch";
+	}
+	
+	public LogicTreeBranch getBranch() {
+		return branch;
+	}
+
+	@Override
+	public String getJSON_FileName() {
+		return "logic_tree_branch.json";
+	}
+
+	@Override
+	public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
+		BranchAdapter adapter = new BranchAdapter();
+		adapter.write(out, getBranch());
+	}
+
+	@Override
+	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
+		BranchAdapter adapter = new BranchAdapter();
+		this.branch = adapter.read(in);
+	}
+	
+	private static class BranchAdapter extends TypeAdapter<LogicTreeBranch> {
+
+		@Override
+		public void write(JsonWriter out, LogicTreeBranch branch) throws IOException {
+			out.beginArray();
+			
+			for (int i=0; i<branch.size(); i++) {
+				out.beginObject();
+				
+				LogicTreeBranchNode<?> node = branch.getValue(i);
+				
+				if (node != null) {
+					out.name("level").value(node.getBranchLevelName());
+					out.name("description").value(node.getName());
+					out.name("relativeWeight").value(node.getRelativeWeight(null));
+					out.name("class").value(LogicTreeBranch.getEnumEnclosingClass(node.getClass()).getName());
+					out.name("name").value(node.name());
+				}
+				
+				out.endObject();
+			}
+			
+			out.endArray();
+		}
+
+		@Override
+		public LogicTreeBranch read(JsonReader in) throws IOException {
+			List<LogicTreeBranchNode<?>> nodes = new ArrayList<>();
+			
+			in.beginArray();
+			
+			while (in.hasNext()) {
+				in.beginObject();
+				
+				Class<? extends LogicTreeBranchNode<?>> clazz = null;
+				String name = null;
+				while (in.hasNext()) {
+					switch (in.nextName()) {
+					case "class":
+						try {
+							clazz = (Class<? extends LogicTreeBranchNode<?>>) Class.forName(in.nextString());
+						} catch (ClassNotFoundException e) {
+							throw ExceptionUtils.asRuntimeException(e);
+						}
+						break;
+					case "name":
+						name = in.nextString();;
+						break;
+
+					default:
+						in.skipValue();
+						break;
+					}
+				}
+				
+				if (clazz != null) {
+					Preconditions.checkNotNull(name, "class supplied but not name?");
+					LogicTreeBranchNode<?> value = null;
+					LogicTreeBranchNode<?>[] options = clazz.getEnumConstants();
+					for (LogicTreeBranchNode<?> option : options) {
+						if (option.name().equals(name) || option.getShortName().equals(name)) {
+							value = option;
+							break;
+						}
+					}
+					Preconditions.checkNotNull(value, "Could not load enum with name=%s of type %s", name, clazz.getName());
+					nodes.add(value);
+				} else {
+					Preconditions.checkState(name == null, "name supplied but not class?");
+					nodes.add(null);
+				}
+				
+				in.endObject();
+			}
+			
+			in.endArray();
+			return LogicTreeBranch.fromValues(nodes);
+		}
+		
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/PlausibilityConfigurationModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/PlausibilityConfigurationModule.java
@@ -15,7 +15,7 @@ public class PlausibilityConfigurationModule extends RupSetModule implements JSO
 	
 	private PlausibilityConfiguration config;
 
-	public PlausibilityConfigurationModule() {
+	private PlausibilityConfigurationModule() {
 		super(null);
 	}
 	
@@ -34,7 +34,7 @@ public class PlausibilityConfigurationModule extends RupSetModule implements JSO
 		return "plausibility.json";
 	}
 	
-	public PlausibilityConfiguration getConfiguration() {
+	public PlausibilityConfiguration get() {
 		return config;
 	}
 
@@ -50,7 +50,7 @@ public class PlausibilityConfigurationModule extends RupSetModule implements JSO
 
 	@Override
 	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
-		PlausibilityConfiguration config = gson.fromJson(in, PlausibilityConfiguration.class);
+		this.config = gson.fromJson(in, PlausibilityConfiguration.class);
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/PlausibilityConfigurationModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/PlausibilityConfigurationModule.java
@@ -1,0 +1,56 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
+
+import java.io.IOException;
+
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.JSON_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
+
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class PlausibilityConfigurationModule extends RupSetModule implements JSON_BackedModule {
+	
+	private PlausibilityConfiguration config;
+
+	public PlausibilityConfigurationModule() {
+		super(null);
+	}
+	
+	public PlausibilityConfigurationModule(FaultSystemRupSet rupSet, PlausibilityConfiguration config) {
+		super(rupSet);
+		this.config = config;
+	}
+	
+	@Override
+	public String getName() {
+		return "Plausibility Configuration";
+	}
+
+	@Override
+	public String getJSON_FileName() {
+		return "plausibility.json";
+	}
+	
+	public PlausibilityConfiguration getConfiguration() {
+		return config;
+	}
+
+	@Override
+	public Gson buildGson() {
+		return PlausibilityConfiguration.buildGson(getRupSet().getFaultSectionDataList());
+	}
+
+	@Override
+	public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
+		gson.toJson(config, PlausibilityConfiguration.class, out);
+	}
+
+	@Override
+	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
+		PlausibilityConfiguration config = gson.fromJson(in, PlausibilityConfiguration.class);
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/RupMFDsModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/RupMFDsModule.java
@@ -1,0 +1,82 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules.impl;
+
+import java.awt.geom.Point2D;
+
+import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.modules.CSV_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionModule;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Module that assigns magnitude-frequency distributions to each rupture, allowing some calculations to use the full
+ * distribution rather than the average magnitude returned by the rupture set. This is mostly useful for branch-averaged
+ * solutions.
+ * 
+ * @author kevin
+ *
+ */
+public class RupMFDsModule extends SolutionModule implements CSV_BackedModule {
+	
+	private DiscretizedFunc[] rupMFDs;
+	
+	public RupMFDsModule() {
+		super(null);
+	}
+
+	public RupMFDsModule(FaultSystemSolution sol, DiscretizedFunc[] rupMFDs) {
+		super(sol);
+		this.rupMFDs = rupMFDs;
+		int numRups = sol.getRupSet().getNumRuptures();
+		Preconditions.checkState(numRups == rupMFDs.length,
+				"Have %s ruptures but %s rupture MFDs", numRups, rupMFDs.length);
+	}
+
+	@Override
+	public String getName() {
+		return "Rupture MFDs";
+	}
+
+	@Override
+	public String getCSV_FileName() {
+		return "rup_mfds.csv";
+	}
+
+	@Override
+	public CSVFile<?> getCSV() {
+		CSVFile<String> csv = new CSVFile<>(true);
+		csv.addLine("Rupture Index", "Magnitude", "Rate");
+		for (int r=0; r<rupMFDs.length; r++) {
+			if (rupMFDs[r] == null || rupMFDs[r].size() == 1)
+				continue;
+			for (Point2D pt : rupMFDs[r])
+				csv.addLine(r+"", pt.getX()+"", pt.getY()+"");
+		}
+		return csv;
+	}
+
+	@Override
+	public void initFromCSV(CSVFile<String> csv) {
+		DiscretizedFunc[] rupMFDs = new DiscretizedFunc[getSolution().getRupSet().getNumRuptures()];
+		for (int row=1; row<csv.getNumRows(); row++) {
+			int r = csv.getInt(row, 0);
+			double mag = csv.getDouble(row, 1);
+			double rate = csv.getDouble(row, 2);
+			if (rupMFDs[r] == null)
+				rupMFDs[r] = new ArbitrarilyDiscretizedFunc();
+			Preconditions.checkState(!rupMFDs[r].hasX(mag),
+					"Duplicate magntiude encountered for rupture %s: %s", r+"", mag);
+			rupMFDs[r].set(mag, rate);
+		}
+		// TODO turn them into light fixed-x functions?
+		this.rupMFDs = rupMFDs;
+	}
+	
+	public DiscretizedFunc getRuptureMFD(int rupIndex) {
+		return rupMFDs[rupIndex];
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/RupMFDsModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/impl/RupMFDsModule.java
@@ -23,7 +23,7 @@ public class RupMFDsModule extends SolutionModule implements CSV_BackedModule {
 	
 	private DiscretizedFunc[] rupMFDs;
 	
-	public RupMFDsModule() {
+	private RupMFDsModule() {
 		super(null);
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRupture.java
@@ -662,7 +662,7 @@ public class ClusterRupture {
 		return ruptures;
 	}
 	
-	private static Gson buildGson(List<? extends FaultSection> subSects, boolean pretty) {
+	public static Gson buildGson(List<? extends FaultSection> subSects, boolean pretty) {
 		GsonBuilder builder = new GsonBuilder();
 		if (pretty)
 			builder.setPrettyPrinting(); // extra whitespace makes these large files large

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -1539,7 +1539,7 @@ public class ClusterRuptureBuilder {
 		FaultSystemRupSet rupSet = new FaultSystemRupSet(subSects, sectSlipRates, null, sectAreasReduced, 
 				rupsIDsList, rupMags, rupRakes, rupAreas, rupLengths, "");
 		rupSet.addModule(new PlausibilityConfigurationModule(rupSet, config));
-		rupSet.addModule(new ClusterRuptures(rupSet, rups));
+		rupSet.addModule(ClusterRuptures.instance(rupSet, rups));
 		rupSet.addModule(AveSlipModule.forModel(rupSet, scale));
 		return rupSet;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -26,6 +26,7 @@ import org.opensha.commons.util.FaultUtils;
 import org.opensha.commons.util.XMLUtils;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.impl.AveSlipModule;
 import org.opensha.sha.earthquake.faultSysSolution.modules.impl.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.modules.impl.PlausibilityConfigurationModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
@@ -1539,6 +1540,7 @@ public class ClusterRuptureBuilder {
 				rupsIDsList, rupMags, rupRakes, rupAreas, rupLengths, "");
 		rupSet.addModule(new PlausibilityConfigurationModule(rupSet, config));
 		rupSet.addModule(new ClusterRuptures(rupSet, rups));
+		rupSet.addModule(AveSlipModule.forModel(rupSet, scale));
 		return rupSet;
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -25,6 +25,9 @@ import org.opensha.commons.util.ExceptionUtils;
 import org.opensha.commons.util.FaultUtils;
 import org.opensha.commons.util.XMLUtils;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.impl.ClusterRuptures;
+import org.opensha.sha.earthquake.faultSysSolution.modules.impl.PlausibilityConfigurationModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration.Builder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityFilter;
@@ -39,6 +42,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.GeoJSONFaultRea
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.GeoJSONFaultReader.GeoSlipRateRecord;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
+import org.opensha.sha.earthquake.faultSysSolution.util.FaultSystemIO;
 import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.simulators.stiffness.AggregatedStiffnessCache;
 import org.opensha.sha.simulators.stiffness.AggregatedStiffnessCalculator;
@@ -53,14 +57,12 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Ints;
 
-import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.enumTreeBranches.DeformationModels;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
 import scratch.UCERF3.inversion.coulomb.CoulombRates;
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
 import scratch.UCERF3.utils.DeformationModelFetcher;
-import scratch.UCERF3.utils.FaultSystemIO;
 
 /**
  * Code to recursively build ClusterRuptures, applying any rupture plausibility filters
@@ -1043,398 +1045,398 @@ public class ClusterRuptureBuilder {
 		 * To reproduce UCERF3
 		 * =============================
 		 */
-//		PlausibilityConfiguration config = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
-//		RuptureGrowingStrategy growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
-//		String outputName = fmPrefix+"_reproduce_ucerf3.zip";
-//		AggregatedStiffnessCache stiffnessCache = null;
-//		File stiffnessCacheFile = null;
-//		int stiffnessCacheSize = 0;
-//		File outputDir = rupSetsDir;
+		PlausibilityConfiguration config = PlausibilityConfiguration.getUCERF3(subSects, distAzCalc, fm);
+		RuptureGrowingStrategy growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
+		String outputName = fmPrefix+"_reproduce_ucerf3_new_format.zip";
+		AggregatedStiffnessCache stiffnessCache = null;
+		File stiffnessCacheFile = null;
+		int stiffnessCacheSize = 0;
+		File outputDir = rupSetsDir;
 		
 		/*
 		 * =============================
 		 * To reproduce UCERF3 with an alternative distance/conn strategy (and calculate missing Coulomb)
 		 * =============================
 		 */
-//		String outputName = fmPrefix+"_ucerf3";
-//		CoulombRates coulombRates = CoulombRates.loadUCERF3CoulombRates(fm);
-//		
-//		double maxJumpDist = 10d;
-//		ClusterConnectionStrategy connectionStrategy =
-//				new UCERF3ClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist, coulombRates);
-//		outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-//		
-////		double r0 = 5d;
-////		double rMax = 10d;
-////		int cMax = -1;
-////		int sMax = 1;
+////		String outputName = fmPrefix+"_ucerf3";
+////		CoulombRates coulombRates = CoulombRates.loadUCERF3CoulombRates(fm);
+////		
+////		double maxJumpDist = 10d;
 ////		ClusterConnectionStrategy connectionStrategy =
-////				new AdaptiveDistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, r0, rMax, cMax, sMax);
-////		outputName += "_adapt"+new DecimalFormat("0.#").format(r0)+"_"+new DecimalFormat("0.#").format(rMax)+"km";
-////		if (cMax >= 0)
-////			outputName += "_cMax"+cMax;
-////		if (sMax >= 0)
-////			outputName += "_sMax"+sMax;
+////				new UCERF3ClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist, coulombRates);
+////		outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+////		
+//////		double r0 = 5d;
+//////		double rMax = 10d;
+//////		int cMax = -1;
+//////		int sMax = 1;
+//////		ClusterConnectionStrategy connectionStrategy =
+//////				new AdaptiveDistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, r0, rMax, cMax, sMax);
+//////		outputName += "_adapt"+new DecimalFormat("0.#").format(r0)+"_"+new DecimalFormat("0.#").format(rMax)+"km";
+//////		if (cMax >= 0)
+//////			outputName += "_cMax"+cMax;
+//////		if (sMax >= 0)
+//////			outputName += "_sMax"+sMax;
+////		
+////		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
+////		
+//////		configBuilder.u3All(coulombRates); outputName += "_u3All";
+////		configBuilder.u3Azimuth();
+////		configBuilder.cumulativeAzChange(560f);
+////		configBuilder.cumulativeRakeChange(180f);
+//////		configBuilder.add(new U3CompatibleCumulativeRakeChangeFilter(180d));
+//////		configBuilder.u3Cumulatives();
+////		configBuilder.minSectsPerParent(2, true, true);
+//////		configBuilder.u3Coulomb(coulombRates);
+//////		outputName += "_u3NoCmlAz";
+//////		outputName += "_u3NoSectsPerParent";
+//////		outputName += "_u3NoAz";
+//////		outputName += "_u3CorrectedRake";
+////		outputName += "_noCoulomb";
+////		AggregatedStiffnessCache stiffnessCache = null;
+////		File stiffnessCacheFile = null;
+////		int stiffnessCacheSize = 0;
+////		
+//////		configBuilder.minSectsPerParent(2, true, true);
+//////		configBuilder.u3Cumulatives();
+////////		configBuilder.cumulativeAzChange(560f);
+//////		configBuilder.u3Azimuth();
+//////		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
+//////				subSects, 1d, 3e4, 3e4, 0.5, PatchAlignment.FILL_OVERLAP, 1d);
+//////		AggregatedStiffnessCache stiffnessCache = stiffnessCalc.getAggregationCache(StiffnessType.CFF);
+//////		File stiffnessCacheFile = new File(rupSetsDir, stiffnessCache.getCacheFileName());
+//////		int stiffnessCacheSize = 0;
+//////		if (stiffnessCacheFile.exists())
+//////			stiffnessCacheSize = stiffnessCache.loadCacheFile(stiffnessCacheFile);
+////////		configBuilder.u3Coulomb(coulombRates, stiffnessCalc); outputName += "_cffFallback";
+////////		outputName += "_noCoulomb";
+//////		configBuilder.u3Coulomb(new CoulombRates(fm, new HashMap<>()), stiffnessCalc); outputName += "_cffReproduce";
+////		PlausibilityConfiguration config = configBuilder.build();
+////		RuptureGrowingStrategy growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
+//////		float sectFract = 0.05f;
+//////		SectCountAdaptivePermutationStrategy permStrat = new SectCountAdaptivePermutationStrategy(
+//////				new ExhaustiveUnilateralClusterPermuationStrategy(), sectFract, true);
+//////		configBuilder.add(permStrat.buildConnPointCleanupFilter(connectionStrategy));
+//////		outputName += "_sectFractPerm"+sectFract;
+////		outputName += ".zip";
+////		File outputDir = rupSetsDir;
+//		
+//		/*
+//		 * =============================
+//		 * For other experiments
+//		 * =============================
+//		 */
+//		/*
+//		 * Thresholds & params
+//		 * 
+//		 * preferred values are listed to the right of each parameter/threshold, and 'MOD' is appended whenever
+//		 * one is temporarily modified from the preferred value.
+//		 */
+//		// PLAUSIBILITY FILTERS
+//		// minimum subsections per parent
+//		int minSectsPerParent = 2;				// PREF: 2
+//		// filters out indirect paths
+//		boolean noIndirectPaths = true;			// PREF: true
+//		// relative slip rate probability
+//		float slipRateProb = 0.05f;				// PREF: 0.05
+//		// if false, slip rate probabilities only consider alternative jumps up to the distance (+2km) of the taken jump
+//		boolean slipIncludeLonger = false;		// PREF: false
+//		// fraction of interactions positive
+//		float cffFractInts = 0.75f;				// PREF: 0.75
+//		// number of denominator values for the CFF favorability ratio
+//		int cffRatioN = 2;						// PREF: 2
+//		// CFF favorability ratio threshold
+//		float cffRatioThresh = 0.5f;			// PREF: 0.5
+//		// relative CFF probability
+//		float cffRelativeProb = 0.01f;			// PREF: 0.01
+//		// if true, CFF calculations are computed with the most favorable path (up to max jump distance), which may not
+//		// use the exact jumping point from the connection strategy
+//		boolean favorableJumps = true;			// PREF: true
+//		// cumulative jump probability threshold
+//		float jumpProbThresh = 0.001f;			// PREF: 0.001 (~21 km)
+//		// cumulative rake change threshold
+//		float cmlRakeThresh = 360f;				// PREF: 360
+//		// CONNECTION STRATEGY
+//		// maximum individual jump distance
+//		double maxJumpDist = 15d;				// PREF: 15
+//		// if true, connections happen at places that actually work and paths are optimized. if false, closest points
+//		boolean plausibleConnections = true;	// PREF: true
+//		// if >0 and <maxDist, connections will only be added above this distance when no other connections exist from
+//		// a given subsection. e.g., if set to 5, you can jump more than 5 km but only if no <= 5km jumps exist
+//		double adaptiveMinDist = 6d;			// PREF: 6
+//		// GROWING STRATEGY
+//		// if nonzero, apply thinning to growing strategy
+//		float adaptiveSectFract = 0.1f;			// PREF: 0.1
+//		// if true, allow bilateral rupture growing (using default settings)
+//		boolean bilateral = false;				// PREF: false
+//		// if true, allow splays (using default settings)
+//		boolean splays = false;					// PREF: false
+//		/*
+//		 * END Plausibility thresholds & params
+//		 */
+//		
+//		// build stiffness calculator (used for new Coulomb)
+//		double stiffGridSpacing = 2d;
+//		double coeffOfFriction = 0.5;
+//		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
+//				subSects, stiffGridSpacing, 3e4, 3e4, coeffOfFriction, PatchAlignment.FILL_OVERLAP, 1d);
+//		AggregatedStiffnessCache stiffnessCache = stiffnessCalc.getAggregationCache(StiffnessType.CFF);
+//		File stiffnessCacheFile = new File(rupSetsDir, stiffnessCache.getCacheFileName());
+//		int stiffnessCacheSize = 0;
+//		if (stiffnessCacheFile.exists())
+//			stiffnessCacheSize = stiffnessCache.loadCacheFile(stiffnessCacheFile);
+//		// common aggregators
+//		AggregatedStiffnessCalculator sumAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
+//				AggregationMethod.FLATTEN, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.SUM);
+//		AggregatedStiffnessCalculator fractRpatchPosAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
+//				AggregationMethod.SUM, AggregationMethod.PASSTHROUGH, AggregationMethod.RECEIVER_SUM, AggregationMethod.FRACT_POSITIVE);
+////		AggregatedStiffnessCalculator threeQuarterInts = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
+////				AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.THREE_QUARTER_INTERACTIONS);
+//		AggregatedStiffnessCalculator fractIntsAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
+//				AggregationMethod.FLATTEN, AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.NORM_BY_COUNT);
+//		
+//		String outputName = fmPrefix;
+//		
+//		if (stiffGridSpacing != 2d)
+//			outputName += "_stiff"+new DecimalFormat("0.#").format(stiffGridSpacing)+"km";
+//		if (coeffOfFriction != 0.5d)
+//			outputName += "_coeff"+(float)coeffOfFriction;
+//		
+//		/*
+//		 * Connection strategy: which faults are allowed to connect, and where?
+//		 */
+//		// use this for the exact same connections as UCERF3
+////		double maxJumpDist = 5d;
+////		ClusterConnectionStrategy connectionStrategy =
+////				new UCERF3ClusterConnectionStrategy(subSects,
+////						distAzCalc, maxJumpDist, CoulombRates.loadUCERF3CoulombRates(fm));
+////		if (maxJumpDist != 5d)
+////			outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+//		ClusterConnectionStrategy connectionStrategy;
+//		if (plausibleConnections) {
+//			// use this to pick connections which agree with your plausibility filters
+//			
+//			// some filters need a connection strategy, use one that only includes immediate neighbors at this step
+//			DistCutoffClosestSectClusterConnectionStrategy neighborsConnStrat =
+//					new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d);
+//			List<PlausibilityFilter> connFilters = new ArrayList<>();
+//			if (cffRatioThresh > 0f) {
+//				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new CoulombSectRatioProb(
+//						sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)));
+//				if (cffRelativeProb > 0f)
+//					connFilters.add(new PathPlausibilityFilter(
+//							new CumulativeProbPathEvaluator(cffRatioThresh, PlausibilityResult.FAIL_HARD_STOP,
+//									new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)),
+//							new CumulativeProbPathEvaluator(cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP,
+//									new RelativeCoulombProb(sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc))));
+//			} else if (cffRelativeProb > 0f) {
+//				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new RelativeCoulombProb(
+//						sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc)));
+//			}
+//			if (cffFractInts > 0f)
+//				connFilters.add(new NetRuptureCoulombFilter(fractIntsAgg, cffFractInts));
+//			connectionStrategy = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
+//						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters);
+//			outputName += "_plausibleMulti"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+////						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT_SINGLE, connFilters);
+////			outputName += "_plausible"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+//			System.out.println("Building plausible connections w/ "+threads+" threads...");
+//			connectionStrategy.checkBuildThreaded(threads);
+//			System.out.println("DONE building plausible connections");
+//		} else {
+//			// just use closest distance
+//			connectionStrategy = new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist);
+//			if (maxJumpDist != 5d)
+//				outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
+//		}
+//		if (adaptiveMinDist > 0d && adaptiveMinDist < maxJumpDist) {
+//			connectionStrategy = new AdaptiveClusterConnectionStrategy(connectionStrategy, adaptiveMinDist, 1);
+//			outputName += "_adaptive"+new DecimalFormat("0.#").format(adaptiveMinDist)+"km";
+//		}
 //		
 //		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
 //		
-////		configBuilder.u3All(coulombRates); outputName += "_u3All";
-//		configBuilder.u3Azimuth();
-//		configBuilder.cumulativeAzChange(560f);
-//		configBuilder.cumulativeRakeChange(180f);
-////		configBuilder.add(new U3CompatibleCumulativeRakeChangeFilter(180d));
-////		configBuilder.u3Cumulatives();
-//		configBuilder.minSectsPerParent(2, true, true);
-////		configBuilder.u3Coulomb(coulombRates);
-////		outputName += "_u3NoCmlAz";
-////		outputName += "_u3NoSectsPerParent";
-////		outputName += "_u3NoAz";
-////		outputName += "_u3CorrectedRake";
-//		outputName += "_noCoulomb";
-//		AggregatedStiffnessCache stiffnessCache = null;
-//		File stiffnessCacheFile = null;
-//		int stiffnessCacheSize = 0;
+//		/*
+//		 * Plausibility filters: which ruptures (utilizing those connections) are allowed?
+//		 */
 //		
-////		configBuilder.minSectsPerParent(2, true, true);
-////		configBuilder.u3Cumulatives();
-//////		configBuilder.cumulativeAzChange(560f);
-////		configBuilder.u3Azimuth();
-////		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
-////				subSects, 1d, 3e4, 3e4, 0.5, PatchAlignment.FILL_OVERLAP, 1d);
-////		AggregatedStiffnessCache stiffnessCache = stiffnessCalc.getAggregationCache(StiffnessType.CFF);
-////		File stiffnessCacheFile = new File(rupSetsDir, stiffnessCache.getCacheFileName());
-////		int stiffnessCacheSize = 0;
-////		if (stiffnessCacheFile.exists())
-////			stiffnessCacheSize = stiffnessCache.loadCacheFile(stiffnessCacheFile);
-//////		configBuilder.u3Coulomb(coulombRates, stiffnessCalc); outputName += "_cffFallback";
-//////		outputName += "_noCoulomb";
-////		configBuilder.u3Coulomb(new CoulombRates(fm, new HashMap<>()), stiffnessCalc); outputName += "_cffReproduce";
-//		PlausibilityConfiguration config = configBuilder.build();
-//		RuptureGrowingStrategy growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
-////		float sectFract = 0.05f;
-////		SectCountAdaptivePermutationStrategy permStrat = new SectCountAdaptivePermutationStrategy(
-////				new ExhaustiveUnilateralClusterPermuationStrategy(), sectFract, true);
-////		configBuilder.add(permStrat.buildConnPointCleanupFilter(connectionStrategy));
-////		outputName += "_sectFractPerm"+sectFract;
-//		outputName += ".zip";
-//		File outputDir = rupSetsDir;
-		
-		/*
-		 * =============================
-		 * For other experiments
-		 * =============================
-		 */
-		/*
-		 * Thresholds & params
-		 * 
-		 * preferred values are listed to the right of each parameter/threshold, and 'MOD' is appended whenever
-		 * one is temporarily modified from the preferred value.
-		 */
-		// PLAUSIBILITY FILTERS
-		// minimum subsections per parent
-		int minSectsPerParent = 2;				// PREF: 2
-		// filters out indirect paths
-		boolean noIndirectPaths = true;			// PREF: true
-		// relative slip rate probability
-		float slipRateProb = 0.05f;				// PREF: 0.05
-		// if false, slip rate probabilities only consider alternative jumps up to the distance (+2km) of the taken jump
-		boolean slipIncludeLonger = false;		// PREF: false
-		// fraction of interactions positive
-		float cffFractInts = 0.75f;				// PREF: 0.75
-		// number of denominator values for the CFF favorability ratio
-		int cffRatioN = 2;						// PREF: 2
-		// CFF favorability ratio threshold
-		float cffRatioThresh = 0.5f;			// PREF: 0.5
-		// relative CFF probability
-		float cffRelativeProb = 0.01f;			// PREF: 0.01
-		// if true, CFF calculations are computed with the most favorable path (up to max jump distance), which may not
-		// use the exact jumping point from the connection strategy
-		boolean favorableJumps = true;			// PREF: true
-		// cumulative jump probability threshold
-		float jumpProbThresh = 0.001f;			// PREF: 0.001 (~21 km)
-		// cumulative rake change threshold
-		float cmlRakeThresh = 360f;				// PREF: 360
-		// CONNECTION STRATEGY
-		// maximum individual jump distance
-		double maxJumpDist = 15d;				// PREF: 15
-		// if true, connections happen at places that actually work and paths are optimized. if false, closest points
-		boolean plausibleConnections = true;	// PREF: true
-		// if >0 and <maxDist, connections will only be added above this distance when no other connections exist from
-		// a given subsection. e.g., if set to 5, you can jump more than 5 km but only if no <= 5km jumps exist
-		double adaptiveMinDist = 6d;			// PREF: 6
-		// GROWING STRATEGY
-		// if nonzero, apply thinning to growing strategy
-		float adaptiveSectFract = 0.1f;			// PREF: 0.1
-		// if true, allow bilateral rupture growing (using default settings)
-		boolean bilateral = false;				// PREF: false
-		// if true, allow splays (using default settings)
-		boolean splays = false;					// PREF: false
-		/*
-		 * END Plausibility thresholds & params
-		 */
-		
-		// build stiffness calculator (used for new Coulomb)
-		double stiffGridSpacing = 2d;
-		double coeffOfFriction = 0.5;
-		SubSectStiffnessCalculator stiffnessCalc = new SubSectStiffnessCalculator(
-				subSects, stiffGridSpacing, 3e4, 3e4, coeffOfFriction, PatchAlignment.FILL_OVERLAP, 1d);
-		AggregatedStiffnessCache stiffnessCache = stiffnessCalc.getAggregationCache(StiffnessType.CFF);
-		File stiffnessCacheFile = new File(rupSetsDir, stiffnessCache.getCacheFileName());
-		int stiffnessCacheSize = 0;
-		if (stiffnessCacheFile.exists())
-			stiffnessCacheSize = stiffnessCache.loadCacheFile(stiffnessCacheFile);
-		// common aggregators
-		AggregatedStiffnessCalculator sumAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
-				AggregationMethod.FLATTEN, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.SUM);
-		AggregatedStiffnessCalculator fractRpatchPosAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
-				AggregationMethod.SUM, AggregationMethod.PASSTHROUGH, AggregationMethod.RECEIVER_SUM, AggregationMethod.FRACT_POSITIVE);
-//		AggregatedStiffnessCalculator threeQuarterInts = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
-//				AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.SUM, AggregationMethod.THREE_QUARTER_INTERACTIONS);
-		AggregatedStiffnessCalculator fractIntsAgg = new AggregatedStiffnessCalculator(StiffnessType.CFF, stiffnessCalc, true,
-				AggregationMethod.FLATTEN, AggregationMethod.NUM_POSITIVE, AggregationMethod.SUM, AggregationMethod.NORM_BY_COUNT);
-		
-		String outputName = fmPrefix;
-		
-		if (stiffGridSpacing != 2d)
-			outputName += "_stiff"+new DecimalFormat("0.#").format(stiffGridSpacing)+"km";
-		if (coeffOfFriction != 0.5d)
-			outputName += "_coeff"+(float)coeffOfFriction;
-		
-		/*
-		 * Connection strategy: which faults are allowed to connect, and where?
-		 */
-		// use this for the exact same connections as UCERF3
-//		double maxJumpDist = 5d;
-//		ClusterConnectionStrategy connectionStrategy =
-//				new UCERF3ClusterConnectionStrategy(subSects,
-//						distAzCalc, maxJumpDist, CoulombRates.loadUCERF3CoulombRates(fm));
-//		if (maxJumpDist != 5d)
-//			outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-		ClusterConnectionStrategy connectionStrategy;
-		if (plausibleConnections) {
-			// use this to pick connections which agree with your plausibility filters
-			
-			// some filters need a connection strategy, use one that only includes immediate neighbors at this step
-			DistCutoffClosestSectClusterConnectionStrategy neighborsConnStrat =
-					new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, 0.1d);
-			List<PlausibilityFilter> connFilters = new ArrayList<>();
-			if (cffRatioThresh > 0f) {
-				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new CoulombSectRatioProb(
-						sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)));
-				if (cffRelativeProb > 0f)
-					connFilters.add(new PathPlausibilityFilter(
-							new CumulativeProbPathEvaluator(cffRatioThresh, PlausibilityResult.FAIL_HARD_STOP,
-									new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, (float)maxJumpDist, distAzCalc)),
-							new CumulativeProbPathEvaluator(cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP,
-									new RelativeCoulombProb(sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc))));
-			} else if (cffRelativeProb > 0f) {
-				connFilters.add(new CumulativeProbabilityFilter(cffRatioThresh, new RelativeCoulombProb(
-						sumAgg, neighborsConnStrat, false, true, favorableJumps, (float)maxJumpDist, distAzCalc)));
-			}
-			if (cffFractInts > 0f)
-				connFilters.add(new NetRuptureCoulombFilter(fractIntsAgg, cffFractInts));
-			connectionStrategy = new PlausibleClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist,
-						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT, connFilters);
-			outputName += "_plausibleMulti"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-//						PlausibleClusterConnectionStrategy.JUMP_SELECTOR_DEFAULT_SINGLE, connFilters);
-//			outputName += "_plausible"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-			System.out.println("Building plausible connections w/ "+threads+" threads...");
-			connectionStrategy.checkBuildThreaded(threads);
-			System.out.println("DONE building plausible connections");
-		} else {
-			// just use closest distance
-			connectionStrategy = new DistCutoffClosestSectClusterConnectionStrategy(subSects, distAzCalc, maxJumpDist);
-			if (maxJumpDist != 5d)
-				outputName += "_"+new DecimalFormat("0.#").format(maxJumpDist)+"km";
-		}
-		if (adaptiveMinDist > 0d && adaptiveMinDist < maxJumpDist) {
-			connectionStrategy = new AdaptiveClusterConnectionStrategy(connectionStrategy, adaptiveMinDist, 1);
-			outputName += "_adaptive"+new DecimalFormat("0.#").format(adaptiveMinDist)+"km";
-		}
-		
-		Builder configBuilder = PlausibilityConfiguration.builder(connectionStrategy, subSects);
-		
-		/*
-		 * Plausibility filters: which ruptures (utilizing those connections) are allowed?
-		 */
-		
-		/*
-		 *  UCERF3 filters
-		 */
-//		configBuilder.u3All(CoulombRates.loadUCERF3CoulombRates(fm)); outputName += "_ucerf3";
-		if (minSectsPerParent > 1) {
-			configBuilder.minSectsPerParent(2, true, true); // always do this one
-		}
-		if (noIndirectPaths) {
-			configBuilder.noIndirectPaths(true);
-			outputName += "_direct";
-		}
-//		configBuilder.u3Cumulatives(); outputName += "_u3Cml"; // cml rake and azimuth
-//		configBuilder.cumulativeAzChange(560f); outputName += "_cmlAz"; // cml azimuth only
-		if (cmlRakeThresh > 0) {
-			configBuilder.cumulativeRakeChange(cmlRakeThresh);
-			outputName += "_cmlRake"+(int)cmlRakeThresh; // cml rake only
-		}
-//		configBuilder.cumulativeRakeChange(270f); outputName += "_cmlRake270"; // cml rake only
-//		configBuilder.cumulativeRakeChange(360f); outputName += "_cmlRake360"; // cml rake only
-//		configBuilder.u3Azimuth(); outputName += "_u3Az";
-//		configBuilder.u3Coulomb(CoulombRates.loadUCERF3CoulombRates(fm)); outputName += "_u3CFF";
-		
-		/*
-		 * Cumulative jump prob
-		 */
-		// JUMP PROB: only increasing
-		if (jumpProbThresh > 0f) {
-			configBuilder.cumulativeProbability(jumpProbThresh, new Shaw07JumpDistProb(1d, 3d));
-			outputName += "_jumpP"+jumpProbThresh;
-		}
-		// JUMP RATE PROB
-		
-		/*
-		 * Regular slip prob
-		 */
-		// SLIP RATE PROB: only increasing
-		if (slipRateProb > 0f) {
-			configBuilder.cumulativeProbability(slipRateProb,
-					new RelativeSlipRateProb(connectionStrategy, true, slipIncludeLonger));
-			outputName += "_slipP"+slipRateProb+"incr";
-			if (!slipIncludeLonger)
-				outputName += "CapDist";
-		}
-		// END SLIP RATE PROB
-		
-		/*
-		 * Regular CFF prob (not currently used)
-		 */
-		// CFF prob: allow neg, 0.01
-//		configBuilder.cumulativeProbability(0.01f, new RelativeCoulombProb(
-//				sumAgg, connectionStrategy, false, true, true));
-//		outputName += "_cffP0.01incr";
-		// END SLIP RATE PROB
-		
-		/*
-		 *  CFF net rupture filters
-		 */
-		// FRACT INTERACTIONS POSITIVE
-		if (cffFractInts > 0f) {
-			configBuilder.netRupCoulomb(fractIntsAgg,
-					Range.greaterThan(cffFractInts));
-			outputName += "_cff"+cffFractInts+"IntsPos";
-		}
-		// END MAIN 3/4 INTERACTIONS POSITIVE
-		
-		/**
-		 * Path filters
-		 */
-		List<NucleationClusterEvaluator> combPathEvals = new ArrayList<>();
-		List<String> combPathPrefixes = new ArrayList<>();
-		float fractPathsThreshold = 0f; String fractPathsStr = "";
-		float favorableDist = Float.max((float)maxJumpDist, 10f);
-		String favStr = "";
-		if (favorableJumps) {
-			favStr = "Fav";
-			if (favorableDist != (float)maxJumpDist)
-				favStr += (int)favorableDist;
-		}
-		// SLIP RATE PROB: as a path, only increasing NOT CURRENTLY PREFERRED
-//		float pathSlipProb = 0.1f;
-//		CumulativeJumpProbPathEvaluator slipEval = new CumulativeJumpProbPathEvaluator(
-//				pathSlipProb, PlausibilityResult.FAIL_HARD_STOP, new RelativeSlipRateProb(connectionStrategy, true));
-//		combPathEvals.add(slipEval); combPathPrefixes.add("slipP"+pathSlipProb+"incr");
-////		configBuilder.path(slipEval); outputName += "_slipPathP"+pathSlipProb+"incr"; // do it separately
-		// END SLIP RATE PROB
-		// CFF PROB: as a path, allow negative, 0.01
-		if (cffRelativeProb > 0f) {
-			RelativeCoulombProb cffProbCalc = new RelativeCoulombProb(
-					sumAgg, connectionStrategy, false, true, favorableJumps, favorableDist, distAzCalc);
-			CumulativeProbPathEvaluator cffProbPathEval = new CumulativeProbPathEvaluator(
-					cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP, cffProbCalc);
-			combPathEvals.add(cffProbPathEval); combPathPrefixes.add("cff"+favStr+"P"+cffRelativeProb);
-		}
-//		configBuilder.path(cffProbPathEval); outputName += "_cffPathP0.01"; // do it separately
-		// CFF SECT PATH: relBest, 15km
-//		SectCoulombPathEvaluator prefCFFSectPathEval = new SectCoulombPathEvaluator(
-//				sumAgg, Range.atLeast(0f), PlausibilityResult.FAIL_HARD_STOP, true, 15f, distAzCalc);
-//		combPathEvals.add(prefCFFSectPathEval); combPathPrefixes.add("cffSPathFav15");
-////		configBuilder.path(prefCFFSectPathEval); outputName += "_cffSPathFav15"; // do it separately
-		// END CFF SECT PATH
-		// CFF CLUSTER PATH: half RPatches positive
-//		ClusterCoulombPathEvaluator prefCFFRPatchEval = new ClusterCoulombPathEvaluator(
-//				fractRpatchPosAgg, Range.atLeast(0.5f), PlausibilityResult.FAIL_HARD_STOP);
-//		combPathEvals.add(prefCFFRPatchEval); combPathPrefixes.add("cffCPathRPatchHalfPos");
+//		/*
+//		 *  UCERF3 filters
+//		 */
+////		configBuilder.u3All(CoulombRates.loadUCERF3CoulombRates(fm)); outputName += "_ucerf3";
+//		if (minSectsPerParent > 1) {
+//			configBuilder.minSectsPerParent(2, true, true); // always do this one
+//		}
+//		if (noIndirectPaths) {
+//			configBuilder.noIndirectPaths(true);
+//			outputName += "_direct";
+//		}
+////		configBuilder.u3Cumulatives(); outputName += "_u3Cml"; // cml rake and azimuth
+////		configBuilder.cumulativeAzChange(560f); outputName += "_cmlAz"; // cml azimuth only
+//		if (cmlRakeThresh > 0) {
+//			configBuilder.cumulativeRakeChange(cmlRakeThresh);
+//			outputName += "_cmlRake"+(int)cmlRakeThresh; // cml rake only
+//		}
+////		configBuilder.cumulativeRakeChange(270f); outputName += "_cmlRake270"; // cml rake only
+////		configBuilder.cumulativeRakeChange(360f); outputName += "_cmlRake360"; // cml rake only
+////		configBuilder.u3Azimuth(); outputName += "_u3Az";
+////		configBuilder.u3Coulomb(CoulombRates.loadUCERF3CoulombRates(fm)); outputName += "_u3CFF";
+//		
+//		/*
+//		 * Cumulative jump prob
+//		 */
+//		// JUMP PROB: only increasing
+//		if (jumpProbThresh > 0f) {
+//			configBuilder.cumulativeProbability(jumpProbThresh, new Shaw07JumpDistProb(1d, 3d));
+//			outputName += "_jumpP"+jumpProbThresh;
+//		}
+//		// JUMP RATE PROB
+//		
+//		/*
+//		 * Regular slip prob
+//		 */
+//		// SLIP RATE PROB: only increasing
+//		if (slipRateProb > 0f) {
+//			configBuilder.cumulativeProbability(slipRateProb,
+//					new RelativeSlipRateProb(connectionStrategy, true, slipIncludeLonger));
+//			outputName += "_slipP"+slipRateProb+"incr";
+//			if (!slipIncludeLonger)
+//				outputName += "CapDist";
+//		}
+//		// END SLIP RATE PROB
+//		
+//		/*
+//		 * Regular CFF prob (not currently used)
+//		 */
+//		// CFF prob: allow neg, 0.01
+////		configBuilder.cumulativeProbability(0.01f, new RelativeCoulombProb(
+////				sumAgg, connectionStrategy, false, true, true));
+////		outputName += "_cffP0.01incr";
+//		// END SLIP RATE PROB
+//		
+//		/*
+//		 *  CFF net rupture filters
+//		 */
+//		// FRACT INTERACTIONS POSITIVE
+//		if (cffFractInts > 0f) {
+//			configBuilder.netRupCoulomb(fractIntsAgg,
+//					Range.greaterThan(cffFractInts));
+//			outputName += "_cff"+cffFractInts+"IntsPos";
+//		}
+//		// END MAIN 3/4 INTERACTIONS POSITIVE
+//		
+//		/**
+//		 * Path filters
+//		 */
+//		List<NucleationClusterEvaluator> combPathEvals = new ArrayList<>();
+//		List<String> combPathPrefixes = new ArrayList<>();
+//		float fractPathsThreshold = 0f; String fractPathsStr = "";
+//		float favorableDist = Float.max((float)maxJumpDist, 10f);
+//		String favStr = "";
+//		if (favorableJumps) {
+//			favStr = "Fav";
+//			if (favorableDist != (float)maxJumpDist)
+//				favStr += (int)favorableDist;
+//		}
+//		// SLIP RATE PROB: as a path, only increasing NOT CURRENTLY PREFERRED
+////		float pathSlipProb = 0.1f;
+////		CumulativeJumpProbPathEvaluator slipEval = new CumulativeJumpProbPathEvaluator(
+////				pathSlipProb, PlausibilityResult.FAIL_HARD_STOP, new RelativeSlipRateProb(connectionStrategy, true));
+////		combPathEvals.add(slipEval); combPathPrefixes.add("slipP"+pathSlipProb+"incr");
+//////		configBuilder.path(slipEval); outputName += "_slipPathP"+pathSlipProb+"incr"; // do it separately
+//		// END SLIP RATE PROB
+//		// CFF PROB: as a path, allow negative, 0.01
+//		if (cffRelativeProb > 0f) {
+//			RelativeCoulombProb cffProbCalc = new RelativeCoulombProb(
+//					sumAgg, connectionStrategy, false, true, favorableJumps, favorableDist, distAzCalc);
+//			CumulativeProbPathEvaluator cffProbPathEval = new CumulativeProbPathEvaluator(
+//					cffRelativeProb, PlausibilityResult.FAIL_HARD_STOP, cffProbCalc);
+//			combPathEvals.add(cffProbPathEval); combPathPrefixes.add("cff"+favStr+"P"+cffRelativeProb);
+//		}
+////		configBuilder.path(cffProbPathEval); outputName += "_cffPathP0.01"; // do it separately
+//		// CFF SECT PATH: relBest, 15km
+////		SectCoulombPathEvaluator prefCFFSectPathEval = new SectCoulombPathEvaluator(
+////				sumAgg, Range.atLeast(0f), PlausibilityResult.FAIL_HARD_STOP, true, 15f, distAzCalc);
+////		combPathEvals.add(prefCFFSectPathEval); combPathPrefixes.add("cffSPathFav15");
+//////		configBuilder.path(prefCFFSectPathEval); outputName += "_cffSPathFav15"; // do it separately
+//		// END CFF SECT PATH
+//		// CFF CLUSTER PATH: half RPatches positive
+////		ClusterCoulombPathEvaluator prefCFFRPatchEval = new ClusterCoulombPathEvaluator(
+////				fractRpatchPosAgg, Range.atLeast(0.5f), PlausibilityResult.FAIL_HARD_STOP);
+////		combPathEvals.add(prefCFFRPatchEval); combPathPrefixes.add("cffCPathRPatchHalfPos");
+//////		configBuilder.path(prefCFFRPatchEval); outputName += "_cffCPathRPatchHalfPos"; // do it separately
+//		// END CFF CLUSTER PATH
+//		// CFF RATIO PATH: N=2, relBest, 15km
+//		if (cffRatioThresh > 0f) {
+//			CumulativeProbPathEvaluator cffRatioPatchEval = new CumulativeProbPathEvaluator(cffRatioThresh,
+//					PlausibilityResult.FAIL_HARD_STOP,
+//					new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, favorableDist, distAzCalc));
+//			combPathEvals.add(cffRatioPatchEval);
+//			combPathPrefixes.add("cff"+favStr+"RatioN"+cffRatioN+"P"+cffRatioThresh);
+//		}
 ////		configBuilder.path(prefCFFRPatchEval); outputName += "_cffCPathRPatchHalfPos"; // do it separately
-		// END CFF CLUSTER PATH
-		// CFF RATIO PATH: N=2, relBest, 15km
-		if (cffRatioThresh > 0f) {
-			CumulativeProbPathEvaluator cffRatioPatchEval = new CumulativeProbPathEvaluator(cffRatioThresh,
-					PlausibilityResult.FAIL_HARD_STOP,
-					new CoulombSectRatioProb(sumAgg, cffRatioN, favorableJumps, favorableDist, distAzCalc));
-			combPathEvals.add(cffRatioPatchEval);
-			combPathPrefixes.add("cff"+favStr+"RatioN"+cffRatioN+"P"+cffRatioThresh);
-		}
-//		configBuilder.path(prefCFFRPatchEval); outputName += "_cffCPathRPatchHalfPos"; // do it separately
-		// END CFF RATIO PATH
-		// add them
-		Preconditions.checkState(combPathEvals.size() == combPathPrefixes.size());
-		if (!combPathEvals.isEmpty()) {
-			configBuilder.path(fractPathsThreshold, combPathEvals.toArray(new NucleationClusterEvaluator[0]));
-			outputName += "_";
-			if (combPathEvals.size() > 1)
-				outputName += "comb"+combPathEvals.size();
-			outputName += fractPathsStr;
-			if (fractPathsStr.isEmpty() && combPathEvals.size() == 1) {
-				outputName += "path";
-			} else {
-				outputName += "Path";
-				if (combPathEvals.size() > 1)
-					outputName += "s";
-			}
-			outputName += "_"+Joiner.on("_").join(combPathPrefixes);
-		}
-
-		// Check connectivity only (maximum 2 clusters per rupture)
-//		configBuilder.maxNumClusters(2); outputName += "_connOnly";
-		
-//		File outputDir = new File(rupSetsDir, "fm3_1_plausible10km_slipP0.05incr_cff3_4_IntsPos_comb2Paths_cffP0.05_cffRatioN2P0.5_sectFractPerm0.05_comp");
-//		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
-		File outputDir = rupSetsDir;
-		
-		/*
-		 * Splay constraints
-		 */
-		if (splays) {
-			configBuilder.maxSplays(1); outputName += "_max1Splays";
-			//configBuilder.splayLength(0.1, true, true); outputName += "_splayLenFract0.1";
-			//configBuilder.splayLength(100, false, true, true); outputName += "_splayLen100km";
-			configBuilder.splayLength(50, false, true, true); outputName += "_splayLen50km";
-			configBuilder.splayLength(.5, true, true, true); outputName += "OrHalf";
-			configBuilder.addFirst(new SplayConnectionsOnlyFilter(connectionStrategy, true)); outputName += "_splayConn";
-		} else {
-			configBuilder.maxSplays(0); // default, no splays
-		}
-		
-		/*
-		 * Growing strategies: how should ruptures be broken up and spread onto new faults
-		 */
-		RuptureGrowingStrategy growingStrat;
-		if (bilateral) {
-			growingStrat = new ExhaustiveBilateralRuptureGrowingStrategy(
-					SecondaryVariations.EQUAL_LEN, false);
-			outputName += "_bilateral";
-		} else {
-			growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
-		}
-		if (adaptiveSectFract > 0f) {
-			SectCountAdaptiveRuptureGrowingStrategy adaptiveStrat = new SectCountAdaptiveRuptureGrowingStrategy(
-					growingStrat, adaptiveSectFract, true, minSectsPerParent);
-			configBuilder.add(adaptiveStrat.buildConnPointCleanupFilter(connectionStrategy));
-			outputName += "_sectFractGrow"+adaptiveSectFract;
-			growingStrat = adaptiveStrat;
-		}
-		
-		// build our configuration
-		PlausibilityConfiguration config = configBuilder.build();
-		outputName += ".zip";
+//		// END CFF RATIO PATH
+//		// add them
+//		Preconditions.checkState(combPathEvals.size() == combPathPrefixes.size());
+//		if (!combPathEvals.isEmpty()) {
+//			configBuilder.path(fractPathsThreshold, combPathEvals.toArray(new NucleationClusterEvaluator[0]));
+//			outputName += "_";
+//			if (combPathEvals.size() > 1)
+//				outputName += "comb"+combPathEvals.size();
+//			outputName += fractPathsStr;
+//			if (fractPathsStr.isEmpty() && combPathEvals.size() == 1) {
+//				outputName += "path";
+//			} else {
+//				outputName += "Path";
+//				if (combPathEvals.size() > 1)
+//					outputName += "s";
+//			}
+//			outputName += "_"+Joiner.on("_").join(combPathPrefixes);
+//		}
+//
+//		// Check connectivity only (maximum 2 clusters per rupture)
+////		configBuilder.maxNumClusters(2); outputName += "_connOnly";
+//		
+////		File outputDir = new File(rupSetsDir, "fm3_1_plausible10km_slipP0.05incr_cff3_4_IntsPos_comb2Paths_cffP0.05_cffRatioN2P0.5_sectFractPerm0.05_comp");
+////		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
+//		File outputDir = rupSetsDir;
+//		
+//		/*
+//		 * Splay constraints
+//		 */
+//		if (splays) {
+//			configBuilder.maxSplays(1); outputName += "_max1Splays";
+//			//configBuilder.splayLength(0.1, true, true); outputName += "_splayLenFract0.1";
+//			//configBuilder.splayLength(100, false, true, true); outputName += "_splayLen100km";
+//			configBuilder.splayLength(50, false, true, true); outputName += "_splayLen50km";
+//			configBuilder.splayLength(.5, true, true, true); outputName += "OrHalf";
+//			configBuilder.addFirst(new SplayConnectionsOnlyFilter(connectionStrategy, true)); outputName += "_splayConn";
+//		} else {
+//			configBuilder.maxSplays(0); // default, no splays
+//		}
+//		
+//		/*
+//		 * Growing strategies: how should ruptures be broken up and spread onto new faults
+//		 */
+//		RuptureGrowingStrategy growingStrat;
+//		if (bilateral) {
+//			growingStrat = new ExhaustiveBilateralRuptureGrowingStrategy(
+//					SecondaryVariations.EQUAL_LEN, false);
+//			outputName += "_bilateral";
+//		} else {
+//			growingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
+//		}
+//		if (adaptiveSectFract > 0f) {
+//			SectCountAdaptiveRuptureGrowingStrategy adaptiveStrat = new SectCountAdaptiveRuptureGrowingStrategy(
+//					growingStrat, adaptiveSectFract, true, minSectsPerParent);
+//			configBuilder.add(adaptiveStrat.buildConnPointCleanupFilter(connectionStrategy));
+//			outputName += "_sectFractGrow"+adaptiveSectFract;
+//			growingStrat = adaptiveStrat;
+//		}
+//		
+//		// build our configuration
+//		PlausibilityConfiguration config = configBuilder.build();
+//		outputName += ".zip";
 		/*
 		 * =============================
 		 * END other experiments
@@ -1535,8 +1537,8 @@ public class ClusterRuptureBuilder {
 		}
 		FaultSystemRupSet rupSet = new FaultSystemRupSet(subSects, sectSlipRates, null, sectAreasReduced, 
 				rupsIDsList, rupMags, rupRakes, rupAreas, rupLengths, "");
-		rupSet.setPlausibilityConfiguration(config);
-		rupSet.setClusterRuptures(rups);
+		rupSet.addModule(new PlausibilityConfigurationModule(rupSet, config));
+		rupSet.addModule(new ClusterRuptures(rupSet, rups));
 		return rupSet;
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
@@ -425,7 +425,7 @@ public class PlausibilityConfiguration {
 	private static Gson prevGson;
 	private static List<? extends FaultSection> prevSubSects;
 	
-	private synchronized static Gson buildGson(List<? extends FaultSection> subSects) {
+	public synchronized static Gson buildGson(List<? extends FaultSection> subSects) {
 		if (prevGson != null && prevSubSects != null && prevSubSects.size() == subSects.size()) {
 			// see if we can reuse
 //			System.out.println("Lets se if we can reuse Gson....");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/PlausibilityConfiguration.java
@@ -508,6 +508,7 @@ public class PlausibilityConfiguration {
 
 		@Override
 		public void write(JsonWriter out, PlausibilityConfiguration config) throws IOException {
+			Preconditions.checkNotNull(config);
 			out.beginObject();
 			
 			out.name("connectionStrategy");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
@@ -10,6 +10,9 @@ import java.util.Map;
 import java.util.zip.ZipException;
 
 import org.dom4j.DocumentException;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.modules.impl.PlausibilityConfigurationModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder.*;
@@ -41,6 +44,7 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.Plausible
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.PlausibleClusterConnectionStrategy.*;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.SectCountAdaptiveRuptureGrowingStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.UCERF3ClusterConnectionStrategy;
+import org.opensha.sha.earthquake.faultSysSolution.util.FaultSystemIO;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ExhaustiveBilateralRuptureGrowingStrategy.SecondaryVariations;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.SectCountAdaptiveRuptureGrowingStrategy.ConnPointCleanupFilter;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ExhaustiveUnilateralRuptureGrowingStrategy;
@@ -54,13 +58,10 @@ import org.opensha.sha.simulators.stiffness.SubSectStiffnessCalculator.Stiffness
 
 import com.google.common.base.Preconditions;
 
-import scratch.UCERF3.FaultSystemRupSet;
-import scratch.UCERF3.FaultSystemSolution;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
 import scratch.UCERF3.inversion.coulomb.CoulombRates;
 import scratch.UCERF3.inversion.laughTest.PlausibilityResult;
-import scratch.UCERF3.utils.FaultSystemIO;
 
 public class ClusterRupturePerturbationBuilder {
 
@@ -103,7 +104,7 @@ public class ClusterRupturePerturbationBuilder {
 		else
 			primaryGrowingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
 		FaultSystemRupSet rupSet = FaultSystemIO.loadRupSet(primaryFile);
-		PlausibilityConfiguration primaryConfig = rupSet.getPlausibilityConfiguration();
+		PlausibilityConfiguration primaryConfig = rupSet.getModule(PlausibilityConfigurationModule.class).getConfiguration();
 		Preconditions.checkNotNull(primaryConfig);
 		
 		List<? extends FaultSection> subSects = rupSet.getFaultSectionDataList();
@@ -406,7 +407,8 @@ public class ClusterRupturePerturbationBuilder {
 			if (replot || !new File(plotDir, "README.md").exists()) {
 				FaultSystemSolution u3 = FaultSystemIO.loadSol(new File(rupSetsDir, "fm3_1_ucerf3.zip"));
 				System.out.println("Plotting UCERF3");
-				RupSetDiagnosticsPageGen pageGen = new RupSetDiagnosticsPageGen(rupSet, null, primaryName, u3.getRupSet(), u3, "UCERF3", plotDir);
+				RupSetDiagnosticsPageGen pageGen = new RupSetDiagnosticsPageGen(rupSet.toOldRupSet(), null, primaryName,
+						u3.getRupSet().toOldRupSet(), u3.toOldSol(), "UCERF3", plotDir);
 				pageGen.setSkipPlausibility(false);
 				pageGen.setIndexDir(indexDir);
 				
@@ -464,7 +466,7 @@ public class ClusterRupturePerturbationBuilder {
 					altRupSet = FaultSystemIO.loadRupSet(outputFile);
 				}
 				System.out.println("Plotting "+name);
-				RupSetDiagnosticsPageGen pageGen = new RupSetDiagnosticsPageGen(rupSet, null, primaryName, altRupSet, null, name, plotDir);
+				RupSetDiagnosticsPageGen pageGen = new RupSetDiagnosticsPageGen(rupSet.toOldRupSet(), null, primaryName, altRupSet.toOldRupSet(), null, name, plotDir);
 				pageGen.setSkipPlausibility(skipPlausibility);
 				pageGen.setIndexDir(indexDir);
 				pageGen.generatePage();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ClusterRupturePerturbationBuilder.java
@@ -104,7 +104,7 @@ public class ClusterRupturePerturbationBuilder {
 		else
 			primaryGrowingStrat = new ExhaustiveUnilateralRuptureGrowingStrategy();
 		FaultSystemRupSet rupSet = FaultSystemIO.loadRupSet(primaryFile);
-		PlausibilityConfiguration primaryConfig = rupSet.getModule(PlausibilityConfigurationModule.class).getConfiguration();
+		PlausibilityConfiguration primaryConfig = rupSet.getModule(PlausibilityConfigurationModule.class).get();
 		Preconditions.checkNotNull(primaryConfig);
 		
 		List<? extends FaultSection> subSects = rupSet.getFaultSectionDataList();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSystemIO.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSystemIO.java
@@ -535,11 +535,6 @@ public class FaultSystemIO {
 				e.printStackTrace();
 				System.err.println("Error loading module '"+record.name+"', skipping.");
 			}
-			try {
-				
-			} catch (Exception e) {
-				
-			}
 		}
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSystemIO.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSystemIO.java
@@ -1,0 +1,553 @@
+package org.opensha.sha.earthquake.faultSysSolution.util;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.dom4j.Document;
+import org.dom4j.DocumentException;
+import org.dom4j.Element;
+import org.dom4j.io.OutputFormat;
+import org.dom4j.io.XMLWriter;
+import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.data.Named;
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.commons.util.XMLUtils;
+import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupSetModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.StatefulModule;
+import org.opensha.sha.faultSurface.FaultSection;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+public class FaultSystemIO {
+	
+	public static void writeRupSet(FaultSystemRupSet rupSet, File outputFile) throws IOException {
+		System.out.println("Writing rupture set to"+outputFile.getAbsolutePath());
+		ZipOutputStream zout = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outputFile)));
+		writeRupSet(rupSet, zout);
+		zout.close();
+	}
+	
+	public static void writeRupSet(FaultSystemRupSet rupSet, ZipOutputStream zout) throws IOException {
+		// ruptures CSV
+		System.out.println("Writing ruptures.csv");
+		zout.putNextEntry(new ZipEntry("ruptures.csv"));
+		buildRupturesCSV(rupSet).writeToStream(zout);
+		zout.flush();
+		zout.closeEntry();
+		
+		// sections CSV
+		System.out.println("Writing sections.csv");
+		zout.putNextEntry(new ZipEntry("sections.csv"));
+		buildSectsCSV(rupSet).writeToStream(zout);
+		zout.flush();
+		zout.closeEntry();
+		
+		// fault sections
+		// TODO: retire the old XML format
+		Document doc = XMLUtils.createDocumentWithRoot();
+		Element root = doc.getRootElement();
+		scratch.UCERF3.utils.FaultSystemIO.fsDataToXML(root, FaultSectionPrefData.XML_METADATA_NAME+"List",
+				null, null, rupSet.getFaultSectionDataList());
+		zout.putNextEntry(new ZipEntry("fault_sections.xml"));
+		XMLWriter writer = new XMLWriter(new BufferedWriter(new OutputStreamWriter(zout)),
+				OutputFormat.createPrettyPrint());
+		writer.write(doc);
+		writer.flush();
+		zout.flush();
+		zout.closeEntry();
+		
+		String info = rupSet.getInfoString();
+		if (info != null && !info.isBlank())
+			writeInfoToZip(zout, info, "rupture_info.txt");
+		
+		writeModules(zout, rupSet.getModules(), "rupture_modules.json");
+	}
+	
+	public static FaultSystemRupSet loadRupSet(File rupSetFile) throws IOException {
+		System.out.println("Loading rupture set from "+rupSetFile.getAbsolutePath());
+		return loadRupSet(new ZipFile(rupSetFile));
+	}
+	
+	public static FaultSystemRupSet loadRupSet(ZipFile zip) throws IOException {
+		ZipEntry rupsEntry = new ZipEntry("ruptures.csv");
+		CSVFile<String> rupsCSV = CSVFile.readStream(zip.getInputStream(rupsEntry), true);
+		ZipEntry sectsEntry = new ZipEntry("sections.csv");
+		CSVFile<String> sectsCSV = CSVFile.readStream(zip.getInputStream(sectsEntry), true);
+		
+		// fault sections
+		// TODO: retire old XML format
+		ZipEntry fsdEntry = zip.getEntry("fault_sections.xml");
+		Document doc;
+		try {
+			doc = XMLUtils.loadDocument(
+					new BufferedInputStream(zip.getInputStream(fsdEntry)));
+		} catch (DocumentException e) {
+			throw ExceptionUtils.asRuntimeException(e);
+		}
+		Element fsEl = doc.getRootElement().element(FaultSectionPrefData.XML_METADATA_NAME+"List");
+		List<FaultSection> sections = scratch.UCERF3.utils.FaultSystemIO.fsDataFromXML(fsEl);
+		
+		// info
+		String info = loadInfoFromZip(zip, "rupture_info.txt");
+		
+		FaultSystemRupSet rupSet = loadRupSetCSVs(sections, rupsCSV, sectsCSV, info);
+		
+		if (zip.getEntry("modules.json") != null) {
+			List<StatefulModuleRecord> records = loadModuleRecords(zip, "rupture_modules.json");
+			loadRupSetModules(rupSet, records, zip);
+		}
+		
+		return rupSet;
+	}
+	
+	private static CSVFile<String> buildRupturesCSV(FaultSystemRupSet rupSet) {
+		CSVFile<String> csv = new CSVFile<>(false);
+		
+		csv.addLine("Rupture Index", "Magnitude", "Average Rake (degrees)", "Area (m^2)", "Length (m)",
+				"Num Sections", "Section Index 1", "Section Index N");
+		
+		double[] lengths = rupSet.getLengthForAllRups();
+		for (int r=0; r<rupSet.getNumRuptures(); r++) {
+			List<Integer> sectIDs = rupSet.getSectionsIndicesForRup(r);
+			List<String> line = new ArrayList<>(5+sectIDs.size());
+			
+			line.add(r+"");
+			line.add(rupSet.getMagForRup(r)+"");
+			line.add(rupSet.getAveRakeForRup(r)+"");
+			line.add(rupSet.getAreaForRup(r)+"");
+			if (lengths == null)
+				line.add("");
+			else
+				line.add(lengths[r]+"");
+			line.add(sectIDs.size()+"");
+			for (int s : sectIDs)
+				line.add(s+"");
+			csv.addLine(line);
+		}
+		
+		return csv;
+	}
+	
+	private static CSVFile<String> buildSectsCSV(FaultSystemRupSet rupSet) {
+		CSVFile<String> csv = new CSVFile<>(true);
+		
+		// TODO: what should we put in here? how should we represent sections in these files?
+		csv.addLine("Section Index", "Section Name", "Area (m^2)", "Slip Rate (m/yr)", "Slip Rate Standard Deviation (m/yr)");
+		double[] sectAreas = rupSet.getAreaForAllSections();
+		double[] sectSlipRates = rupSet.getSlipRateForAllSections();
+		double[] sectSlipRateStdDevs = rupSet.getSlipRateStdDevForAllSections();
+		for (int s=0; s<rupSet.getNumSections(); s++) {
+			FaultSection sect = rupSet.getFaultSectionData(s);
+			Preconditions.checkState(sect.getSectionId() == s, "Section ID mismatch, expected %s but is %s", s, sect.getSectionId());
+			List<String> line = new ArrayList<>(5);
+			line.add(s+"");
+			line.add(sect.getSectionName());
+			line.add(sectAreas == null ? "" : sectAreas[s]+"");
+			line.add(sectSlipRates == null ? "" : sectSlipRates[s]+"");
+			line.add(sectSlipRateStdDevs == null ? "" : sectSlipRateStdDevs[s]+"");
+			csv.addLine(line);
+		}
+		
+		return csv;
+	}
+	
+	private static FaultSystemRupSet loadRupSetCSVs(List<? extends FaultSection> sections,
+			CSVFile<String> rupturesCSV, CSVFile<String> sectsCSV, String info) {
+		int numRuptures = rupturesCSV.getNumRows()-1;
+		Preconditions.checkState(numRuptures > 0, "No ruptures found in CSV file");
+		int numSections = sectsCSV.getNumRows()-1;
+		
+		// load rupture data
+		double[] mags = new double[numRuptures];
+		double[] rakes = new double[numRuptures];
+		double[] areas = new double[numRuptures];
+		double[] lengths = null;
+		List<List<Integer>> rupSectsList = new ArrayList<>(numRuptures);
+		boolean shortSafe = numSections < Short.MAX_VALUE;
+		for (int r=0; r<numRuptures; r++) {
+			int row = r+1;
+			int col = 0;
+			Preconditions.checkState(r == rupturesCSV.getInt(row, col++),
+					"Ruptures out of order or not 0-based in CSV file, expected id=%s at row %s", r, row);
+			mags[r] = rupturesCSV.getDouble(row, col++);
+			rakes[r] = rupturesCSV.getDouble(row, col++);
+			areas[r] = rupturesCSV.getDouble(row, col++);
+			String lenStr = rupturesCSV.get(row, col++);
+			if ((r == 0 && !lenStr.isBlank()) || lengths != null) {
+				lengths = new double[numRuptures];
+				lengths[r] = Double.parseDouble(lenStr);
+			} else {
+				Preconditions.checkState(lenStr.isBlank(),
+						"Rupture lenghts must be populated for all ruptures, or omitted for all. We have a length for "
+						+ "rupture %s but the first rupture did not have a length.", r);
+			}
+			int numRupSects = rupturesCSV.getInt(row, col++);
+			Preconditions.checkState(numRupSects > 0, "Rupture %s has no sections!", r);
+			List<Integer> rupSects;
+			if (shortSafe) {
+				short[] sectIDs = new short[numRupSects];
+				for (int i=0; i<numRupSects; i++)
+					sectIDs[i] = (short)rupturesCSV.getInt(row, col++);
+				rupSects = new ShortListWrapper(sectIDs);
+			} else {
+				int[] sectIDs = new int[numRupSects];
+				for (int i=0; i<numRupSects; i++)
+					sectIDs[i] = rupturesCSV.getInt(row, col++);
+				rupSects = new IntListWrapper(sectIDs);
+			}
+			int rowSize = rupturesCSV.getLine(row).size();
+			Preconditions.checkState(col == rowSize,
+					"Unexpected line lenth for rupture %s, have %s columns but expected %s", r, col, rowSize);
+			rupSectsList.add(rupSects);
+		}
+		
+		double[] sectAreas = null;
+		double[] sectSlipRates = null;
+		double[] sectSlipRateStdDevs = null;
+		for (int s=0; s<numSections; s++) {
+			int row = s+1;
+			int col = 0;
+			Preconditions.checkState(s == sectsCSV.getInt(row, col++),
+					"Sections out of order or not 0-based in CSV file, expected id=%s at row %s", s, row);
+			
+			col++; // don't need name
+			String areaStr = sectsCSV.get(row, col++);
+			String rateStr = sectsCSV.get(row, col++);
+			String rateStdDevStr = sectsCSV.get(row, col++);
+			
+			
+			if (s == 0) {
+				if (!areaStr.isBlank())
+					sectAreas = new double[numSections];
+				if (!rateStr.isBlank())
+					sectSlipRates = new double[numSections];
+				if (!rateStdDevStr.isBlank())
+					sectSlipRateStdDevs = new double[numSections];
+			}
+			if (sectAreas != null)
+				sectAreas[s] = Double.parseDouble(areaStr);
+			if (sectSlipRates != null)
+				sectSlipRates[s] = Double.parseDouble(rateStr);
+			if (sectSlipRateStdDevs != null)
+				sectSlipRateStdDevs[s] = Double.parseDouble(rateStdDevStr);
+			int rowSize = rupturesCSV.getLine(row).size();
+			Preconditions.checkState(col == rowSize,
+					"Unexpected line lenth for rupture %s, have %s columns but expected %s", s, col, rowSize);
+		}
+		
+		return new FaultSystemRupSet(sections, sectSlipRates, sectSlipRateStdDevs, sectAreas,
+				rupSectsList, mags, rakes, sectAreas, lengths, info);
+	}
+	
+	/**
+	 * Memory efficient list that is backed by an array of short values for memory efficiency
+	 * @author kevin
+	 *
+	 */
+	private static class ShortListWrapper extends AbstractList<Integer> {
+		
+		private short[] vals;
+		
+		public ShortListWrapper(short[] vals) {
+			this.vals = vals;
+		}
+
+		@Override
+		public Integer get(int index) {
+			return (int)vals[index];
+		}
+
+		@Override
+		public int size() {
+			this.equals(null);
+			return vals.length;
+		}
+		
+		public boolean equals(Object o) {
+	        if (o == this)
+	            return true;
+	        if (!(o instanceof List))
+	            return false;
+	        List<?> oList = (List<?>)o;
+	        if (size() != oList.size())
+	        	return false;
+	        if (Integer.class.isAssignableFrom(oList.get(0).getClass()))
+	        	return false;
+	        
+	        for (int i=0; i<vals.length; i++)
+	        	if ((int)vals[i] != ((Integer)oList.get(i)).intValue())
+	        		return false;
+	        return true;
+	    }
+		
+	}
+	
+	/**
+	 * Memory efficient list that is backed by an array of integer values for memory efficiency
+	 * @author kevin
+	 *
+	 */
+	private static class IntListWrapper extends AbstractList<Integer> {
+		
+		private int[] vals;
+		
+		public IntListWrapper(int[] vals) {
+			this.vals = vals;
+		}
+
+		@Override
+		public Integer get(int index) {
+			return vals[index];
+		}
+
+		@Override
+		public int size() {
+			this.equals(null);
+			return vals.length;
+		}
+		
+		public boolean equals(Object o) {
+	        if (o == this)
+	            return true;
+	        if (!(o instanceof List))
+	            return false;
+	        List<?> oList = (List<?>)o;
+	        if (size() != oList.size())
+	        	return false;
+	        if (Integer.class.isAssignableFrom(oList.get(0).getClass()))
+	        	return false;
+	        
+	        for (int i=0; i<vals.length; i++)
+	        	if (vals[i] != ((Integer)oList.get(i)).intValue())
+	        		return false;
+	        return true;
+	    }
+		
+	}
+	
+	public static void writeSol(FaultSystemSolution sol, File outputFile) throws IOException {
+		System.out.println("Writing solution to"+outputFile.getAbsolutePath());
+		ZipOutputStream zout = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outputFile)));
+		writeRupSet(sol.getRupSet(), zout);
+		zout.close();
+		
+		// sections CSV
+		System.out.println("Writing rates.csv");
+		zout.putNextEntry(new ZipEntry("rates.csv"));
+		CSVFile<String> ratesCSV = new CSVFile<>(true);
+		ratesCSV.addLine("Rupture Index", "Annual Rate");
+		double[] rates = sol.getRateForAllRups();
+		for (int r=0; r<rates.length; r++)
+			ratesCSV.addLine(r+"", rates[r]+"");
+		ratesCSV.writeToStream(zout);
+		zout.flush();
+		zout.closeEntry();
+		
+		String info = sol.getInfoString();
+		if (info != null && !info.isBlank())
+			writeInfoToZip(zout, info, "solution_info.txt");
+		
+		writeModules(zout, sol.getModules(), "solution_modules.json");
+	}
+	
+	public static FaultSystemSolution loadSol(File solFile) throws IOException {
+		System.out.println("Loading solution from "+solFile.getAbsolutePath());
+		
+		ZipFile zip = new ZipFile(solFile);
+		
+		FaultSystemRupSet rupSet = loadRupSet(zip);
+		
+		ZipEntry ratesEntry = new ZipEntry("rates.csv");
+		CSVFile<String> ratesCSV = CSVFile.readStream(zip.getInputStream(ratesEntry), true);
+		double[] rates = new double[rupSet.getNumRuptures()];
+		Preconditions.checkState(ratesCSV.getNumRows() == rupSet.getNumRuptures()+1, "Unexpected number of rows in rates CSV");
+		for (int r=0; r<rates.length; r++) {
+			Preconditions.checkState(ratesCSV.getInt(r+1, 0) == r, "Rates CSV out of order or not 0-based");
+			rates[r] = ratesCSV.getDouble(r+1, 1);
+		}
+		
+		// info
+		String info = loadInfoFromZip(zip, "solution_info.txt");
+		
+		FaultSystemSolution sol = new FaultSystemSolution(rupSet, rates);
+		if (info != null && !info.isBlank())
+			sol.setInfoString(info);
+		
+		if (zip.getEntry("modules.json") != null) {
+			List<StatefulModuleRecord> records = loadModuleRecords(zip, "solution_modules.json");
+			loadSolutionModules(sol, records, zip);
+		}
+		
+		return sol;
+	}
+	
+	private static void writeModules(ZipOutputStream zout, List<? extends Named> modules, String entryName) throws IOException {
+		List<StatefulModuleRecord> written = new ArrayList<>();
+		for (Named module : modules) {
+			if (module instanceof StatefulModule) {
+				System.out.println("Writing stateful module: "+module.getName());
+				StatefulModule stateful = (StatefulModule)module;
+				stateful.writeToArchive(zout, null);
+				written.add(new StatefulModuleRecord(stateful));
+			} else {
+				System.out.println("Skipping transient module: "+module.getName());
+			}
+		}
+		if (!written.isEmpty()) {
+			System.out.println("Wrote "+written.size()+" modules, writing index");
+			Gson gson = new GsonBuilder().setPrettyPrinting().create();
+			
+			zout.putNextEntry(new ZipEntry(entryName));
+			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(zout));
+			gson.toJson(written, writer);
+			writer.write("\n");
+			writer.flush();
+			zout.closeEntry();
+		}
+	}
+	
+	private static class StatefulModuleRecord {
+		public final String className;
+		public final String name;
+		
+		public StatefulModuleRecord(StatefulModule module) {
+			this.className = module.getLoadingClass().getName();
+			this.name = module.getName();
+		}
+	}
+	
+	private static List<StatefulModuleRecord> loadModuleRecords(ZipFile zip, String entryName) throws IOException {
+		ZipEntry entry = zip.getEntry(entryName);
+		Preconditions.checkNotNull(entry, "Modules entry not found in zip archive");
+		
+		Gson gson = new GsonBuilder().create();
+		
+		InputStream zin = zip.getInputStream(entry);
+		BufferedReader reader = new BufferedReader(new InputStreamReader(zin));
+		List<StatefulModuleRecord> records = gson.fromJson(reader,
+				TypeToken.getParameterized(List.class, StatefulModuleRecord.class).getType());
+		reader.close();
+		
+		zin.close();
+		return records;
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static void loadRupSetModules(FaultSystemRupSet rupSet, List<StatefulModuleRecord> records, ZipFile zip)
+			throws IOException {
+		for (StatefulModuleRecord record : records) {
+			System.out.println("Loading module: "+record.name);
+			Class<?> clazz;
+			try {
+				clazz = Class.forName(record.className);
+			} catch(Exception e) {
+				System.err.println("WARNING: Skipping module '"+record.name
+						+"', couldn't locate class: "+record.className);
+				continue;
+			}
+			if (!RupSetModule.class.isAssignableFrom(clazz)) {
+				System.err.println("WARNING: Skipping module '"+record.name
+						+"' as the specified class isn't a RupSetModule: "+record.className);
+				continue;
+			}
+			try {
+				RupSetModule module = RupSetModule.instance((Class<? extends RupSetModule>)clazz, rupSet);
+				if (!(module instanceof StatefulModule)) {
+					System.err.println("WARNING: Module class is not stateful, skipping: "+record.className);
+					continue;
+				}
+				((StatefulModule)module).initFromArchive(zip, null);
+				rupSet.addModule(module);
+			} catch (Exception e) {
+				e.printStackTrace();
+				System.err.println("Error loading module '"+record.name+"', skipping.");
+			}
+		}
+	}
+	
+	@SuppressWarnings("unchecked")
+	private static void loadSolutionModules(FaultSystemSolution sol, List<StatefulModuleRecord> records, ZipFile zip)
+			throws IOException {
+		for (StatefulModuleRecord record : records) {
+			System.out.println("Loading module: "+record.name);
+			Class<?> clazz;
+			try {
+				clazz = Class.forName(record.className);
+			} catch(Exception e) {
+				System.err.println("WARNING: Skipping module '"+record.name
+						+"', couldn't locate class: "+record.className);
+				continue;
+			}
+			if (!SolutionModule.class.isAssignableFrom(clazz)) {
+				System.err.println("WARNING: Skipping module '"+record.name
+						+"' as the specified class isn't a RupSetModule: "+record.className);
+				continue;
+			}
+			try {
+				SolutionModule module = SolutionModule.instance((Class<? extends SolutionModule>)clazz, sol);
+				if (!(module instanceof StatefulModule)) {
+					System.err.println("WARNING: Module class is not stateful, skipping: "+record.className);
+					continue;
+				}
+				((StatefulModule)module).initFromArchive(zip, null);
+				sol.addModule(module);
+			} catch (Exception e) {
+				e.printStackTrace();
+				System.err.println("Error loading module '"+record.name+"', skipping.");
+			}
+		}
+	}
+	
+	private static String loadInfoFromZip(ZipFile zip, String entryName) throws IOException {
+		ZipEntry infoEntry = zip.getEntry(entryName);
+		if (infoEntry != null) {
+			StringBuilder text = new StringBuilder();
+			String NL = System.getProperty("line.separator");
+			Scanner scanner = new Scanner(
+					new BufferedInputStream(zip.getInputStream(infoEntry)));
+			try {
+				while (scanner.hasNextLine()){
+					text.append(scanner.nextLine() + NL);
+				}
+			}
+			finally{
+				scanner.close();
+			}
+			return text.toString();
+		} else {
+			return null;
+		}
+	}
+	
+	private static void writeInfoToZip(ZipOutputStream zout, String info, String entryName) throws IOException {
+		zout.putNextEntry(new ZipEntry(entryName));
+		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(zout));
+		writer.write(info);
+		writer.flush();
+		zout.flush();
+		zout.closeEntry();
+	}
+
+}

--- a/src/main/java/scratch/UCERF3/FaultSystemSolution.java
+++ b/src/main/java/scratch/UCERF3/FaultSystemSolution.java
@@ -57,6 +57,7 @@ import com.google.common.collect.Maps;
  * @author Field, Milner, Page, and Powers
  *
  */
+@Deprecated
 public class FaultSystemSolution implements Serializable {
 	
 	private FaultSystemRupSet rupSet;

--- a/src/main/java/scratch/UCERF3/analysis/FaultSystemRupSetCalc.java
+++ b/src/main/java/scratch/UCERF3/analysis/FaultSystemRupSetCalc.java
@@ -120,7 +120,7 @@ public class FaultSystemRupSetCalc {
 				System.out.println(i+" has NaN moRate; "+faultSystemRupSet.getFaultSectionData(i).getName()+
 						"\tarea="+(float)faultSystemRupSet.getAreaForSection(i)+"\tslipRate="+(float)faultSystemRupSet.getSlipRateForSection(i));
 			}
-			double min = faultSystemRupSet.getOrigMinMagForSection(i);
+			double min = getOrigMinMagForSection(faultSystemRupSet, i);
 			if(!Double.isNaN(wt)) {
 				hist.add(min, wt);
 			}
@@ -1716,7 +1716,7 @@ public class FaultSystemRupSetCalc {
 		List<? extends FaultSection> sectDataList = faultSystemRupSet.getFaultSectionDataList();
 		for(int s=0; s< sectDataList.size();s++) {
 			String parSectName = sectDataList.get(s).getParentSectionName();
-			minSectMag = faultSystemRupSet.getOrigMinMagForSection(s);
+			minSectMag = getOrigMinMagForSection(faultSystemRupSet, s);
 			maxSectMag = faultSystemRupSet.getMaxMagForSection(s);
 			if(!parSectName.equals(prevParSectName)) { // if it's a new parent section
 				if(!prevParSectName.equals("junk")) { // Process results
@@ -1857,6 +1857,26 @@ public class FaultSystemRupSetCalc {
 
 	}
 	
+	/**
+	 * This returns the magnitude of the smallest rupture involving this section or NaN
+	 * if no ruptures involve this section.  This is called "Orig" because subclasses
+	 * may filter the minimum magnitudes further (e.g., so they don't fall below some
+	 * threshold).
+	 * @param sectIndex
+	 * @return
+	 */
+	private static double getOrigMinMagForSection(FaultSystemRupSet rupSet, int sectIndex) {
+		List<Integer> rups = rupSet.getRupturesForSection(sectIndex);
+		if (rups.isEmpty())
+			return Double.NaN;
+		double minMag = Double.POSITIVE_INFINITY;
+		for (int rupIndex : rupSet.getRupturesForSection(sectIndex)) {
+			double mag = rupSet.getMagForRup(rupIndex);
+			if (mag < minMag)
+				minMag = mag;
+		}
+		return minMag;
+	}
 	
 	/**
 	 * This computes the final minimum seismogenic rupture mag for each section,
@@ -1889,7 +1909,7 @@ public class FaultSystemRupSetCalc {
 		double minMinSeismoMag=0;	// this is for testing
 		for(int s=0; s< sectDataList.size();s++) {
 			String parSectName = sectDataList.get(s).getParentSectionName();
-			double minSeismoMag = fltSystRupSet.getOrigMinMagForSection(s);
+			double minSeismoMag = getOrigMinMagForSection(fltSystRupSet, s);
 			if(!parSectName.equals(prevParSectName)) { // it's a new parent section
 				// set the previous result
 				if(!prevParSectName.equals("junk")) {


### PR DESCRIPTION
This is a working draft of my idea for how to re-think the nasty hierarchy of FaultSystemRupSet/Solution classes. I've given it some thought and settled on this approach after chasing other dead ends, but it's still definitely up for debate and the specifics of the API are very much subject to change based on feedback. Tagging the most likely interested parties here so you can provide feedback and track the progress: @field-usgs @chrisbc @voj @pmpowers-usgs 

I'll start with the motivation:

## Current limitations

The class hierarchy for solutions and rupture sets is complex as is, and without a redesign it's about to get way worse as we begin UCERF4 development (and NZ integration). Here's some of it as is (does not include the NZ stuff):

* **FaultSystemRupSet**: base class
  * _SlipEnabledRupSet_: interface that adds average-slip functionality
    * _SlipAlongRuptureModelRupSet_: interface that adds Dsr functionality
      * **InversionFaultSystemRupSet**: UCERF3 rupture set class
* **FaultSystemSolution**: base class
  * _SlipEnabledSolution_: interface that adds solution slip rate calculation functionality
    * **InversionFaultSystemSolution**: UCERF3 solution
      * **AverageFaultSystemSolution**: Average of multiple inversions
  * **SimulatorFaultSystemSolution**: RSQSim, etc

That's a lot as it is, and Kiwis will want to add many analogous classes. There are properties of the UCERF3 classes, on top of the existing interfaces, that we will want to carry forward and have show up in plots/diagnostic pages, such as:

* Logic tree branch information
* Information about plausibility filters used to create a rupture set
* Inversion metadata, misfits
* Cluster Ruptures
* Branch-averaged information, such as rupture MFDs
* Grid source provider

In the future, lets say we wanted an 'average' UCERF4 fault system solution. We would first have to extract an 'AverageSolution' interface that lies between InversionFaultSystemSolution and AverageFualtSystemSolution, and make another sub-class of UCERF4 solutions that contain average functionality. Now we have yet another interface with 2 additional implementations.

Things get even nastier when you're trying to load in a rupture set/solution from a file. Currently, I have to figure out which of the concrete classes that I know about best matches the information available in the zip file. This gets tough, and only gets more complicated as more and more classes/interfaces are added. If you want to see the nastiness, [here's the current code for loading a rupture set](https://github.com/opensha/opensha/blob/a62c41ecca27cbb786f76b78e8c5c01ff464ad65/src/main/java/scratch/UCERF3/utils/FaultSystemIO.java#L219). Now imagine that the Kiwis want to add custom information to their rupture sets that needs to be serialized to a rupture set zip file: they would have to add a bunch more special cases to our existing I/O class in order to do that. Yikes.

## Modular Proposal

I propose that we strip RupSet and Solution to their basic capabilities, those that are common all all conceivable implementations. Any additional features are then represented as modules, that can be loaded into and retrieved from any rupture set/solution. There are different [RupSetModule](https://github.com/opensha/opensha/blob/modular-fault-sys-rup-set/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupSetModule.java) and [SolutionModule](https://github.com/opensha/opensha/blob/modular-fault-sys-rup-set/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionModule.java) base classes. Those classes really only force that modules have a name, and gives them access to the rupture set/solution to which they belong.

You then retrieve a module by asking a rupture set/solution for it using the class. For example, lets say you have a module called LogicTreeBranchModule that supplies branch information to rupture sets. First, you can register it with a rupture set:

```
rupSet.addModule(new LogicTreeBranchModule(rupSet, branch));
```

You can then retrieve it by calling:

```
LogicTreeBranchModule branchModule = rupSet.getModule(LogicTreeBranchModule.class);
```

Or query for it's existence by calling

```
rupSet.hasModule(LogicTreeBranch.class);
```

Modules can be subclassed, and if so than you can call for any super-class when retrieving a module. So if you have a `MyLogicTreeBranchModule` that extends `LogicTreeBranchModule`, you can retrieve it with either `rupSet.getModule(LogicTreeBranchModule.class);` or `rupSet.getModule(MyLogicTreeBranchModule.class);`.

## I/O Implications

One of the main benefits of this is that it can drastically simplify I/O. By default, modules are transient (not written to files), but they can become stateful by implementing the [StatefulModule](https://github.com/opensha/opensha/blob/modular-fault-sys-rup-set/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/StatefulModule.java) interface. Modules themselves are responsible for their (de)serialization, so anyone can add their own modules an use the same I/O code (so long as their module is on the classpath). I have added helper interfaces for [JSON backed modules](https://github.com/opensha/opensha/blob/modular-fault-sys-rup-set/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/JSON_BackedModule.java) and [CSV backed modules](https://github.com/opensha/opensha/blob/modular-fault-sys-rup-set/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/CSV_BackedModule.java) where most of the work is done for you.

Here's a super-simple example SolutionModule implementation that is backed by a CSV. The new I/O code will automatically store the CSV to a solution zip file, and load the module from it:

```java
public class RupMFDsModule extends SolutionModule implements CSV_BackedModule {
	
	private DiscretizedFunc[] rupMFDs;
	
	public RupMFDsModule() {
		super(null);
	}

	public RupMFDsModule(FaultSystemSolution sol, DiscretizedFunc[] rupMFDs) {
		super(sol);
		this.rupMFDs = rupMFDs;
		int numRups = sol.getRupSet().getNumRuptures();
		Preconditions.checkState(numRups == rupMFDs.length,
				"Have %s ruptures but %s rupture MFDs", numRups, rupMFDs.length);
	}

	@Override
	public String getName() {
		return "Rupture MFDs";
	}

	@Override
	public String getCSV_FileName() {
		return "rup_mfds.csv";
	}

	@Override
	public CSVFile<?> getCSV() {
		CSVFile<String> csv = new CSVFile<>(true);
		csv.addLine("Rupture Index", "Magnitude", "Rate");
		// do stuff here
		return csv;
	}

	@Override
	public void initFromCSV(CSVFile<String> csv) {
		// do stuff here
	}
	
	public DiscretizedFunc getRuptureMFD(int rupIndex) {
		return rupMFDs[rupIndex];
	}

}
```

I'm also taking this opportunity to revamp the file structure, switching out the old binary formats for simpler CSVs. I'll edit this description to provide more details about that in the future.

## Current questions/TODOs

* Should the rupture set/solution classes be final? Making them final forces us to follow the design pattern, and things could get messy if not
* I'm interested in retiring the fault system XML format, but not sure what the format should be. It could be represented in CSVs, or in GeoJSON, though we would need to add a bunch of custom fields to GeoJSON for it to work.
* In order to be deserialized, all modules currently require a public no-arg constructor. There is no way to enforce this at compile-time, however, so that gets a little nasty. Any suggestions on improving this?