### PR TITLE
fixes #62 getScaledNodeFractions() returns NaN

### DIFF
--- a/src/main/java/scratch/UCERF3/griddedSeismicity/FaultPolyMgr.java
+++ b/src/main/java/scratch/UCERF3/griddedSeismicity/FaultPolyMgr.java
@@ -298,8 +298,8 @@ public class FaultPolyMgr implements Iterable<Area>, PolygonFaultGridAssociation
 		for (Integer nodeIdx : nodeIdxs) {
 			Area nodeArea = region.areaForIndex(nodeIdx); // should be singular
 			nodeArea.intersect(ssArea);
-			if (nodeArea.isEmpty()) continue; // no overlap; eliminate
 			nodeArea = SectionPolygons.cleanBorder(nodeArea);
+			if (nodeArea.isEmpty()) continue; // no overlap; eliminate
 			double faultExtent = SectionPolygons.getExtent(nodeArea);
 			double ratio = faultExtent / nodeExtents.get(nodeIdx);
 			newNodeIdxs.add(nodeIdx);


### PR DESCRIPTION
fixes #62

In our edge case, `nodeArea.isEmpty()` returns `false` before the border is cleaned, and `true` after.