### PR TITLE
Added filled polygons to plots 

### DIFF
--- a/src/main/java/org/opensha/commons/gui/plot/PlotLineType.java
+++ b/src/main/java/org/opensha/commons/gui/plot/PlotLineType.java
@@ -5,11 +5,7 @@ import java.awt.Shape;
 import java.awt.Stroke;
 import java.util.NoSuchElementException;
 
-import org.jfree.chart.renderer.xy.StackedXYBarRenderer;
-import org.jfree.chart.renderer.xy.StandardXYBarPainter;
-import org.jfree.chart.renderer.xy.XYBarRenderer;
-import org.jfree.chart.renderer.xy.XYItemRenderer;
-import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
+import org.jfree.chart.renderer.xy.*;
 
 import com.google.common.base.Preconditions;
 
@@ -35,7 +31,11 @@ public enum PlotLineType {
 	/**
 	 * Shaded uncertainty bounds with default 50% transparency, can only be used with UncertainArbDiscDataset
 	 */
-	SHADED_UNCERTAIN_TRANS("Shaded Transparent Uncertain Dataset");
+	SHADED_UNCERTAIN_TRANS("Shaded Transparent Uncertain Dataset"),
+	/**
+	 * Polygon with solid fill, edges are not drawn. Path is closed automatically.
+	 */
+	POLYGON_SOLID("Polygon with solid fill");
 	
 	private String desc;
 	
@@ -140,6 +140,8 @@ public enum PlotLineType {
 				renderer = new XYShadedUncertainLineRenderer();
 			} else if (plt == SHADED_UNCERTAIN_TRANS) {
 				renderer = new XYShadedUncertainLineRenderer(0.5);
+			} else if (plt == POLYGON_SOLID){
+				renderer = new XYAreaRenderer(XYAreaRenderer.AREA);
 			} else {
 				renderer = lineShpRend;
 				Stroke stroke = plt.buildStroke(lineWidth);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/SolidFillPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/SolidFillPlot.java
@@ -1,0 +1,7 @@
+package org.opensha.sha.earthquake.faultSysSolution.reports;
+
+public interface SolidFillPlot {
+
+    public void setFillSurfaces(boolean fillSurfaces);
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/ParticipationRatePlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/ParticipationRatePlot.java
@@ -17,9 +17,17 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractSolutionPlot;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
+import org.opensha.sha.earthquake.faultSysSolution.reports.SolidFillPlot;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupSetMapMaker;
 
-public class ParticipationRatePlot extends AbstractSolutionPlot {
+public class ParticipationRatePlot extends AbstractSolutionPlot implements SolidFillPlot {
+
+	boolean fillSurfaces = false;
+
+	@Override
+	public void setFillSurfaces(boolean fillSurfaces){
+		this.fillSurfaces = fillSurfaces;
+	}
 
 	@Override
 	public String getName() {
@@ -70,6 +78,7 @@ public class ParticipationRatePlot extends AbstractSolutionPlot {
 		
 		RupSetMapMaker mapMaker = new RupSetMapMaker(sol.getRupSet(), meta.region);
 		mapMaker.setWriteGeoJSON(true);
+		mapMaker.setFillSurfaces(fillSurfaces);
 		
 		TableBuilder table = MarkdownUtils.tableBuilder();
 		CPT ratioCPT = null;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SlipRatePlots.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SlipRatePlots.java
@@ -32,9 +32,17 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
 import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractRupSetPlot;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
+import org.opensha.sha.earthquake.faultSysSolution.reports.SolidFillPlot;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupSetMapMaker;
 
-public class SlipRatePlots extends AbstractRupSetPlot {
+public class SlipRatePlots extends AbstractRupSetPlot implements SolidFillPlot {
+
+	boolean fillSurfaces = false;
+
+	@Override
+	public void setFillSurfaces(boolean fillSurfaces){
+		this.fillSurfaces = fillSurfaces;
+	}
 
 	@Override
 	public String getName() {
@@ -46,6 +54,7 @@ public class SlipRatePlots extends AbstractRupSetPlot {
 			String relPathToResources, String topLink) throws IOException {
 		RupSetMapMaker mapMaker = new RupSetMapMaker(rupSet, meta.region);
 		mapMaker.setWriteGeoJSON(true);
+		mapMaker.setFillSurfaces(fillSurfaces);
 		
 		List<String> lines = new ArrayList<>();
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetMapMaker.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetMapMaker.java
@@ -65,6 +65,7 @@ public class RupSetMapMaker {
 	private float scalarThickness = 3f;
 	private float jumpLineThickness = 3f;
 	private boolean legendVisible = true;
+	private boolean fillSurfaces = false;
 	
 	private boolean writePDFs = true;
 	private boolean writeGeoJSON = true;
@@ -197,6 +198,10 @@ public class RupSetMapMaker {
 	
 	public void setWriteGeoJSON(boolean writeGeoJSON) {
 		this.writeGeoJSON = writeGeoJSON;
+	}
+
+	public void setFillSurfaces(boolean fillSurfaces){
+		this.fillSurfaces = fillSurfaces;
 	}
 	
 	public void plotSectScalars(List<Double> scalars, CPT cpt, String label) {
@@ -393,6 +398,19 @@ public class RupSetMapMaker {
 				if (!plotSects.contains(sect) || (skipNaNs && Double.isNaN(val.getComparable())))
 					continue;
 				RuptureSurface surf = getSectSurface(sect);
+
+				if (fillSurfaces && sect.getAveDip() != 90d) {
+					XY_DataSet outline = new DefaultXY_DataSet();
+					LocationList perimeter = surf.getPerimeter();
+					for (Location loc : perimeter)
+						outline.set(loc.getLongitude(), loc.getLatitude());
+
+					PlotCurveCharacterstics fillChar = new PlotCurveCharacterstics(PlotLineType.POLYGON_SOLID, 0.5f, color);
+
+					funcs.add(0, outline);
+					chars.add(0, fillChar);
+				}
+
 				XY_DataSet trace = new DefaultXY_DataSet();
 				for (Location loc : surf.getEvenlyDiscritizedUpperEdge())
 					trace.set(loc.getLongitude(), loc.getLatitude());


### PR DESCRIPTION
Adds (optional) solid fill to surfaces in `RupSetMapMaker`, with `SlipRatePlots` making use of it.

This is to make subduction plots easier to read. I haven't touched the geojson code, I can make it match if you prefer.

I added a polygon option to `PlotLineType` but didn't change the name to something like `PlotFunType` because I didn't want to change too much.

Here's an example of how filled surface polygons can make outliers easier to spot for a subduction plot:

![image (3)](https://user-images.githubusercontent.com/3160916/132798841-f83932ac-5742-4e2c-9bb7-eb6b1fca1c2a.png)

![slip_rates_sol_ratio (2)](https://user-images.githubusercontent.com/3160916/132798855-2e743582-3424-47b5-84a4-e3259571efa0.png)
