### PR TITLE
fixes #40: shutdown ExecutorService

### DIFF
--- a/src/main/java/scratch/UCERF3/simulatedAnnealing/ThreadedSimulatedAnnealing.java
+++ b/src/main/java/scratch/UCERF3/simulatedAnnealing/ThreadedSimulatedAnnealing.java
@@ -505,6 +505,16 @@ public class ThreadedSimulatedAnnealing implements SimulatedAnnealing {
 		long[] ret = { iter, perturbs };
 		return ret;
 	}
+
+	/**
+	 * Shuts down the thread pool.
+	 */
+	public void shutdown(){
+		if (exec != null){
+			exec.shutdown();
+			exec = null;
+		}
+	}
 	
 	public static String timeStr(long millis) {
 		double secs = millis/1000d;


### PR DESCRIPTION
closes #40 

I noticed the `ExecutorService` is not simply local to the `iterate` method, not sure what the intention is. I've simply added a `shutdown` method to the class, although I think it's safer to simply always shutdown the service at the end of the `iterate` method.

Alternatively, you might want to consider making the TSA `Closeable`, so that we can use the try-with-resources statement https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html 