### PR TITLE
Allowing LogicTreeBranches to have nodes with custom JSON serialization

### DIFF
--- a/src/main/java/org/opensha/commons/logicTree/JsonAdapterHelper.java
+++ b/src/main/java/org/opensha/commons/logicTree/JsonAdapterHelper.java
@@ -1,0 +1,111 @@
+package org.opensha.commons.logicTree;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+
+/**
+ * Helper class to serialize and deserialize instances of classes that have a TypeAdapter.
+ * Classes must be annotated with @JsonAdapter(TypeAdapter)
+ */
+@SuppressWarnings("unchecked")
+public class JsonAdapterHelper {
+
+    protected static Class getTypeAdapterClass(Object o) {
+        JsonAdapter annotation = o.getClass().getAnnotation(JsonAdapter.class);
+        if (annotation != null) {
+            Class c = annotation.value();
+            if (TypeAdapter.class.isAssignableFrom(c)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    protected static TypeAdapter getTypeAdapter(Object o) {
+        Class c = getTypeAdapterClass(o);
+        if (c != null) {
+            try {
+                return (TypeAdapter) c.getDeclaredConstructor().newInstance();
+            } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException | InstantiationException e) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public static boolean hasTypeAdapter(Object o) {
+        return getTypeAdapter(o) != null;
+    }
+
+    /**
+     * Writes value to out using the TypeAdapter associated with value's class.
+     *
+     * @param out
+     * @param value
+     * @throws IOException
+     */
+    public static void writeAdapterValue(JsonWriter out, Object value) throws IOException {
+        TypeAdapter adapter = getTypeAdapter(value);
+        writeAdapterValue(out, adapter, value);
+    }
+
+    /**
+     * Writes value to out using the specified adapter.
+     *
+     * @param out
+     * @param value
+     * @throws IOException
+     */
+    public static void writeAdapterValue(JsonWriter writer, TypeAdapter adapter, Object value) throws IOException {
+        writer.beginObject();
+        writer.name("adapterClass");
+        writer.value(adapter.getClass().getName());
+        writer.name("adapterData");
+        adapter.write(writer, value);
+        writer.endObject();
+    }
+
+    /**
+     * Reads in an object that was written with writeAdapterValue(). The TypeAdapter class specified
+     * in the JSON must be available to the ClassLoader.
+     *
+     * @param in
+     * @return
+     * @throws IOException
+     */
+    public static Object readAdapterValue(JsonReader in) throws IOException {
+        in.beginObject();
+        Preconditions.checkArgument("adapterClass".equals(in.nextName()));
+        String adapterName = in.nextString();
+        TypeAdapter adapter = null;
+        try {
+            Class<? extends TypeAdapter> rawClass = (Class<? extends TypeAdapter>) Class.forName(adapterName);
+            adapter = rawClass.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            System.err.println("WARNING: couldn't locate logic tree branch node adapter class '" + adapterName + "', "
+                    + "returning null instead");
+        } catch (ClassCastException e) {
+            System.err.println("WARNING: logic tree branch node adapter class '" + adapterName + "' is of the wrong type, "
+                    + "returning null instead");
+        } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+        Preconditions.checkArgument("adapterData".equals(in.nextName()));
+        Object result = null;
+        if (adapter != null) {
+            result = adapter.read(in);
+        } else {
+            in.skipValue();
+        }
+        in.endObject();
+        return result;
+    }
+}

--- a/src/main/java/org/opensha/commons/logicTree/LogicTreeBranch.java
+++ b/src/main/java/org/opensha/commons/logicTree/LogicTreeBranch.java
@@ -426,7 +426,7 @@ Comparable<LogicTreeBranch<E>>, JSON_BackedModule {
 		
 		return builder.create();
 	}
-	
+
 	public static class Adapter extends TypeAdapter<LogicTreeBranch<?>> {
 
 		@Override
@@ -516,7 +516,7 @@ Comparable<LogicTreeBranch<E>>, JSON_BackedModule {
 		}
 		
 	}
-	
+
 	private static class NodeTypeAdapter extends TypeAdapter<LogicTreeNode> {
 		
 		private LogicTreeBranch<?> branch;
@@ -542,7 +542,10 @@ Comparable<LogicTreeBranch<E>>, JSON_BackedModule {
 				Preconditions.checkState(enumClass.isEnum(), "Enum enclosing class not an enum?");
 				out.name("enumClass").value(enumClass.getName());
 				out.name("enumName").value(((Enum<?>)value).name());
-			} else if (!(value instanceof FileBackedNode)) {
+			} else if (JsonAdapterHelper.hasTypeAdapter(value)) {
+				out.name("adapterValue");
+				JsonAdapterHelper.writeAdapterValue(out, value);
+			}else if (!(value instanceof FileBackedNode)) {
 				out.name("class").value(value.getClass().getName());
 			}
 			
@@ -559,6 +562,7 @@ Comparable<LogicTreeBranch<E>>, JSON_BackedModule {
 			Class<? extends LogicTreeNode> clazz = null;
 			Class<? extends Enum<? extends LogicTreeNode>> enumClass = null;
 			String enumName = null;
+			LogicTreeNode adapterNode = null;
 			
 			in.beginObject();
 			while (in.hasNext()) {
@@ -604,13 +608,19 @@ Comparable<LogicTreeBranch<E>>, JSON_BackedModule {
 				case "enumName":
 					enumName = in.nextString();
 					break;
-
+				case "adapterValue":
+					adapterNode = (LogicTreeNode) JsonAdapterHelper.readAdapterValue(in);
+					break;
 				default:
 					break;
 				}
 			}
 			
 			in.endObject();
+
+			if(adapterNode != null){
+				return adapterNode;
+			}
 			
 			if (enumClass != null && enumName != null) {
 				// load it as an enum

--- a/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
+++ b/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
@@ -122,7 +122,54 @@ public abstract class LogicTreeLevel<E extends LogicTreeNode> implements ShortNa
 		}
 		
 	}
-	
+
+	public static abstract class AdapterBackedLevel extends LogicTreeLevel<LogicTreeNode>{
+		String name;
+		String shortName;
+		Class<? extends LogicTreeNode> nodeType;
+
+		public AdapterBackedLevel(String name, String shortName, Class<? extends LogicTreeNode>nodeType){
+		    this.name = name;
+			this.shortName = shortName;
+			this.nodeType = nodeType;
+		}
+
+		@Override
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String getShortName() {
+			return shortName;
+		}
+
+		@Override
+		public Class<? extends LogicTreeNode> getType() {
+			return nodeType;
+		}
+
+		@Override
+		public List<? extends LogicTreeNode> getNodes() {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isMember(LogicTreeNode node) {
+			return node.getClass() == getType();
+		}
+
+		@Override
+		public boolean equals(Object o){
+			if(o instanceof LogicTreeLevel.AdapterBackedLevel){
+				AdapterBackedLevel other = (AdapterBackedLevel) o;
+				return other.getName() == getName() && other.getType() == getType();
+			}else{
+				return false;
+			}
+		}
+	}
+
 	public static <E extends Enum<E> & LogicTreeNode> LogicTreeLevel<E> forEnum(
 			Class<E> type, String name, String shortName) {
 		return new EnumBackedLevel<>(name, shortName, type);
@@ -259,7 +306,7 @@ public abstract class LogicTreeLevel<E extends LogicTreeNode> implements ShortNa
 				case "enumClass":
 					enumClassName = in.nextString();
 					break;
-				case "className":
+				case "class":
 					className = in.nextString();
 					break;
 

--- a/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
+++ b/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
@@ -1,0 +1,211 @@
+package org.opensha.commons.logicTree;
+
+import static org.junit.Assert.*;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import org.junit.Test;
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
+import scratch.UCERF3.enumTreeBranches.InversionModels;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestLogicTreeBranch {
+
+    @Test
+    public void testFileBackedJSON() throws IOException {
+        List<LogicTreeLevel<? extends LogicTreeNode>> levels = new ArrayList<>();
+        List<LogicTreeNode> values = new ArrayList<>();
+
+        LogicTreeNode.FileBackedNode node = new LogicTreeNode.FileBackedNode("Node 1", "Node1", 1d, "n1");
+        levels.add(new LogicTreeLevel.FileBackedLevel("Level 1", "Level1", node));
+        values.add(node);
+
+        node = new LogicTreeNode.FileBackedNode("Node 2", "Node2", 1d, "n2");
+        levels.add(new LogicTreeLevel.FileBackedLevel("Level 2", "Level2", node));
+        values.add(node);
+
+        node = null;
+        levels.add(new LogicTreeLevel.FileBackedLevel("Level 3", "Level3", node));
+        values.add(node);
+
+        LogicTreeBranch<?> branch = new LogicTreeBranch<>(levels, values);
+        String json = branch.getJSON();
+//        System.out.println(json);
+
+        LogicTreeBranch<?> branch2 = new LogicTreeBranch<>();
+        branch2.initFromJSON(json);
+        String json2 = branch2.getJSON();
+
+        assertEquals(branch, branch2);
+        assertEquals(0, branch.getNumAwayFrom(branch2));
+        assertEquals(json, json2);
+    }
+
+    @Test
+    public void testEnumBackedJSON() throws IOException {
+        List<LogicTreeLevel<? extends LogicTreeNode>> levels = new ArrayList<>();
+        List<LogicTreeNode> values = new ArrayList<>();
+
+        levels.add(LogicTreeLevel.forEnum(FaultModels.class, "Fault Model", "FM"));
+        values.add(FaultModels.FM3_1);
+        levels.add(LogicTreeLevel.forEnum(DeformationModels.class, "Deformation Model", "DM"));
+        values.add(DeformationModels.GEOLOGIC);
+        levels.add(LogicTreeLevel.forEnum(InversionModels.class, "Inversion Model", "IM"));
+        values.add(null);
+
+        LogicTreeBranch<?> branch = new LogicTreeBranch<>(levels, values);
+        String json = branch.getJSON();
+//        System.out.println(json);
+
+        LogicTreeBranch<?> branch2 = new LogicTreeBranch<>();
+        branch2.initFromJSON(json);
+        String json2 = branch2.getJSON();
+
+        assertEquals(branch, branch2);
+        assertEquals(0, branch.getNumAwayFrom(branch2));
+        assertEquals(json, json2);
+    }
+
+    @JsonAdapter(TestAdapterBackedNode.Adapter.class)
+    public static class TestAdapterBackedNode implements LogicTreeNode {
+
+        protected int val1 = 0;
+        protected double val2 = 0;
+
+        public TestAdapterBackedNode(int val1, double val2){
+            this.val1 = val1;
+            this.val2 = val2;
+        }
+
+        @Override
+        public String getName() {
+            return "TestAdapterBackedNode";
+        }
+
+        @Override
+        public String getShortName() {
+            return "TestAdapterBackedNode";
+        }
+
+        @Override
+        public double getNodeWeight(LogicTreeBranch<?> fullBranch) {
+            return 0;
+        }
+
+        @Override
+        public String getFilePrefix() {
+            return null;
+        }
+
+        @Override
+        public boolean equals(Object o){
+            if( o instanceof TestAdapterBackedNode){
+                TestAdapterBackedNode other = (TestAdapterBackedNode) o;
+                return val1 == other.val1 && val2 == other.val2;
+            }else{
+                return false;
+            }
+        }
+
+        public static class Adapter extends TypeAdapter<LogicTreeNode> {
+
+            @Override
+            public void write(JsonWriter out, LogicTreeNode value) throws IOException {
+                TestAdapterBackedNode node = (TestAdapterBackedNode) value;
+                out.beginObject();
+                out.name("a");
+                out.value(node.val1);
+                out.name("b");
+                out.value(node.val2);
+                out.endObject();
+            }
+
+            @Override
+            public TestAdapterBackedNode read(JsonReader in) throws IOException {
+                int val1 = 0;
+                double val2 = 0;
+                in.beginObject();
+                while (in.hasNext()) {
+                    switch (in.nextName()) {
+                        case "a":
+                            val1 = in.nextInt();
+                            break;
+                        case "b":
+                            val2 = in.nextDouble();
+                            break;
+                    }
+                }
+                in.endObject();
+                TestAdapterBackedNode node = new TestAdapterBackedNode(val1, val2);
+                return node;
+            }
+        }
+
+        public static class TestAdapterBackedLevel extends LogicTreeLevel.AdapterBackedLevel {
+            public TestAdapterBackedLevel() {
+                super("test adapter backed", "test adapter backed", TestAdapterBackedNode.class);
+            }
+        }
+    }
+
+
+
+    @Test
+    public void testAdapterBackedJSON() throws IOException {
+        List<LogicTreeLevel<? extends LogicTreeNode>> levels = new ArrayList<>();
+        List<LogicTreeNode> values = new ArrayList<>();
+
+        levels.add(new TestAdapterBackedNode.TestAdapterBackedLevel());
+        values.add(new TestAdapterBackedNode(42, 33));
+
+        LogicTreeBranch<?> branch = new LogicTreeBranch<>(levels, values);
+        String json = branch.getJSON();
+        System.out.println(json);
+
+        LogicTreeBranch<?> branch2 = new LogicTreeBranch<>();
+        branch2.initFromJSON(json);
+        String json2 = branch2.getJSON();
+
+        assertEquals(branch, branch2);
+        assertEquals(0, branch.getNumAwayFrom(branch2));
+        assertEquals(json, json2);
+    }
+
+    @Test
+    public void testGracefulAdapterBackedFailure() throws IOException {
+        // JSON with unknown level class and node adapter class
+        String json = "[\n" +
+                "  {\n" +
+                "    \"level\": {\n" +
+                "      \"name\": \"test adapter backed\",\n" +
+                "      \"shortName\": \"test adapter backed\",\n" +
+                "      \"class\": \"UnknownLevel\"\n" +
+                "    },\n" +
+                "    \"value\": {\n" +
+                "      \"name\": \"TestAdapterBackedNode\",\n" +
+                "      \"shortName\": \"TestAdapterBackedNode\",\n" +
+                "      \"weight\": 0.0,\n" +
+                "      \"adapterValue\": {\n" +
+                "        \"adapterClass\": \"UnknownAdapter\",\n" +
+                "        \"adapterData\": {\n" +
+                "          \"a\": 42,\n" +
+                "          \"b\": 33.0\n" +
+                "        }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "]\n";
+
+        LogicTreeBranch<?> branch = new LogicTreeBranch<>();
+        branch.initFromJSON(json);
+
+        assertEquals( LogicTreeLevel.FileBackedLevel.class, branch.getLevel(0).getClass());
+        assertEquals("TestAdapterBackedNode", branch.getValue(0).getName());
+    }
+}


### PR DESCRIPTION
This PR lets nodes provide their own JSON TypeAdapter. This allows us to use complex nodes, such as scaling relationships with multiple config values.

Deserialization where the level and adapter class are unknown (e.g. SCEC VDO) is handled gracefully.
