### PR TITLE
fix for trace buffers of faults that turn back on themselves

### DIFF
--- a/src/test/java/scratch/UCERF3/griddedSeismicity/SectionPolygonsTest.java
+++ b/src/test/java/scratch/UCERF3/griddedSeismicity/SectionPolygonsTest.java
@@ -1,0 +1,47 @@
+package scratch.UCERF3.griddedSeismicity;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationList;
+
+import java.awt.geom.Area;
+
+public class SectionPolygonsTest {
+
+    @Test
+    public void testBuildBufferPoly() {
+        // a fault that turns back on itself
+        LocationList trace = new LocationList();
+        trace.add(new Location(-43.5116, 171.398));
+        trace.add(new Location(-43.5343, 171.3843));
+        trace.add(new Location(-43.5527, 171.3412));
+
+        Area actual = SectionPolygons.buildBufferPoly(trace, 220, 12);
+
+        assertTrue(containsAll(actual, trace));
+    }
+
+    public static boolean containsAll(Area area, LocationList locations) {
+        for (Location location : locations) {
+            if (!containsWithTolerance(area, location, 0.0000000001)) {
+               return false;
+            }
+        }
+        return true;
+    }
+
+    public static boolean containsWithTolerance(Area area, Location location, double tolerance) {
+        for (int lat = -1; lat <= 1; lat++) {
+            for (int lon = -1; lon <= 1; lon++) {
+                if (area.contains(
+                        location.getLongitude() + lon * tolerance,
+                        location.getLatitude() + lat * tolerance)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
Trace buffers for faults that turn back on themselves do not always contain the whole fault trace. E.g.:
![image (1)](https://user-images.githubusercontent.com/3160916/123895633-3b781c00-d9b4-11eb-80ae-e4fc2aff5932.png)

Because the (red/green) fault curves back against itself in the south, the (blue) buffer polygon is constructed in a faulty way.

This fix will construct the following polygon instead:

![image](https://user-images.githubusercontent.com/3160916/123895785-87c35c00-d9b4-11eb-8767-fc7745c23e86.png)
