### PR TITLE
added new MFD Uncertainty weighted constraint; 

### DIFF
--- a/src/main/java/org/opensha/commons/data/function/EvenlyDiscretizedFunc.java
+++ b/src/main/java/org/opensha/commons/data/function/EvenlyDiscretizedFunc.java
@@ -208,7 +208,7 @@ public class EvenlyDiscretizedFunc extends AbstractDiscretizedFunc{
 
 	/**
 	 * Returns the minimum y-value in this series. Since the value could
-	 * appear aywhere along the x-axis, each point needs to be
+	 * appear anywhere along the x-axis, each point needs to be
 	 * examined, lookup is slower the larger the dataset. <p>
 	 *
 	 * Note: An alternative would be to check for the min value every time a
@@ -224,7 +224,7 @@ public class EvenlyDiscretizedFunc extends AbstractDiscretizedFunc{
 
 	/**
 	 * Returns the maximum y-value in this series. Since the value could
-	 * appear aywhere along the x-axis, each point needs to be
+	 * appear anywhere along the x-axis, each point needs to be
 	 * examined, lookup is slower the larger the dataset. <p>
 	 *
 	 * Note: An alternative would be to check for the min value every time a
@@ -240,7 +240,7 @@ public class EvenlyDiscretizedFunc extends AbstractDiscretizedFunc{
 	
 	/**
 	 * Returns the x index for the maximum y-value in this series. Since the value could
-	 * appear aywhere along the x-axis, each point needs to be
+	 * appear anywhere along the x-axis, each point needs to be
 	 * examined, lookup is slower the larger the dataset. <p>
 	 *
 	 */

--- a/src/main/java/org/opensha/commons/data/function/XY_DataSet.java
+++ b/src/main/java/org/opensha/commons/data/function/XY_DataSet.java
@@ -9,6 +9,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleUnaryOperator;
 
 import org.dom4j.Element;
 import org.opensha.commons.data.Named;
@@ -120,6 +122,27 @@ public interface XY_DataSet extends PlotElement, Named, XMLSaveable, Serializabl
 	/** Replaces a DataPoint y-value at the specifed index. */
 	public void set(int index, double Y) throws IndexOutOfBoundsException;
 
+	/**
+	 * Maps a user-defined function F to each point, setting y = F(x).
+	 *
+	 * @param mappedFn(x) a function that takes an x value and returns a new y value.
+	 */
+	public default void setYofX(DoubleUnaryOperator mappedFn){
+		for(int i=0; i<this.size();i++) {
+			this.set(i, mappedFn.applyAsDouble(getX(i)));
+		}
+	}
+
+	/**
+	 * Maps a user-defined function F to each point, setting y = F(x, y).
+	 *
+	 * @param mappedFn(x, y) a function that takes an ax and a y value and returns a new y value.
+	 */
+	public default void setYofX(DoubleBinaryOperator mappedFn){
+		for(int i=0; i<this.size();i++) {
+			this.set(i, mappedFn.applyAsDouble(getX(i), getY(i)));
+		}
+	}
 
 
 	/* **********/

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDUncertaintyWeightedInversionConstraint.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/MFDUncertaintyWeightedInversionConstraint.java
@@ -1,0 +1,104 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl;
+
+import java.util.HashSet;
+import java.util.List;
+
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import com.google.common.base.Preconditions;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import scratch.UCERF3.utils.MFD_InversionConstraint;
+import scratch.UCERF3.utils.MFD_WeightedInversionConstraint;
+
+/**
+ * Constrain the solution to match the given MFD Weighted constraints. 
+ * 
+ * @author chrisbc
+ *
+ */
+public class MFDUncertaintyWeightedInversionConstraint extends InversionConstraint {
+	
+	public static final String NAME = "MFD UncertaintyWeighted";
+	public static final String SHORT_NAME = "MFDUncertaintyWeighted";
+	
+	private FaultSystemRupSet rupSet;
+	private double weight;
+	private List<MFD_WeightedInversionConstraint> mfdWeightedConstraints;
+	private HashSet<Integer> excludeRupIndexes;
+
+	public MFDUncertaintyWeightedInversionConstraint(FaultSystemRupSet rupSet, double weight,
+			List<MFD_WeightedInversionConstraint> mfdWeightedConstraints) {
+		this.rupSet = rupSet;
+		this.weight = weight;
+		this.mfdWeightedConstraints = mfdWeightedConstraints;
+	}
+
+	@Override
+	public String getShortName() {
+		return SHORT_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public int getNumRows() {
+		return MFDEqualityInversionConstraint.getNumRows(mfdWeightedConstraints, rupSet);
+	}
+
+	@Override
+	public boolean isInequality() {
+		return false;
+	}
+
+	@Override
+	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		long numNonZeroElements = 0;
+		// Loop over all MFD constraints in different regions
+		int numRuptures = rupSet.getNumRuptures();
+		for (int i=0; i < mfdWeightedConstraints.size(); i++) {
+			double[] fractRupsInside = rupSet.getFractRupsInsideRegion(mfdWeightedConstraints.get(i).getRegion(), false);
+			IncrementalMagFreqDist targetMagFreqDist = mfdWeightedConstraints.get(i).getMagFreqDist();
+			EvenlyDiscretizedFunc targetUncertaintyWeight = mfdWeightedConstraints.get(i).getWeights();
+			
+			int minMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMinMag());
+			int maxMagIndex = targetMagFreqDist.getClosestXIndex(rupSet.getMaxMag());
+			for(int rup=0; rup<numRuptures; rup++) {
+				double mag = rupSet.getMagForRup(rup);
+				double fractRupInside = fractRupsInside[rup];
+				if (fractRupInside > 0 && mag>targetMagFreqDist.getMinX()-targetMagFreqDist.getDelta()/2.0 && mag<targetMagFreqDist.getMaxX()+targetMagFreqDist.getDelta()/2.0) {
+					if (excludeRupIndexes != null && excludeRupIndexes.contains(rup))
+						continue;
+					int magIndex = targetMagFreqDist.getClosestXIndex(mag);
+					Preconditions.checkState(magIndex >= minMagIndex && magIndex <= maxMagIndex);
+					int rowIndex = startRow + magIndex - minMagIndex;
+					if (targetMagFreqDist.getClosestYtoX(mag) == 0) {
+						setA(A, rowIndex, rup, 0d);
+					} else {
+						// apply uncertainty adjusted weight to the A matrix
+						setA(A, rowIndex, rup, weight * targetUncertaintyWeight.getClosestYtoX(mag) * fractRupInside / targetMagFreqDist.getClosestYtoX(mag));
+						numNonZeroElements++;
+					}
+				}
+			}
+			for (int magIndex=minMagIndex; magIndex<=maxMagIndex; magIndex++) {
+				int rowIndex = startRow + magIndex - minMagIndex;
+				if (targetMagFreqDist.getY(magIndex)==0)
+					d[rowIndex]=0;
+				else
+					// apply uncertainty adjusted weight to the d matrix	
+					d[rowIndex] = weight * targetUncertaintyWeight.getY(magIndex); 
+			}
+			// move startRow to point after this constraint
+			startRow += (maxMagIndex - minMagIndex) + 1;
+		}
+		return numNonZeroElements;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
@@ -60,7 +60,7 @@ public class SolMFDPlot extends AbstractSolutionPlot {
 			totalPlot.addComp(targetMFDs.getTotalOnFaultSupraSeisMFD(), SUPRA_SEIS_TARGET_COLOR, "Target Supra-Seis");
 			plots.add(totalPlot);
 			
-			List<MFD_InversionConstraint> constraints = targetMFDs.getMFD_Constraints();
+			List<? extends MFD_InversionConstraint> constraints = targetMFDs.getMFD_Constraints();
 			for (MFD_InversionConstraint constraint : constraints) {
 				Region region = constraint.getRegion();
 				String name;

--- a/src/main/java/scratch/UCERF3/inversion/InversionTargetMFDs.java
+++ b/src/main/java/scratch/UCERF3/inversion/InversionTargetMFDs.java
@@ -75,7 +75,7 @@ public abstract class InversionTargetMFDs implements ArchivableModule, SubModule
 	 * 
 	 * @return MFD constraints
 	 */
-	public abstract List<MFD_InversionConstraint> getMFD_Constraints();
+	public abstract List<? extends MFD_InversionConstraint> getMFD_Constraints();
 	
 	/**
 	 * This returns target sub-seismogenic MFDs for each fault section, and it's contents are implementation-dependent
@@ -145,7 +145,7 @@ public abstract class InversionTargetMFDs implements ArchivableModule, SubModule
 		private IncrementalMagFreqDist onFaultSupraSeisMFD;
 		private IncrementalMagFreqDist onFaultSubSeisMFD;
 		private IncrementalMagFreqDist trulyOffFaultMFD;
-		private ImmutableList<MFD_InversionConstraint> mfdConstraints;
+		private ImmutableList<? extends MFD_InversionConstraint> mfdConstraints;
 		private SubSeismoOnFaultMFDs subSeismoOnFaultMFDs;
 		
 		private Precomputed() {
@@ -160,7 +160,7 @@ public abstract class InversionTargetMFDs implements ArchivableModule, SubModule
 
 		public Precomputed(FaultSystemRupSet rupSet, IncrementalMagFreqDist totalRegionalMFD,
 				IncrementalMagFreqDist onFaultSupraSeisMFD, IncrementalMagFreqDist onFaultSubSeisMFD,
-				IncrementalMagFreqDist trulyOffFaultMFD, List<MFD_InversionConstraint> mfdConstraints,
+				IncrementalMagFreqDist trulyOffFaultMFD, List<? extends MFD_InversionConstraint> mfdConstraints,
 				SubSeismoOnFaultMFDs subSeismoOnFaultMFDs) {
 			super(rupSet);
 			this.totalRegionalMFD = totalRegionalMFD;
@@ -303,7 +303,7 @@ public abstract class InversionTargetMFDs implements ArchivableModule, SubModule
 		}
 
 		@Override
-		public final List<MFD_InversionConstraint> getMFD_Constraints() {
+		public final List<? extends MFD_InversionConstraint> getMFD_Constraints() {
 			return mfdConstraints;
 		}
 		

--- a/src/main/java/scratch/UCERF3/inversion/UCERF3InversionConfiguration.java
+++ b/src/main/java/scratch/UCERF3/inversion/UCERF3InversionConfiguration.java
@@ -260,7 +260,7 @@ public class UCERF3InversionConfiguration implements XMLSaveable {
 		double parkfieldConstraintWt = 1000;
 		
 		// get MFD constraints
-		List<MFD_InversionConstraint> mfdConstraints = targetMFDs.getMFD_Constraints();
+		List<MFD_InversionConstraint> mfdConstraints = (List<MFD_InversionConstraint>) targetMFDs.getMFD_Constraints();
 		
 		double MFDTransitionMag = 7.85; // magnitude to switch from MFD equality to MFD inequality
 		
@@ -330,7 +330,8 @@ public class UCERF3InversionConfiguration implements XMLSaveable {
 				initialRupModel = getSmoothStartingSolution(rupSet, targetOnFaultMFD);
 				minimumRuptureRateFraction = 0.01;
 				minimumRuptureRateBasis = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true);
-				if (mfdInequalityConstraintWt>0.0 || mfdEqualityConstraintWt>0.0) initialRupModel = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true); 
+                if (mfdInequalityConstraintWt > 0.0 || mfdEqualityConstraintWt > 0.0)
+                    initialRupModel = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true);
 				initialRupModel = adjustParkfield(rupSet, initialRupModel);
 				initialRupModel = removeRupsBelowMinMag(rupSet, initialRupModel);
 			} else
@@ -437,7 +438,8 @@ public class UCERF3InversionConfiguration implements XMLSaveable {
 			initialRupModel = getSmoothStartingSolution(rupSet,targetOnFaultMFD);
 			minimumRuptureRateFraction = 0.01;
 			minimumRuptureRateBasis = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true);
-			if (mfdInequalityConstraintWt>0.0 || mfdEqualityConstraintWt>0.0) initialRupModel = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true); 
+            if (mfdInequalityConstraintWt > 0.0 || mfdEqualityConstraintWt > 0.0)
+                initialRupModel = adjustStartingModel(initialRupModel, mfdConstraints, rupSet, true);
 			initialRupModel = adjustParkfield(rupSet, initialRupModel);
 			initialRupModel = removeRupsBelowMinMag(rupSet, initialRupModel);
 		}

--- a/src/main/java/scratch/UCERF3/inversion/UCERF3InversionInputGenerator.java
+++ b/src/main/java/scratch/UCERF3/inversion/UCERF3InversionInputGenerator.java
@@ -1628,8 +1628,8 @@ public class UCERF3InversionInputGenerator extends InversionInputGenerator {
 		UCERF3InversionInputGenerator modGen = getTestConfig(rupSet, newBranch.getValue(FaultModels.class), newTargetMFDs);
 		
 		System.out.println("Validating target MFD constraints");
-		List<MFD_InversionConstraint> origConstrs = origTargetMFDs.getMFD_Constraints();
-		List<MFD_InversionConstraint> newConstrs = newTargetMFDs.getMFD_Constraints();
+		List<? extends MFD_InversionConstraint> origConstrs = origTargetMFDs.getMFD_Constraints();
+		List<? extends MFD_InversionConstraint> newConstrs = newTargetMFDs.getMFD_Constraints();
 		Preconditions.checkState(origConstrs.size() == newConstrs.size(), "MFD constraint size mismatch");
 		for (int i=0; i<origConstrs.size(); i++) {
 			MFD_InversionConstraint origConstr = origConstrs.get(i);
@@ -1679,8 +1679,8 @@ public class UCERF3InversionInputGenerator extends InversionInputGenerator {
 		UCERF3InversionInputGenerator modGen = getTestConfig(rupSet, newBranch.getValue(FaultModels.class), newTargetMFDs);
 		
 		System.out.println("Validating target MFD constraints");
-		List<MFD_InversionConstraint> origConstrs = origTargetMFDs.getMFD_Constraints();
-		List<MFD_InversionConstraint> newConstrs = newTargetMFDs.getMFD_Constraints();
+		List<? extends MFD_InversionConstraint> origConstrs = origTargetMFDs.getMFD_Constraints();
+		List<? extends MFD_InversionConstraint> newConstrs = newTargetMFDs.getMFD_Constraints();
 		Preconditions.checkState(origConstrs.size() == newConstrs.size(), "MFD constraint size mismatch");
 		for (int i=0; i<origConstrs.size(); i++) {
 			MFD_InversionConstraint origConstr = origConstrs.get(i);

--- a/src/main/java/scratch/UCERF3/utils/MFD_InversionConstraint.java
+++ b/src/main/java/scratch/UCERF3/utils/MFD_InversionConstraint.java
@@ -116,6 +116,7 @@ public class MFD_InversionConstraint implements XMLSaveable {
 
 		private TypeAdapter<IncrementalMagFreqDist> mfdAdapter = new IncrementalMagFreqDist.Adapter();
 		private TypeAdapter<Region> regionAdapter = new Region.Adapter();
+		private TypeAdapter<EvenlyDiscretizedFunc> weightsAdapter = new EvenlyDiscretizedFunc.Adapter();
 
 		@Override
 		public void write(JsonWriter out, MFD_InversionConstraint value) throws IOException {
@@ -132,6 +133,11 @@ public class MFD_InversionConstraint implements XMLSaveable {
 				Region region = new Region(value.region);
 				regionAdapter.write(out, region);
 			}
+
+			if(value instanceof MFD_WeightedInversionConstraint){
+				out.name("weights");
+				weightsAdapter.write(out, ((MFD_WeightedInversionConstraint) value).weights);
+			}
 			
 			out.endObject();
 		}
@@ -142,24 +148,32 @@ public class MFD_InversionConstraint implements XMLSaveable {
 			
 			IncrementalMagFreqDist mfd = null;
 			Region region = null;
+			EvenlyDiscretizedFunc weights = null;
 			while (in.hasNext()) {
 				switch (in.nextName()) {
-				case "mfd":
-					mfd = mfdAdapter.read(in);
-					break;
-				case "region":
-					region = regionAdapter.read(in);
-					break;
-
-				default:
-					in.skipValue();
-					break;
+					case "mfd":
+						mfd = mfdAdapter.read(in);
+						break;
+					case "region":
+						region = regionAdapter.read(in);
+						break;
+					case "weights":
+						weights = weightsAdapter.read(in);
+						break;
+					default:
+						in.skipValue();
+						break;
 				}
 			}
 			Preconditions.checkNotNull(mfd, "MFD not specified");
 			
 			in.endObject();
-			return new MFD_InversionConstraint(mfd, region);
+
+			if (weights == null) {
+				return new MFD_InversionConstraint(mfd, region);
+			} else {
+				return new MFD_WeightedInversionConstraint(mfd, region, weights);
+			}
 		}
 		
 	}

--- a/src/main/java/scratch/UCERF3/utils/MFD_WeightedInversionConstraint.java
+++ b/src/main/java/scratch/UCERF3/utils/MFD_WeightedInversionConstraint.java
@@ -1,0 +1,55 @@
+package scratch.UCERF3.utils;
+import org.dom4j.Element;
+import java.io.IOException;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.geo.Region;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+import com.google.common.base.Preconditions;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+/**
+ * This class extends MFD_InversionConstraint (having an MFD and a Region) with an EvenlyDiscretized function 
+ * containing weights.
+ * 
+ * @author chrisbc
+ *
+ */
+@JsonAdapter(MFD_InversionConstraint.Adapter.class)
+public class MFD_WeightedInversionConstraint extends MFD_InversionConstraint {
+	
+	public static final String XML_METADATA_NAME = "MFD_WeightedInversionConstraint";
+	
+	EvenlyDiscretizedFunc weights;
+	
+	public MFD_WeightedInversionConstraint(IncrementalMagFreqDist mfd, Region region, EvenlyDiscretizedFunc weights) {
+		super(mfd, region);
+		this.weights=weights;
+		validateDiscretization();
+	}
+	
+	private void validateDiscretization() {
+		Preconditions.checkState(mfd.getMinX() == weights.getMinX(), "minX of mfd and weight objects must be equal", mfd.getMinX(), weights.getMinX());
+		Preconditions.checkState(mfd.getMaxX() == weights.getMaxX(), "maxX of mfd and weight objects must be equal", mfd.getMaxX(), weights.getMaxX());
+		Preconditions.checkState(mfd.size() == weights.size(), "size of mfd and weight objects must be equal", mfd.size(), weights.size());
+	}
+	
+	public void setWeights(EvenlyDiscretizedFunc weights) {
+		this.weights=weights;
+		validateDiscretization();
+	}
+	
+	
+	public EvenlyDiscretizedFunc getWeights() {
+		return weights;
+	}
+	
+	@Deprecated
+	@Override
+	public Element toXMLMetadata(Element root) {
+		throw new UnsupportedOperationException("No more XML, sorry");
+	}
+
+}

--- a/src/test/java/org/opensha/commons/data/function/EvenlyDiscretizedFuncTest.java
+++ b/src/test/java/org/opensha/commons/data/function/EvenlyDiscretizedFuncTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -115,6 +116,20 @@ public class EvenlyDiscretizedFuncTest extends AbstractDiscretizedFuncTest {
 		double expect = 0;
 		assertTrue(expect == f.getClosestXIndex(5.0));
 	}
-	
+
+	@Test
+	public void setYofXTest() {
+		EvenlyDiscretizedFunc func = new EvenlyDiscretizedFunc(0.0, 9.0, 10);
+		for (int i = 0; i < func.size(); i++) {
+			func.set(i, i);
+		}
+		assertEquals(List.of(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), func.yValues());
+
+		func.setYofX(x -> 2 * x);
+		assertEquals(List.of(0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0), func.yValues());
+
+		func.setYofX((x, y) -> y - x);
+		assertEquals(List.of(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0), func.yValues());
+	}
 
 }

--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
@@ -8,9 +8,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.Region;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
 import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
@@ -30,10 +32,12 @@ import scratch.UCERF3.inversion.UCERF3InversionConfiguration;
 import scratch.UCERF3.inversion.UCERF3InversionInputGenerator;
 import scratch.UCERF3.inversion.UCERF3InversionConfiguration.SlipRateConstraintWeightingType;
 import scratch.UCERF3.utils.MFD_InversionConstraint;
+import scratch.UCERF3.utils.MFD_WeightedInversionConstraint;
 import scratch.UCERF3.utils.SectionMFD_constraint;
 import scratch.UCERF3.utils.aveSlip.AveSlipConstraint;
 import scratch.UCERF3.utils.paleoRateConstraints.PaleoRateConstraint;
 import scratch.UCERF3.utils.paleoRateConstraints.UCERF3_PaleoProbabilityModel;
+
 
 public class InversionConstraintImplTests {
 	
@@ -47,7 +51,7 @@ public class InversionConstraintImplTests {
 	private static IncrementalMagFreqDist testMFD;
 	
 	private static HashSet<Integer> allParents;
-
+	
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		rupSet = FSS_ERF_ParamTest.buildSmallTestRupSet();
@@ -67,6 +71,36 @@ public class InversionConstraintImplTests {
 			allParents.add(sect.getParentSectionId());
 	}
 
+	@Test
+	public void test_MFDUncertaintyWeightedInversionConstraint() {
+				
+		Location a = new Location(34,-120);
+		Location b = new Location(45,-100);
+		Region region = new Region(a,b);
+		
+		int numBins = 10;
+		GutenbergRichterMagFreqDist mfd = new GutenbergRichterMagFreqDist(4.5d, 7.5d, numBins);
+		mfd.setAllButTotMoRate(4.5, 7.5, 10, 1.0);
+
+		EvenlyDiscretizedFunc weight = new EvenlyDiscretizedFunc(4.5d, 7.5d, numBins);
+
+		//CBC: using a lambda function, and new map method setXofY on EvenlyDiscretizedFunc
+		double weightPower = 0.5;
+		double firstWeightPower = Math.pow(mfd.getClosestYtoX(4.5d), weightPower);
+		weight.setYofX(mag -> {
+			double rate = mfd.getClosestYtoX(mag);
+			return Math.pow(rate, weightPower)/firstWeightPower;
+		});
+        
+		List<MFD_WeightedInversionConstraint> mfdConstraints = new ArrayList<>();
+		mfdConstraints.add(new MFD_WeightedInversionConstraint(mfd, region, weight));
+		
+		MFDUncertaintyWeightedInversionConstraint constr = new MFDUncertaintyWeightedInversionConstraint(rupSet, 1000, mfdConstraints);
+	
+		testConstraint(constr);
+	}
+	
+	
 	@Test 
 	public void testCreate_SlipRateUncertaintyAdjustedConstraint() {
 		

--- a/src/test/java/scratch/UCERF3/utils/MFD_InversionConstraintAdapterTest.java
+++ b/src/test/java/scratch/UCERF3/utils/MFD_InversionConstraintAdapterTest.java
@@ -1,0 +1,73 @@
+package scratch.UCERF3.utils;
+
+import static org.junit.Assert.*;
+
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.junit.Test;
+import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.geo.json.Geometry;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+public class MFD_InversionConstraintAdapterTest {
+
+    static MFD_InversionConstraint.Adapter adapter = new MFD_InversionConstraint.Adapter();
+
+    @Test
+    public void readWriteTest() throws IOException {
+        IncrementalMagFreqDist mfd = new IncrementalMagFreqDist(0, 10, 0.5);
+        Region region = new Region(new Location(5, 5), 10);
+        MFD_InversionConstraint expected = new MFD_InversionConstraint(mfd, region);
+
+        MFD_InversionConstraint actual = writeAndReadJSON(expected);
+
+        assertEquals(expected.getClass(), actual.getClass());
+        assertFuncEquals(mfd, actual.getMagFreqDist());
+        assertReqionEquals(region, actual.getRegion());
+    }
+
+    @Test
+    public void weightedReadWriteTest() throws IOException {
+        IncrementalMagFreqDist mfd = new IncrementalMagFreqDist(0, 10, 0.5);
+        Region region = new Region(new Location(5, 5), 10);
+        EvenlyDiscretizedFunc weights = new EvenlyDiscretizedFunc(1, 8, 0.4);
+        MFD_WeightedInversionConstraint expected = new MFD_WeightedInversionConstraint(mfd, region, weights);
+
+        MFD_WeightedInversionConstraint actual = (MFD_WeightedInversionConstraint) writeAndReadJSON(expected);
+
+        assertEquals(expected.getClass(), actual.getClass());
+        assertFuncEquals(mfd, actual.getMagFreqDist());
+        assertReqionEquals(region, actual.getRegion());
+        assertFuncEquals(weights, actual.getWeights());
+    }
+
+    /**
+     * Asserts that two Region instances are equal after writing to and reading from JSON.
+     *
+     * @param expected the Region that was written to JSON
+     * @param actual   the Region that was read from JSON
+     */
+    public void assertReqionEquals(Region expected, Region actual) {
+        assertEquals(
+                ((Geometry.Polygon) expected.toFeature().geometry).polygon,
+                ((Geometry.Polygon) actual.toFeature().geometry).polygon);
+    }
+
+    public void assertFuncEquals(EvenlyDiscretizedFunc expected, EvenlyDiscretizedFunc actual) {
+        assertEquals(expected.xValues(), actual.xValues());
+        assertEquals(expected.yValues(), actual.yValues());
+    }
+
+    public MFD_InversionConstraint writeAndReadJSON(MFD_InversionConstraint constraint) throws IOException {
+        StringWriter writer = new StringWriter();
+        adapter.write(new JsonWriter(writer), constraint);
+        return adapter.read(new JsonReader(new StringReader(writer.toString())));
+    }
+
+}


### PR DESCRIPTION
This PR create two new classes to support the concept of MFD constraints having weights by bin:
 - **MFD_WeightedInversionConstraint** which extends MFD_InversionConstraint, adding the `EvenlyDiscretizedFunc weights;` field
 - **MFDUncertaintyWeightedInversionConstraint** which used the above to assign uncertainty weights

It also adds a new method  to EvenlyDiscretizedFunc -  **setYofX** which expects a user defined function (e.g. a lambda function) …  @kevinmilner I did this because so much code using this class does this mapping outside the class, straight after creating an instance. 