### PR TITLE
Solution logic tree refactor, updates for branch averaging

### DIFF
--- a/src/main/java/org/opensha/commons/hpc/pbs/USC_CARC_ScriptWriter.java
+++ b/src/main/java/org/opensha/commons/hpc/pbs/USC_CARC_ScriptWriter.java
@@ -6,7 +6,8 @@ import java.util.List;
 
 
 public class USC_CARC_ScriptWriter extends BatchScriptWriter {
-	
+
+	public static final File FMPJ_HOME = new File("/project/scec_608/kmilner/mpj/FastMPJ");
 	public static final File MPJ_HOME = new File("/project/scec_608/kmilner/mpj/mpj-current");
 	public static final File JAVA_BIN = new File("java");
 	

--- a/src/main/java/org/opensha/commons/logicTree/Affects.java
+++ b/src/main/java/org/opensha/commons/logicTree/Affects.java
@@ -6,6 +6,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.opensha.commons.logicTree.LogicTreeLevel.EnumBackedLevel;
+
+/**
+ * Tagging interface for use with {@link EnumBackedLevel}, to allow logic tree node enums to specify files/properties
+ * that they affect.
+ * 
+ * @author kevin
+ *
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Repeatable(Affects.Affected.class)

--- a/src/main/java/org/opensha/commons/logicTree/Affects.java
+++ b/src/main/java/org/opensha/commons/logicTree/Affects.java
@@ -1,0 +1,23 @@
+package org.opensha.commons.logicTree;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(Affects.Affected.class)
+public @interface Affects {
+	public static final String NONE = "";
+	
+	public String value() default NONE;
+	
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@interface Affected {
+
+		public Affects[] value();
+	}
+}

--- a/src/main/java/org/opensha/commons/logicTree/DoesNotAffect.java
+++ b/src/main/java/org/opensha/commons/logicTree/DoesNotAffect.java
@@ -1,0 +1,23 @@
+package org.opensha.commons.logicTree;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Repeatable(DoesNotAffect.NotAffected.class)
+public @interface DoesNotAffect {
+	public static final String NONE = "";
+	
+	public String value() default NONE;
+	
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	@interface NotAffected {
+
+		public DoesNotAffect[] value();
+	}
+}

--- a/src/main/java/org/opensha/commons/logicTree/DoesNotAffect.java
+++ b/src/main/java/org/opensha/commons/logicTree/DoesNotAffect.java
@@ -6,6 +6,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.opensha.commons.logicTree.LogicTreeLevel.EnumBackedLevel;
+
+/**
+ * Tagging interface for use with {@link EnumBackedLevel}, to allow logic tree node enums to specify files/properties
+ * that they don't affect.
+ * 
+ * @author kevin
+ *
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @Repeatable(DoesNotAffect.NotAffected.class)

--- a/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
+++ b/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
@@ -54,8 +54,26 @@ public abstract class LogicTreeLevel<E extends LogicTreeNode> implements ShortNa
 		return affectedByDefault;
 	}
 	
+	/**
+	 * Gets list of things (e.g., a file name or some sort of property key) that are explicitly affected by
+	 * the choice at this branching level.
+	 * <b>
+	 * This is originally designed for use for efficient storage of {@link SolutionLogicTree}'s, but other
+	 * use cases may exist.
+	 * 
+	 * @return collection of affected things, or empty collection if none (should never return null)
+	 */
 	protected abstract Collection<String> getAffected();
 	
+	/**
+	 * Gets list of things (e.g., a file name or some sort of property key) that are explicitly not affected by
+	 * the choice at this branching level.
+	 * <b>
+	 * This is originally designed for use for efficient storage of {@link SolutionLogicTree}'s, but other
+	 * use cases may exist.
+	 * 
+	 * @return collection of not affected things, or empty collection if none (should never return null)
+	 */
 	protected abstract Collection<String> getNotAffected();
 	
 	public String toString() {
@@ -202,7 +220,20 @@ public abstract class LogicTreeLevel<E extends LogicTreeNode> implements ShortNa
 
 		@Override
 		public List<? extends LogicTreeNode> getNodes() {
+			// TODO why not force child class to implement this method?
 			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		protected Collection<String> getAffected() {
+			// TODO force child class to implement?
+			return List.of();
+		}
+
+		@Override
+		protected Collection<String> getNotAffected() {
+			// TODO force child class to implement?
+			return List.of();
 		}
 
 		@Override

--- a/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
+++ b/src/main/java/org/opensha/commons/logicTree/LogicTreeLevel.java
@@ -351,18 +351,23 @@ public abstract class LogicTreeLevel<E extends LogicTreeNode> implements ShortNa
 							}
 						} else {
 							// single
-							DoesNotAffect doesnt = type.getAnnotation(DoesNotAffect.class);
-							if (doesnt != null)
-								notAffected.add(doesnt.value());
+							DoesNotAffect doesNot = type.getAnnotation(DoesNotAffect.class);
+							if (doesNot != null) {
+								String name = doesNot.value();
+								Preconditions.checkState(!affected.contains(name),
+										"EnumBackedLevel type %s annotates '%s' as both affected and not affected!",
+										type.getName(), name);
+								notAffected.add(name);
+							}
 						}
 						
-						System.out.println(getName()+" affected:");
-						for (String name : affected)
-							System.out.println("\t"+name);
-						System.out.println(getName()+" unaffected:");
-						for (String name : notAffected)
-							System.out.println("\t"+name);
-						System.out.println();
+//						System.out.println(getName()+" affected:");
+//						for (String name : affected)
+//							System.out.println("\t"+name);
+//						System.out.println(getName()+" unaffected:");
+//						for (String name : notAffected)
+//							System.out.println("\t"+name);
+//						System.out.println();
 						
 						this.notAffected = notAffected;
 						this.affected = affected;

--- a/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
@@ -14,7 +14,7 @@ import com.google.common.base.Preconditions;
  * @param <E>
  */
 @ModuleHelper
-public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Module {
+public interface AverageableModule<E extends AverageableModule<E>> extends OpenSHA_Module {
 	
 	/**
 	 * Creates an accumulator that can build an average of multiple instances of this module
@@ -92,7 +92,7 @@ public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Mod
 	 * @param <E>
 	 */
 	@ModuleHelper
-	public interface ConstantAverageable<E extends OpenSHA_Module> extends AverageableModule<E> {
+	public interface ConstantAverageable<E extends AverageableModule<E>> extends AverageableModule<E> {
 
 		@Override
 		default AveragingAccumulator<E> averagingAccumulator() {
@@ -112,6 +112,7 @@ public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Mod
 					return module;
 				}
 
+				@SuppressWarnings("unchecked") // guaranteed by generics to be the correct type
 				@Override
 				public Class<E> getType() {
 					return (Class<E>)ConstantAverageable.this.getClass();

--- a/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
@@ -1,0 +1,86 @@
+package org.opensha.commons.util.modules;
+
+import java.util.Collection;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Interface for a module that can be averaged across multiple instances of the same type
+ * 
+ * @author kevin
+ *
+ * @param <E>
+ */
+@ModuleHelper
+public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Module {
+	
+	/**
+	 * Creates an accumulator that can build an average of the given number of instance of this module
+	 * 
+	 * @param num
+	 * @return
+	 */
+	public AveragingAccumulator<E> averagingAccumulator(int num);
+	
+	public default E getAverage(Collection<E> modules) {
+		Preconditions.checkState(modules.size() > 0, "Must supply at least 1 module");
+		
+		AveragingAccumulator<E> accumulator = averagingAccumulator(modules.size());
+		
+		for (E module : modules)
+			accumulator.process(module);
+		
+		return accumulator.getAverage();
+	}
+	
+	/**
+	 * Accumulator that can average multiple instances of the same module
+	 * 
+	 * @author kevin
+	 *
+	 * @param <E>
+	 */
+	public interface AveragingAccumulator<E extends OpenSHA_Module> {
+		
+		public void process(E module);
+		
+		public E getAverage();
+	}
+	
+	/**
+	 * Helper for module that constant and can just be copied over from the first isntance in any averaging operation
+	 * 
+	 * @author kevin
+	 *
+	 * @param <E>
+	 */
+	@ModuleHelper
+	public interface ConstantAverageable<E extends OpenSHA_Module> extends AverageableModule<E> {
+
+		@Override
+		default AveragingAccumulator<E> averagingAccumulator(int num) {
+			return new AveragingAccumulator<>() {
+
+				private E module;
+
+				@Override
+				public void process(E module) {
+					this.module = module;
+					// do nothing
+				}
+
+				@Override
+				public E getAverage() {
+					return module;
+				}
+				
+			};
+		}
+
+		@Override
+		default E getAverage(Collection<E> modules) {
+			return modules.iterator().next();
+		}
+	}
+
+}

--- a/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/AverageableModule.java
@@ -51,8 +51,36 @@ public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Mod
 	 */
 	public interface AveragingAccumulator<E extends OpenSHA_Module> {
 		
+		/**
+		 * @return the module class that this accumulator is applicable to
+		 */
+		public Class<E> getType();
+		
+		/**
+		 * Convenience method to fetch and process a module of the correct type from the given container
+		 * 
+		 * @param container
+		 * @param relWeight
+		 * @throws IllegalStateException if the container doesn't contain a module of the correct type
+		 */
+		public default void processContainer(ModuleContainer<? super E> container, double relWeight)
+				throws IllegalStateException {
+			process(container.requireModule(getType()), relWeight);
+		}
+		
+		/**
+		 * Process the given instance of this module type, with the given weight
+		 * 
+		 * @param module
+		 * @param relWeight
+		 */
 		public void process(E module, double relWeight);
 		
+		/**
+		 * Builds an average version of this module from all previously processed instances
+		 * 
+		 * @return
+		 */
 		public E getAverage();
 	}
 	
@@ -82,6 +110,11 @@ public interface AverageableModule<E extends OpenSHA_Module> extends OpenSHA_Mod
 				public E getAverage() {
 					Preconditions.checkNotNull(module);
 					return module;
+				}
+
+				@Override
+				public Class<E> getType() {
+					return (Class<E>)ConstantAverageable.this.getClass();
 				}
 				
 			};

--- a/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
@@ -101,6 +101,12 @@ public abstract class AbstractDoubleArrayCSV_BackedModule implements CSV_BackedM
 					AverageableModule.scaleToTotalWeight(avgValues, sumWeight);
 					return averageInstance(avgValues);
 				}
+
+				@SuppressWarnings("unchecked") // it's guaranteed by generics to be the correct type at runtime
+				@Override
+				public Class<E> getType() {
+					return (Class<E>)Averageable.this.getClass();
+				}
 				
 			};
 		}

--- a/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
@@ -77,26 +77,28 @@ public abstract class AbstractDoubleArrayCSV_BackedModule implements CSV_BackedM
 		}
 
 		@Override
-		public AveragingAccumulator<E> averagingAccumulator(int num) {
+		public AveragingAccumulator<E> averagingAccumulator() {
 			// TODO Auto-generated method stub
-			final double rateEach = 1d/num;
 			return new AveragingAccumulator<>() {
 				
 				private double[] avgValues = null;
+				private double sumWeight = 0d;
 
 				@Override
-				public void process(E module) {
+				public void process(E module, double relWeight) {
 					if (avgValues == null)
 						avgValues = new double[module.values.length];
 					else
 						Preconditions.checkState(module.values.length == avgValues.length);
 					
 					for (int i=0; i< avgValues.length; i++)
-						avgValues[i] += module.values[i]*rateEach;
+						avgValues[i] += module.values[i]*relWeight;
+					sumWeight += relWeight;
 				}
 
 				@Override
 				public E getAverage() {
+					AverageableModule.scaleToTotalWeight(avgValues, sumWeight);
 					return averageInstance(avgValues);
 				}
 				

--- a/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
@@ -78,7 +78,6 @@ public abstract class AbstractDoubleArrayCSV_BackedModule implements CSV_BackedM
 
 		@Override
 		public AveragingAccumulator<E> averagingAccumulator() {
-			// TODO Auto-generated method stub
 			return new AveragingAccumulator<>() {
 				
 				private double[] avgValues = null;

--- a/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/AbstractDoubleArrayCSV_BackedModule.java
@@ -1,0 +1,110 @@
+package org.opensha.commons.util.modules.helpers;
+
+import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.util.modules.AverageableModule;
+import org.opensha.commons.util.modules.ModuleHelper;
+
+import com.google.common.base.Preconditions;
+
+@ModuleHelper
+public abstract class AbstractDoubleArrayCSV_BackedModule implements CSV_BackedModule {
+	
+	protected double[] values;
+	
+	protected AbstractDoubleArrayCSV_BackedModule() {
+		
+	}
+	
+	public AbstractDoubleArrayCSV_BackedModule(double[] values) {
+		this.values = values;
+	}
+	
+	public double get(int index) {
+		return values[index];
+	}
+	
+	public double[] get() {
+		return values;
+	}
+
+	/**
+	 * Name for the first column of the CSV file, which describes to the array index
+	 * 
+	 * @return
+	 */
+	protected abstract String getIndexHeading();
+	
+	/**
+	 * Name for the second column of the CSV file, which describes the data value
+	 * 
+	 * @return
+	 */
+	protected abstract String getValueHeading();
+	
+	@Override
+	public CSVFile<String> getCSV() {
+		CSVFile<String> csv = new CSVFile<>(true);
+		csv.addLine(getIndexHeading(), getValueHeading());
+		for (int r=0; r<values.length; r++)
+			csv.addLine(r+"", values[r]+"");
+		return csv;
+	}
+
+	@Override
+	public void initFromCSV(CSVFile<String> csv) {
+		double[] vals = new double[csv.getNumRows()-1];
+		
+		String heading = getIndexHeading();
+		for (int row=1; row<csv.getNumRows(); row++) {
+			int r = row-1;
+			Preconditions.checkState(r == csv.getInt(row, 0),
+					"%s must be 0-based and in order. Expected %s at row %s", heading, r, row);
+			vals[r] = csv.getDouble(row, 1);
+		}
+		this.values = vals;
+	}
+	
+	@ModuleHelper
+	public static abstract class Averageable<E extends Averageable<E>> extends AbstractDoubleArrayCSV_BackedModule
+	implements AverageableModule<E> {
+		
+		protected Averageable() {
+			super();
+		}
+		
+		public Averageable(double[] values) {
+			super(values);
+		}
+
+		@Override
+		public AveragingAccumulator<E> averagingAccumulator(int num) {
+			// TODO Auto-generated method stub
+			final double rateEach = 1d/num;
+			return new AveragingAccumulator<>() {
+				
+				private double[] avgValues = null;
+
+				@Override
+				public void process(E module) {
+					if (avgValues == null)
+						avgValues = new double[module.values.length];
+					else
+						Preconditions.checkState(module.values.length == avgValues.length);
+					
+					for (int i=0; i< avgValues.length; i++)
+						avgValues[i] += module.values[i]*rateEach;
+				}
+
+				@Override
+				public E getAverage() {
+					return averageInstance(avgValues);
+				}
+				
+			};
+		}
+		
+		protected abstract E averageInstance(double[] avgValues);
+		
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemSolution.java
@@ -814,10 +814,16 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 			double fractInside = 1;
 			if (region != null)
 				fractInside = fractRupsInside[r];
-			double rateInside=getRateForRup(r)*fractInside;
 //			if (fractInside < 1)
 //				System.out.println("inside: "+fractInside+"\trate: "+rateInside+"\tID: "+r);
-			mfd.addResampledMagRate(rupSet.getMagForRup(r), rateInside, true);
+			if (fractInside > 0d) {
+				DiscretizedFunc rupMagDist = getRupMagDist(r);
+				if (rupMagDist == null)
+					mfd.addResampledMagRate(rupSet.getMagForRup(r), getRateForRup(r)*fractInside, true);
+				else
+					for (Point2D pt : rupMagDist)
+						mfd.addResampledMagRate(pt.getX(), pt.getY()*fractInside, true);
+			}
 		}
 		return mfd;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
@@ -460,13 +460,13 @@ public class Inversions {
 			
 			if (doNet)
 				constraints.add(new SlipRateSegmentationConstraint(
-						rupSet, segModel, combiner, weight, true, inequality, true));
+						rupSet, segModel, combiner, weight, true, inequality, true, true));
 			if (doNormalized)
 				constraints.add(new SlipRateSegmentationConstraint(
-						rupSet, segModel, combiner, weight, true, inequality, false));
+						rupSet, segModel, combiner, weight, true, inequality));
 			if (doRegular)
 				constraints.add(new SlipRateSegmentationConstraint(
-						rupSet, segModel, combiner, weight, false, inequality, false));
+						rupSet, segModel, combiner, weight, false, inequality));
 		}
 		
 		if (cmd.hasOption("minimize-below-sect-min")) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateSegmentationConstraint.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateSegmentationConstraint.java
@@ -264,13 +264,15 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 				if (netConstraint) {
 					double prev = getA(A, row, rup);
 					setA(A, row, rup, prev + weight*avgSlip/combRate);
+					if (prev == 0d)
+						count++;
 				} else {
 					if (normalized)
 						setA(A, row, rup, weight*avgSlip/combRate);
 					else
 						setA(A, row, rup, weight*avgSlip);
+					count++;
 				}
-				count++;
 			}
 			
 			if (netConstraint) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateSegmentationConstraint.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/SlipRateSegmentationConstraint.java
@@ -19,7 +19,9 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.Shaw07JumpDistProb;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -50,20 +52,30 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 	private SegmentationModel segModel;
 	private RateCombiner combiner;
 	private boolean netConstraint;
+	private boolean includeUnusedInNet;
 	
 	private transient FaultSystemRupSet rupSet;
 	/*
 	 *  map from jumps to rupture IDs that use that jump. Within the jump, fromID will always be < toID
 	 */
 	private transient Map<Jump, List<Integer>> jumpRupturesMap;
-	private transient EvenlyDiscretizedFunc distanceBins;
+	private transient EvenlyDiscretizedFunc scalarBins;
 
 	@JsonAdapter(SlipRateSegmentationConstraint.SegmentationModelAdapter.class)
 	public static interface SegmentationModel {
 		public double calcReductionBetween(Jump jump);
 	}
 	
-	public static class Shaw07JumpDistSegModel implements SegmentationModel {
+	public static interface ScalarSegmentationModel extends SegmentationModel {
+		public default double calcReductionBetween(Jump jump) {
+			return calcReductionForScalar(getScalar(jump));
+		}
+		public double calcReductionForScalar(double scalar);
+		public double getScalar(Jump jump);
+		public EvenlyDiscretizedFunc getScalarBins(double minVal, double maxVal);
+	}
+	
+	public static class Shaw07JumpDistSegModel implements ScalarSegmentationModel {
 		
 		private double a;
 		private double r0;
@@ -74,8 +86,18 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 		}
 
 		@Override
-		public double calcReductionBetween(Jump jump) {
-			return Shaw07JumpDistProb.calcJumpProbability(jump.distance, a, r0);
+		public double calcReductionForScalar(double distance) {
+			return Shaw07JumpDistProb.calcJumpProbability(distance, a, r0);
+		}
+
+		@Override
+		public double getScalar(Jump jump) {
+			return jump.distance;
+		}
+
+		@Override
+		public EvenlyDiscretizedFunc getScalarBins(double minVal, double maxVal) {
+			return HistogramFunction.getEncompassingHistogram(0.01, Math.max(maxVal, 1d), 0.5);
 		}
 		
 	}
@@ -161,18 +183,39 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 	 * @param weight constraint weight
 	 * @param normalized if true, constraint will be normalized to match low-slip rate faults equally well
 	 * @param inequality false for equality (exactly match seg. rate), true for inequality (don't exceed seg. rate)
-	 * @param netConstraint if true, will be applied as a binned net constraint to match everything on average in each bin
 	 */
 	public SlipRateSegmentationConstraint(FaultSystemRupSet rupSet, SegmentationModel segModel,
-			RateCombiner combiner, double weight, boolean normalized, boolean inequality, boolean netConstraint) {
+			RateCombiner combiner, double weight, boolean normalized, boolean inequality) {
+		this(rupSet, segModel, combiner, weight, normalized, inequality, false, false);
+	}
+	
+	/**
+	 * 
+	 * 
+	 * @param rupSet rupture set, must have average slip, slip along rupture, and slip rate data attached
+	 * @param segModel segmentation model to use, e.g., Shaw '07
+	 * @param combiner method for combining rates across each side of each jump
+	 * @param weight constraint weight
+	 * @param normalized if true, constraint will be normalized to match low-slip rate faults equally well
+	 * @param inequality false for equality (exactly match seg. rate), true for inequality (don't exceed seg. rate)
+	 * @param netConstraint if true, will be applied as a binned net constraint to match everything on average in each bin
+	 * @param includeUnusedInNet if true, unused connections (from the connection strategy) will also be counted in 
+	 */
+	public SlipRateSegmentationConstraint(FaultSystemRupSet rupSet, SegmentationModel segModel,
+			RateCombiner combiner, double weight, boolean normalized, boolean inequality,
+			boolean netConstraint, boolean includeUnusedInNet) {
 		super(getName(normalized, netConstraint), getShortName(normalized, netConstraint), weight, inequality,
 				normalized ? ConstraintWeightingType.NORMALIZED : ConstraintWeightingType.UNNORMALIZED);
 		this.segModel = segModel;
 		this.combiner = combiner;
 		this.netConstraint = netConstraint;
+		this.includeUnusedInNet = includeUnusedInNet;
 		
-		if (netConstraint)
+		if (netConstraint) {
 			Preconditions.checkState(normalized, "Net constraints must be normalized");
+			Preconditions.checkState(segModel instanceof ScalarSegmentationModel,
+					"Must be a scalar segmentation model for net constraint");
+		}
 		setRuptureSet(rupSet);
 	}
 
@@ -194,15 +237,17 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 
 	@Override
 	public int getNumRows() {
+		checkInitJumpRups();
 		if (netConstraint)
 			// one row for each distance bin
-			return distanceBins.size();
+			return scalarBins.size();
 		// one row for each unique section-to-section connection
 		return jumpRupturesMap.size();
 	}
 
 	@Override
 	public long encode(DoubleMatrix2D A, double[] d, int startRow) {
+		checkInitJumpRups();
 		int row = startRow;
 		
 		List<Jump> jumps = new ArrayList<>(jumpRupturesMap.keySet());
@@ -216,8 +261,32 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 				|| weightingType == ConstraintWeightingType.UNNORMALIZED,
 				"Only normalized and un-normalized weighting types are supported");
 		boolean normalized = weightingType == ConstraintWeightingType.NORMALIZED;
-		if (netConstraint)
+		
+		Map<Jump, Integer> jumpScalarBinIndexes = null;
+		double[] scalarBinAMults = null;
+		double[] scalarBinTargets = null;
+		ScalarSegmentationModel scalarSeg;
+		if (netConstraint) {
 			Preconditions.checkState(normalized, "Net constraint must be normalized");
+			Preconditions.checkState(segModel instanceof ScalarSegmentationModel,
+					"Must be a scalar segmentation model for net constraint");
+			scalarSeg = (ScalarSegmentationModel)segModel;
+			jumpScalarBinIndexes = new HashMap<>();
+
+			scalarBinAMults = new double[scalarBins.size()];
+			scalarBinTargets = new double[scalarBins.size()];
+			for (Jump jump : jumps) {
+				double scalar = scalarSeg.getScalar(jump);
+				int bin = scalarBins.getClosestXIndex(scalar);
+				scalarBinAMults[bin]++;
+				scalarBinTargets[bin] += scalarSeg.calcReductionForScalar(scalar);
+				jumpScalarBinIndexes.put(jump, bin);
+			}
+			for (int i=0; i<scalarBinAMults.length; i++) {
+				scalarBinAMults[i] = 1d/scalarBinAMults[i];
+				scalarBinTargets[i] *= scalarBinAMults[i];
+			}
+		}
 		
 		long count = 0;
 		
@@ -239,7 +308,7 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 			
 			int bin = -1;
 			if (netConstraint) {
-				bin = distanceBins.getClosestXIndex(jump.distance);
+				bin = jumpScalarBinIndexes.get(jump);
 				row = startRow + bin;
 			}
 			
@@ -263,7 +332,7 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 						"Non-finite average slip across jump: %s (from %s and %s)", avgSlip, slip1, slip2);
 				if (netConstraint) {
 					double prev = getA(A, row, rup);
-					setA(A, row, rup, prev + weight*avgSlip/combRate);
+					setA(A, row, rup, prev + weight*scalarBinAMults[bin]*avgSlip/combRate);
 					if (prev == 0d)
 						count++;
 				} else {
@@ -275,18 +344,72 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 				}
 			}
 			
-			if (netConstraint) {
-				d[row] += weight*segFract;
-			} else {
-				if (normalized)
-					d[row] = weight*segFract;
-				else
-					d[row] = weight*segRate;
-			}
+			if (netConstraint)
+				d[row] = weight*scalarBinTargets[bin];
+			else if (normalized)
+				d[row] = weight*segFract;
+			else
+				d[row] = weight*segRate;
 			
 			row++;
 		}
 		return count;
+	}
+	
+	private synchronized void checkInitJumpRups() {
+		if (jumpRupturesMap == null) {
+			System.out.println("Detecting jumps for segmentation constraint");
+			jumpRupturesMap = new HashMap<>();
+			
+			ClusterRuptures cRups = rupSet.requireModule(ClusterRuptures.class);
+			int jumpingRups = 0;
+			for (int r=0; r<cRups.size(); r++) {
+				ClusterRupture rup = cRups.get(r);
+//				System.out.println("Rupture "+r+": "+rup);
+				boolean hasJumps = false;
+				for (Jump jump : rup.getJumpsIterable()) {
+					if (jump.fromSection.getSectionId() > jump.toSection.getSectionId())
+						jump = jump.reverse();
+					List<Integer> jumpRups = jumpRupturesMap.get(jump);
+					if (jumpRups == null) {
+						jumpRups = new ArrayList<>();
+						jumpRupturesMap.put(jump, jumpRups);
+					}
+					jumpRups.add(r);
+					hasJumps = true;
+				}
+				if (hasJumps)
+					jumpingRups++;
+			}
+			System.out.println("Found "+jumpRupturesMap.size()+" unique jumps, involving "+jumpingRups+" ruptures");
+			if (netConstraint) {
+				if (includeUnusedInNet) {
+					ClusterConnectionStrategy connStrat = rupSet.requireModule(PlausibilityConfiguration.class).getConnectionStrategy();
+					int unusedCount = 0;
+					for (Jump jump : connStrat.getAllPossibleJumps()) {
+						if (jump.fromSection.getSectionId() > jump.toSection.getSectionId())
+							jump = jump.reverse();
+						if (!jumpRupturesMap.containsKey(jump)) {
+							jumpRupturesMap.put(jump, new ArrayList<>());
+							unusedCount++;
+						}
+					}
+					System.out.println("Added "+unusedCount+" additional jumps from connection strategy that are never used");
+				}
+				
+				ScalarSegmentationModel scalarSeg = (ScalarSegmentationModel)segModel;
+				
+				double minVal = Double.POSITIVE_INFINITY;
+				double maxVal = Double.NEGATIVE_INFINITY;
+				for (Jump jump : jumpRupturesMap.keySet()) {
+					double val = scalarSeg.getScalar(jump);
+					minVal = Math.min(minVal, val);
+					maxVal = Math.max(maxVal, val);
+				}
+				
+				scalarBins = scalarSeg.getScalarBins(minVal, maxVal);
+			}
+		}
 	}
 
 	@Override
@@ -302,35 +425,6 @@ public class SlipRateSegmentationConstraint extends InversionConstraint {
 					"Rupture set does not have slip rate data");
 			if (!rupSet.hasModule(ClusterRuptures.class))
 				rupSet.addModule(ClusterRuptures.singleStranged(rupSet));
-			
-			System.out.println("Detecting jumps for segmentation constraint");
-			jumpRupturesMap = new HashMap<>();
-			
-			ClusterRuptures cRups = rupSet.requireModule(ClusterRuptures.class);
-			int jumpingRups = 0;
-			double maxJumpDist = 0d;
-			for (int r=0; r<cRups.size(); r++) {
-				ClusterRupture rup = cRups.get(r);
-//				System.out.println("Rupture "+r+": "+rup);
-				boolean hasJumps = false;
-				for (Jump jump : rup.getJumpsIterable()) {
-					maxJumpDist = Double.max(maxJumpDist, jump.distance);
-					if (jump.fromSection.getSectionId() > jump.toSection.getSectionId())
-						jump = jump.reverse();
-					List<Integer> jumpRups = jumpRupturesMap.get(jump);
-					if (jumpRups == null) {
-						jumpRups = new ArrayList<>();
-						jumpRupturesMap.put(jump, jumpRups);
-					}
-					jumpRups.add(r);
-					hasJumps = true;
-				}
-				if (hasJumps)
-					jumpingRups++;
-			}
-			System.out.println("Found "+jumpRupturesMap.size()+" unique jumps, involving "+jumpingRups+" ruptures");
-			if (netConstraint)
-				distanceBins = HistogramFunction.getEncompassingHistogram(0.01, Math.max(maxJumpDist, 1d), 0.5);
 		}
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
@@ -281,6 +281,11 @@ public class AnnealingProgress implements CSV_BackedModule, AverageableModule<An
 			public AnnealingProgress getAverage() {
 				return average(progresses);
 			}
+
+			@Override
+			public Class<AnnealingProgress> getType() {
+				return AnnealingProgress.class;
+			}
 		};
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
@@ -267,13 +267,13 @@ public class AnnealingProgress implements CSV_BackedModule, AverageableModule<An
 	}
 
 	@Override
-	public AveragingAccumulator<AnnealingProgress> averagingAccumulator(int num) {
+	public AveragingAccumulator<AnnealingProgress> averagingAccumulator() {
 		return new AveragingAccumulator<AnnealingProgress>() {
 			
 			List<AnnealingProgress> progresses = new ArrayList<>();
 
 			@Override
-			public void process(AnnealingProgress module) {
+			public void process(AnnealingProgress module, double weight) {
 				progresses.add(module);
 			}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/AnnealingProgress.java
@@ -7,6 +7,7 @@ import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
+import org.opensha.commons.util.modules.AverageableModule;
 import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
 
@@ -14,7 +15,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-public class AnnealingProgress implements CSV_BackedModule {
+public class AnnealingProgress implements CSV_BackedModule, AverageableModule<AnnealingProgress> {
 	
 	private ImmutableList<String> energyTypes;
 	
@@ -263,6 +264,24 @@ public class AnnealingProgress implements CSV_BackedModule {
 		for (int i=0; i<size; i++)
 			ret.add((long)func.getX(i));
 		return ret;
+	}
+
+	@Override
+	public AveragingAccumulator<AnnealingProgress> averagingAccumulator(int num) {
+		return new AveragingAccumulator<AnnealingProgress>() {
+			
+			List<AnnealingProgress> progresses = new ArrayList<>();
+
+			@Override
+			public void process(AnnealingProgress module) {
+				progresses.add(module);
+			}
+
+			@Override
+			public AnnealingProgress getAverage() {
+				return average(progresses);
+			}
+		};
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AbstractLogicTreeModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AbstractLogicTreeModule.java
@@ -32,19 +32,19 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 /**
- * Abstract base class for a branch-averaged module. Work in progress
+ * Abstract base class for a module that spans multiple logic tree branches.
  * 
  * @author kevin
  *
  */
 @ModuleHelper
-public abstract class AbstractBranchAveragedModule implements ArchivableModule {
+public abstract class AbstractLogicTreeModule implements ArchivableModule {
 
 	private ZipFile zip;
 	private String prefix;
 	private LogicTree<?> logicTree;
 
-	protected AbstractBranchAveragedModule(ZipFile zip, String prefix, LogicTree<?> logicTree) {
+	protected AbstractLogicTreeModule(ZipFile zip, String prefix, LogicTree<?> logicTree) {
 		this.zip = zip;
 		this.prefix = prefix;
 		this.logicTree = logicTree;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AveSlipModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AveSlipModule.java
@@ -189,6 +189,11 @@ public abstract class AveSlipModule implements SubModule<FaultSystemRupSet>, Bra
 					AverageableModule.scaleToTotalWeight(values, sumWeight);
 					return new Precomputed(null, values);
 				}
+
+				@Override
+				public Class<AveSlipModule> getType() {
+					return AveSlipModule.class;
+				}
 			};
 		}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BranchAverageableModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BranchAverageableModule.java
@@ -1,0 +1,19 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import org.opensha.commons.logicTree.LogicTreeBranch;
+import org.opensha.commons.util.modules.AverageableModule;
+import org.opensha.commons.util.modules.ModuleHelper;
+import org.opensha.commons.util.modules.OpenSHA_Module;
+
+/**
+ * Tagging interface to indicate that this {@link AverageableModule} can and should be branch-averaged across
+ * multiple {@link LogicTreeBranch} instances. 
+ * 
+ * @author kevin
+ *
+ * @param <E>
+ */
+@ModuleHelper
+public interface BranchAverageableModule<E extends OpenSHA_Module> extends AverageableModule<E> {
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BranchAverageableModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BranchAverageableModule.java
@@ -14,6 +14,6 @@ import org.opensha.commons.util.modules.OpenSHA_Module;
  * @param <E>
  */
 @ModuleHelper
-public interface BranchAverageableModule<E extends OpenSHA_Module> extends AverageableModule<E> {
+public interface BranchAverageableModule<E extends BranchAverageableModule<E>> extends AverageableModule<E> {
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InitialSolution.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InitialSolution.java
@@ -1,23 +1,16 @@
 package org.opensha.sha.earthquake.faultSysSolution.modules;
 
-import org.opensha.commons.data.CSVFile;
-import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
+import org.opensha.commons.util.modules.helpers.AbstractDoubleArrayCSV_BackedModule;
 
-import com.google.common.base.Preconditions;
-
-public class InitialSolution implements CSV_BackedModule {
-	
-	private double[] initialSolution;
+public class InitialSolution extends AbstractDoubleArrayCSV_BackedModule.Averageable<InitialSolution> {
 
 	@SuppressWarnings("unused") // used in deserialization
-	private InitialSolution() {}
-	
-	public InitialSolution(double[] initialSolution) {
-		this.initialSolution = initialSolution;
+	private InitialSolution() {
+		super();
 	}
 	
-	public double[] get() {
-		return initialSolution;
+	public InitialSolution(double[] initialSolution) {
+		super(initialSolution);
 	}
 
 	@Override
@@ -31,24 +24,18 @@ public class InitialSolution implements CSV_BackedModule {
 	}
 
 	@Override
-	public CSVFile<String> getCSV() {
-		CSVFile<String> csv = new CSVFile<>(true);
-		csv.addLine("Rupture Index", "Water Level Rate");
-		for (int r=0; r<initialSolution.length; r++)
-			csv.addLine(r+"", initialSolution[r]+"");
-		return csv;
+	protected InitialSolution averageInstance(double[] avgValues) {
+		return new InitialSolution(avgValues);
 	}
 
 	@Override
-	public void initFromCSV(CSVFile<String> csv) {
-		double[] vals = new double[csv.getNumRows()-1];
-		for (int row=1; row<csv.getNumRows(); row++) {
-			int r = row-1;
-			Preconditions.checkState(r == csv.getInt(row, 0),
-					"Rupture indexes must be 0-based and in order. Expected %s at row %s", r, row);
-			vals[r] = csv.getDouble(row, 1);
-		}
-		this.initialSolution = vals;
+	protected String getIndexHeading() {
+		return "Rupture Index";
+	}
+
+	@Override
+	protected String getValueHeading() {
+		return "Water Level Rate";
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.util.DataUtils;
+import org.opensha.commons.util.modules.AverageableModule;
 import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.ConstraintWeightingType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
@@ -18,7 +19,7 @@ import com.google.common.base.Preconditions;
  * @author kevin
  *
  */
-public class InversionMisfitStats implements CSV_BackedModule {
+public class InversionMisfitStats implements CSV_BackedModule, AverageableModule<InversionMisfitStats> {
 	
 	public static class MisfitStats {
 		public final ConstraintRange range;
@@ -100,6 +101,21 @@ public class InversionMisfitStats implements CSV_BackedModule {
 			this.std = Double.parseDouble(csvLine.get(index++));
 		}
 		
+		private MisfitStats(ConstraintRange range, int numRows, double mean, double absMean, double median, double min,
+				double max, double l2Norm, double energy, double std) {
+			super();
+			this.range = range;
+			this.numRows = numRows;
+			this.mean = mean;
+			this.absMean = absMean;
+			this.median = median;
+			this.min = min;
+			this.max = max;
+			this.l2Norm = l2Norm;
+			this.energy = energy;
+			this.std = std;
+		}
+
 		public List<String> buildCSVLine() {
 			return List.of(
 					range.name, range.shortName, range.weight+"", range.weightingType+"", range.inequality+"",
@@ -174,6 +190,66 @@ public class InversionMisfitStats implements CSV_BackedModule {
 		misfitStats = new ArrayList<>();
 		for (int row=1; row<csv.getNumRows(); row++)
 			misfitStats.add(new MisfitStats(csv.getLine(row)));
+	}
+
+	@Override
+	public AveragingAccumulator<InversionMisfitStats> averagingAccumulator() {
+		// TODO Auto-generated method stub
+		return new AveragingAccumulator<InversionMisfitStats>() {
+			
+			private List<List<MisfitStats>> stats = new ArrayList<>();
+			private List<Double> weights = new ArrayList<>();
+			private double totWeight = 0d;
+			
+			@Override
+			public void process(InversionMisfitStats module, double relWeight) {
+				stats.add(module.misfitStats);
+				weights.add(relWeight);
+				totWeight += relWeight;
+			}
+			
+			@Override
+			public InversionMisfitStats getAverage() {
+				List<MisfitStats> avgStats = new ArrayList<>();
+				
+				int num = stats.get(0).size();
+				for (int i=0; i<num; i++) {
+					ConstraintRange range = null;
+					int numRows = -1;
+					double mean = 0d;
+					double absMean = 0d;
+					double median = 0d;
+					double min = 0d;
+					double max = 0d;
+					double l2Norm = 0d;
+					double energy = 0d;
+					double std = 0d;
+					for (int j=0; j<stats.size(); j++) {
+						double weight = weights.get(j)/totWeight;
+						MisfitStats myStats = stats.get(j).get(i);
+						if (range == null) {
+							range = myStats.range;
+							numRows = myStats.numRows;
+						} else {
+							Preconditions.checkState(range.name.equals(myStats.range.name));
+							Preconditions.checkState(numRows == myStats.numRows);
+						}
+						mean += weight*myStats.mean;
+						absMean += weight*myStats.absMean;
+						median += weight*myStats.median;
+						min = weight*myStats.min;
+						max = weight*myStats.max;
+						l2Norm = weight*myStats.l2Norm;
+						energy = weight*myStats.energy;
+						std = weight*myStats.std;
+					}
+					
+					avgStats.add(new MisfitStats(range, numRows, mean, absMean, median, min,
+							max, l2Norm, energy, std));
+				}
+				return new InversionMisfitStats(avgStats);
+			}
+		};
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
@@ -194,7 +194,6 @@ public class InversionMisfitStats implements CSV_BackedModule, AverageableModule
 
 	@Override
 	public AveragingAccumulator<InversionMisfitStats> averagingAccumulator() {
-		// TODO Auto-generated method stub
 		return new AveragingAccumulator<InversionMisfitStats>() {
 			
 			private List<List<MisfitStats>> stats = new ArrayList<>();
@@ -248,6 +247,11 @@ public class InversionMisfitStats implements CSV_BackedModule, AverageableModule
 							max, l2Norm, energy, std));
 				}
 				return new InversionMisfitStats(avgStats);
+			}
+
+			@Override
+			public Class<InversionMisfitStats> getType() {
+				return InversionMisfitStats.class;
 			}
 		};
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfits.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfits.java
@@ -282,6 +282,11 @@ public class InversionMisfits implements ArchivableModule, AverageableModule<Inv
 			}
 			return new InversionMisfits(ranges, misfits, data, misfits_ineq, data_ineq);
 		}
+
+		@Override
+		public Class<InversionMisfits> getType() {
+			return InversionMisfits.class;
+		}
 		
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionTargetMFDs.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionTargetMFDs.java
@@ -33,6 +33,8 @@ import scratch.UCERF3.utils.MFD_InversionConstraint;
  * Module for magnitude frequency distribution used to constrain an inversion, and to facilitate building
  * a gridded seismicity module.
  * 
+ * TODO averaging support
+ * 
  * @author kevin
  *
  */

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModSectMinMags.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModSectMinMags.java
@@ -214,6 +214,11 @@ public abstract class ModSectMinMags implements SubModule<FaultSystemRupSet>, Br
 					Precomputed ret = new Precomputed();
 					ret.sectMinMags = minMags;
 					return ret;
+				}
+
+				@Override
+				public Class<ModSectMinMags> getType() {
+					return ModSectMinMags.class;
 				}}
 			;
 		}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/NamedFaults.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/NamedFaults.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.opensha.commons.util.modules.SubModule;
+import org.opensha.commons.util.modules.AverageableModule.ConstantAverageable;
 import org.opensha.commons.util.modules.helpers.JSON_TypeAdapterBackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.faultSurface.FaultSection;
@@ -27,7 +28,8 @@ import com.google.gson.reflect.TypeToken;
  * @author kevin
  *
  */
-public class NamedFaults implements SubModule<FaultSystemRupSet>, JSON_TypeAdapterBackedModule<Map<String, List<Integer>>> {
+public class NamedFaults implements SubModule<FaultSystemRupSet>, BranchAverageableModule<NamedFaults>,
+ConstantAverageable<NamedFaults>, JSON_TypeAdapterBackedModule<Map<String, List<Integer>>> {
 	
 	private FaultSystemRupSet rupSet;
 	private Map<String, List<Integer>> namedFaults;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PaleoseismicConstraintData.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PaleoseismicConstraintData.java
@@ -267,6 +267,11 @@ JSON_TypeAdapterBackedModule<PaleoseismicConstraintData>, BranchAverageableModul
 			public PaleoseismicConstraintData getAverage() {
 				return paleoData;
 			}
+
+			@Override
+			public Class<PaleoseismicConstraintData> getType() {
+				return PaleoseismicConstraintData.class;
+			}
 		};
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PaleoseismicConstraintData.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PaleoseismicConstraintData.java
@@ -34,7 +34,7 @@ import scratch.UCERF3.utils.paleoRateConstraints.UCERF3_PaleoRateConstraintFetch
  *
  */
 public class PaleoseismicConstraintData implements SubModule<FaultSystemRupSet>,
-JSON_TypeAdapterBackedModule<PaleoseismicConstraintData> {
+JSON_TypeAdapterBackedModule<PaleoseismicConstraintData>, BranchAverageableModule<PaleoseismicConstraintData> {
 	
 	private transient FaultSystemRupSet rupSet;
 	private List<? extends SectMappedUncertainDataConstraint> paleoRateConstraints;
@@ -235,6 +235,58 @@ JSON_TypeAdapterBackedModule<PaleoseismicConstraintData> {
 		
 		PaleoseismicConstraintData data = loadUCERF3(rupSet);
 		data.inferRatesFromSlipConstraints(true);
+	}
+
+	@Override
+	public AveragingAccumulator<PaleoseismicConstraintData> averagingAccumulator() {
+		// TODO Auto-generated method stub
+		return new AveragingAccumulator<PaleoseismicConstraintData>() {
+			
+			PaleoseismicConstraintData paleoData;
+
+			@Override
+			public void process(PaleoseismicConstraintData module, double relWeight) {
+				if (paleoData == null) {
+					paleoData = module;
+				} else {
+					// make sure it's the same
+					boolean same = paleoConstraintsSame(paleoData.getPaleoRateConstraints(),
+							module.getPaleoRateConstraints());
+					same = same && paleoConstraintsSame(paleoData.getPaleoSlipConstraints(),
+							module.getPaleoSlipConstraints());
+					if (same && paleoData.getPaleoProbModel() != null)
+						same = paleoData.getPaleoProbModel().getClass().equals(module.getPaleoProbModel().getClass());
+					if (same && paleoData.getPaleoSlipProbModel() != null)
+						same = paleoData.getPaleoSlipProbModel().getClass().equals(module.getPaleoSlipProbModel().getClass());
+					if (!same)
+						throw new IllegalStateException("Paleo-seismic data varies by branch, averaging not (yet) supported");
+				}
+			}
+
+			@Override
+			public PaleoseismicConstraintData getAverage() {
+				return paleoData;
+			}
+		};
+	}
+	
+	private static boolean paleoConstraintsSame(List<? extends SectMappedUncertainDataConstraint> constr1,
+			List<? extends SectMappedUncertainDataConstraint> constr2) {
+		if ((constr1 == null) != (constr2 == null))
+			return false;
+		if (constr1 == null && constr2 == null)
+			return true;
+		if (constr1.size() != constr2.size())
+			return false;
+		for (int i=0; i<constr1.size(); i++) {
+			SectMappedUncertainDataConstraint c1 = constr1.get(i);
+			SectMappedUncertainDataConstraint c2 = constr2.get(i);
+			if (c1.sectionIndex != c2.sectionIndex)
+				return false;
+			if ((float)c1.bestEstimate != (float)c2.bestEstimate)
+				return false;
+		}
+		return true;
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PolygonFaultGridAssociations.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/PolygonFaultGridAssociations.java
@@ -26,6 +26,12 @@ import com.google.common.collect.ImmutableMap;
 import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
 
+/**
+ * TODO: averaging support?
+ * 
+ * @author kevin
+ *
+ */
 public interface PolygonFaultGridAssociations extends FaultGridAssociations {
 	
 	/**

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupMFDsModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RupMFDsModule.java
@@ -16,6 +16,8 @@ import com.google.common.base.Preconditions;
  * distribution rather than the average magnitude returned by the rupture set. This is mostly useful for branch-averaged
  * solutions.
  * 
+ * TODO support averaging?
+ * 
  * @author kevin
  *
  */

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
@@ -93,7 +93,7 @@ public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
 	
 	public static final String DATA_FILE_NAME = "sect_areas.csv";
 	
-	public static class Precomputed extends SectAreas implements CSV_BackedModule, ConstantAverageable<SectAreas> {
+	public static class Precomputed extends SectAreas implements CSV_BackedModule, ConstantAverageable<Precomputed> {
 		
 		private double[] sectAreas;
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
@@ -1,6 +1,7 @@
 package org.opensha.sha.earthquake.faultSysSolution.modules;
 
 import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.util.modules.AverageableModule.ConstantAverageable;
 import org.opensha.commons.util.modules.SubModule;
 import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
@@ -92,7 +93,7 @@ public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
 	
 	public static final String DATA_FILE_NAME = "sect_areas.csv";
 	
-	public static class Precomputed extends SectAreas implements CSV_BackedModule {
+	public static class Precomputed extends SectAreas implements CSV_BackedModule, ConstantAverageable<SectAreas> {
 		
 		private double[] sectAreas;
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectSlipRates.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectSlipRates.java
@@ -257,6 +257,11 @@ public abstract class SectSlipRates implements SubModule<FaultSystemRupSet>, Bra
 					ret.slipRateStdDevs = slipRateStdDevs;
 					return ret;
 				}
+
+				@Override
+				public Class<SectSlipRates> getType() {
+					return SectSlipRates.class;
+				}
 			};
 		}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SlipAlongRuptureModel.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SlipAlongRuptureModel.java
@@ -9,6 +9,7 @@ import java.util.zip.ZipOutputStream;
 import org.opensha.commons.calc.FaultMomentCalc;
 import org.opensha.commons.data.function.EvenlyDiscretizedFunc;
 import org.opensha.commons.util.modules.ArchivableModule;
+import org.opensha.commons.util.modules.AverageableModule.ConstantAverageable;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
@@ -17,7 +18,7 @@ import com.google.common.base.Preconditions;
 
 import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 
-public abstract class SlipAlongRuptureModel implements OpenSHA_Module {
+public abstract class SlipAlongRuptureModel implements OpenSHA_Module, ConstantAverageable<SlipAlongRuptureModel> {
 
 	public static SlipAlongRuptureModel forModel(SlipAlongRuptureModels slipAlong) {
 		return slipAlong.getModel();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -1,60 +1,56 @@
 package org.opensha.sha.earthquake.faultSysSolution.modules;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
-import org.dom4j.Element;
 import org.opensha.commons.data.CSVFile;
-import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
-import org.opensha.commons.data.function.DiscretizedFunc;
 import org.opensha.commons.geo.GriddedRegion;
-import org.opensha.commons.geo.Region;
 import org.opensha.commons.geo.json.Feature;
 import org.opensha.commons.logicTree.LogicTree;
 import org.opensha.commons.logicTree.LogicTreeBranch;
 import org.opensha.commons.logicTree.LogicTreeLevel;
 import org.opensha.commons.logicTree.LogicTreeNode;
-import org.opensha.commons.util.FaultUtils;
+import org.opensha.commons.util.ExceptionUtils;
+import org.opensha.commons.util.modules.ArchivableModule;
 import org.opensha.commons.util.modules.ModuleArchive;
 import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
 import org.opensha.commons.util.modules.helpers.FileBackedModule;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet.RuptureProperties;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.UncertainDataConstraint.SectMappedUncertainDataConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.AnnealingProgress;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.AnnealingProgress;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.GeoJSONFaultReader;
+import org.opensha.sha.earthquake.faultSysSolution.util.BranchAverageSolutionCreator;
 import org.opensha.sha.faultSurface.FaultSection;
-import org.opensha.sha.faultSurface.FaultTrace;
-import org.opensha.sha.faultSurface.GeoJSONFaultSection;
-import org.opensha.sha.faultSurface.RuptureSurface;
-import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
 import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 import scratch.UCERF3.FaultSystemSolutionFetcher;
-import scratch.UCERF3.enumTreeBranches.DeformationModels;
-import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.MaxMagOffFault;
 import scratch.UCERF3.enumTreeBranches.MomentRateFixes;
-import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
-import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
 import scratch.UCERF3.griddedSeismicity.AbstractGridSourceProvider;
 import scratch.UCERF3.griddedSeismicity.UCERF3_GridSourceGenerator;
-import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 import scratch.UCERF3.logicTree.U3LogicTreeBranch;
+import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
 /**
  * Module that stores/loads fault system solutions for individual branches of a logic tree.
@@ -62,36 +58,33 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranch;
  * @author kevin
  *
  */
-public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
+public class SolutionLogicTree extends AbstractBranchAveragedModule {
 	
 	private boolean serializeGridded = true;
+	private SolutionProcessor processor;
 	
-	public static class UCERF3 extends AbstractExternalFetcher {
-
-		private FaultSystemSolutionFetcher oldFetcher;
-
-		private UCERF3() {
-			super(null);
-		}
+	/**
+	 * Class that can be used to attach any necessary modules to an already loaded rupture set/solution
+	 * for the given branch.
+	 * <p>
+	 * This is useful in order to add extra information not stored in the standard logic tree files. One
+	 * use case is to infer a grid source provider based on logic tree branch choices and supraseismogenic
+	 * rates, rather than serializing one.
+	 * 
+	 * @author kevin
+	 *
+	 */
+	public interface SolutionProcessor {
 		
-		public UCERF3(LogicTree<?> logicTree) {
-			super(logicTree);
-		}
+		public FaultSystemRupSet processRupSet(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch);
 		
-		public UCERF3(FaultSystemSolutionFetcher oldFetcher) {
-			super(LogicTree.fromExisting(U3LogicTreeBranch.getLogicTreeLevels(), oldFetcher.getBranches()));
-			this.oldFetcher = oldFetcher;
-		}
+		public FaultSystemSolution processSolution(FaultSystemSolution sol, LogicTreeBranch<?> branch);
+	}
+	
+	public static class UCERF3_SolutionProcessor implements SolutionProcessor {
 
 		@Override
-		protected FaultSystemSolution loadExternalForBranch(LogicTreeBranch<?> branch) throws IOException {
-			if (oldFetcher != null)
-				return oldFetcher.getSolution(asU3Branch(branch));
-			return null;
-		}
-
-		@Override
-		protected FaultSystemRupSet processRupSet(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
+		public FaultSystemRupSet processRupSet(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
 //			System.out.println("Start process");
 			rupSet = FaultSystemRupSet.buildFromExisting(rupSet).u3BranchModules(asU3Branch(branch)).build();
 //			System.out.println("End process");
@@ -99,7 +92,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 		}
 
 		@Override
-		protected FaultSystemSolution processSolution(FaultSystemSolution sol, LogicTreeBranch<?> branch) {
+		public FaultSystemSolution processSolution(FaultSystemSolution sol, LogicTreeBranch<?> branch) {
 			sol.addAvailableModule(new Callable<SubSeismoOnFaultMFDs>() {
 
 				@Override
@@ -125,60 +118,50 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			return sol;
 		}
 		
-		private U3LogicTreeBranch asU3Branch(LogicTreeBranch<?> branch) {
-			if (branch instanceof U3LogicTreeBranch)
-				return (U3LogicTreeBranch)branch;
-			Preconditions.checkState(branch.size() >= U3LogicTreeBranch.getLogicTreeLevels().size());
-			List<U3LogicTreeBranchNode<?>> vals = new ArrayList<>();
-			for (LogicTreeNode val : branch) {
-				Preconditions.checkState(val instanceof U3LogicTreeBranchNode);
-				vals.add((U3LogicTreeBranchNode<?>) val);
-			}
-			return U3LogicTreeBranch.fromValues(vals);
+	}
+	
+	private static U3LogicTreeBranch asU3Branch(LogicTreeBranch<?> branch) {
+		if (branch instanceof U3LogicTreeBranch)
+			return (U3LogicTreeBranch)branch;
+		Preconditions.checkState(branch.size() >= U3LogicTreeBranch.getLogicTreeLevels().size());
+		List<U3LogicTreeBranchNode<?>> vals = new ArrayList<>();
+		for (LogicTreeNode val : branch) {
+			Preconditions.checkState(val instanceof U3LogicTreeBranchNode);
+			vals.add((U3LogicTreeBranchNode<?>) val);
 		}
+		return U3LogicTreeBranch.fromValues(vals);
+	}
+	
+	public static class UCERF3 extends AbstractExternalFetcher {
 
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForFaultSections() {
-			return List.of(getLevelForType(FaultModels.class), getLevelForType(DeformationModels.class));
-		}
+		private FaultSystemSolutionFetcher oldFetcher;
 
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForRuptureSectionIndices() {
-			return List.of(getLevelForType(FaultModels.class));
-		}
-
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForRuptureProperties() {
-			return List.of(getLevelForType(FaultModels.class), getLevelForType(DeformationModels.class),
-					getLevelForType(ScalingRelationships.class));
-		}
-
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForRuptureRates() {
-			return getLogicTree().getLevels();
-		}
-
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForGridRegion() {
-			return List.of();
-		}
-
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForGridMechs() {
-			return List.of();
-		}
-
-		@Override
-		public List<? extends LogicTreeLevel<?>> getLevelsForGridMFDs() {
-			return getLogicTree().getLevels();
+		private UCERF3() {
+			super(new UCERF3_SolutionProcessor(), null);
 		}
 		
+		public UCERF3(LogicTree<?> logicTree) {
+			super(new UCERF3_SolutionProcessor(), logicTree);
+		}
+		
+		public UCERF3(FaultSystemSolutionFetcher oldFetcher) {
+			super(new UCERF3_SolutionProcessor(),
+					LogicTree.fromExisting(U3LogicTreeBranch.getLogicTreeLevels(), oldFetcher.getBranches()));
+			this.oldFetcher = oldFetcher;
+		}
+
+		@Override
+		protected FaultSystemSolution loadExternalForBranch(LogicTreeBranch<?> branch) throws IOException {
+			if (oldFetcher != null)
+				return oldFetcher.getSolution(asU3Branch(branch));
+			return null;
+		}
 	}
 	
 	public static abstract class AbstractExternalFetcher extends SolutionLogicTree {
 
-		protected AbstractExternalFetcher(LogicTree<?> logicTree) {
-			super(null, null, logicTree);
+		protected AbstractExternalFetcher(SolutionProcessor processor, LogicTree<?> logicTree) {
+			super(processor, null, null, logicTree);
 		}
 		
 		protected abstract FaultSystemSolution loadExternalForBranch(LogicTreeBranch<?> branch) throws IOException;
@@ -193,12 +176,158 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 		
 	}
 	
-	protected SolutionLogicTree(LogicTree<?> logicTree) {
-		super(null, null, logicTree);
+	public static class FileBuilder extends Builder {
+
+		private SolutionProcessor processor;
+		private File outputFile;
+		
+		private ModuleArchive<SolutionLogicTree> archive;
+
+		private CompletableFuture<Void> startModuleWriteFuture = null;
+		private CompletableFuture<Void> endModuleWriteFuture = null;
+		private CompletableFuture<Void> endArchiveWriteFuture = null;
+		
+		private ZipOutputStream zout;
+		private String entryPrefix;
+		private SolutionLogicTree solTree;
+		private HashSet<String> writtenFiles = new HashSet<>();
+		
+		private List<LogicTreeBranch<LogicTreeNode>> branches = new ArrayList<>();
+		private List<LogicTreeLevel<? extends LogicTreeNode>> levels = null;
+		
+		public FileBuilder(File outputFile) throws IOException {
+			this(null, outputFile);
+		}
+		
+		public FileBuilder(SolutionProcessor processor, File outputFile) throws IOException {
+			this(processor, outputFile, "");
+		}
+
+		public FileBuilder(SolutionProcessor processor, File outputFile, String entryPrefix) throws IOException {
+			this.processor = processor;
+			this.outputFile = outputFile;
+			archive = new ModuleArchive<>();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public synchronized void solution(FaultSystemSolution sol, LogicTreeBranch<?> branch) throws IOException {
+			if (levels == null) {
+				levels = new ArrayList<>();
+				for (LogicTreeLevel<?> level : branch.getLevels())
+					levels.add(level);
+			} else {
+				List<? extends LogicTreeLevel<?>> myLevels = branch.getLevels();
+				Preconditions.checkState(myLevels.size() == levels.size(),
+						"Branch %s has a different number of levels than the first branch", branch);
+				for (int i=0; i<myLevels.size(); i++)
+					Preconditions.checkState(myLevels.get(i).equals(levels.get(i)),
+							"Branch %s has a different level at position %s than the first branch", i, branch);
+			}
+			branches.add((LogicTreeBranch<LogicTreeNode>) branch);
+			
+			if (solTree == null) {
+				startModuleWriteFuture = new CompletableFuture<>();
+				endModuleWriteFuture = new CompletableFuture<>();
+				// first time
+				this.solTree = new SolutionLogicTree() {
+
+					@Override
+					public void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+						FileBuilder.this.zout = zout;
+						FileBuilder.this.entryPrefix = entryPrefix;
+						// signal that we have started writing this module
+						startModuleWriteFuture.complete(null);
+						// now wait until we're done writing it externally
+						try {
+							endModuleWriteFuture.get();
+						} catch (Exception e) {
+							throw ExceptionUtils.asRuntimeException(e);
+						}
+					}
+					
+				};
+				archive.addModule(solTree);
+				// begin asynchronous module archive write
+				endArchiveWriteFuture = CompletableFuture.runAsync(new Runnable() {
+					
+					@Override
+					public void run() {
+						try {
+							archive.write(outputFile);
+						} catch (Exception e) {
+							throw ExceptionUtils.asRuntimeException(e);
+						}
+					}
+				});
+			}
+			// wait until we have started writing the module...
+			try {
+				startModuleWriteFuture.get();
+			} catch (Exception e) {
+				throw ExceptionUtils.asRuntimeException(e);
+			}
+			// we have started writing it!
+			Preconditions.checkNotNull(zout);
+			Preconditions.checkNotNull(entryPrefix);
+			
+			String outPrefix = solTree.buildPrefix(entryPrefix);
+
+			System.out.println("Writing branch: "+branch);
+			solTree.writeBranchFilesToArchive(zout, outPrefix, branch, writtenFiles, sol);
+		}
+		
+		public synchronized void close() throws IOException {
+			if (zout != null) {
+				// write logic tree
+				LogicTree<?> tree = LogicTree.fromExisting(levels, branches);
+				solTree.writeLogicTreeToArchive(zout, solTree.buildPrefix(entryPrefix), tree);
+				
+				if (processor != null)
+					writeProcessorJSON(zout, solTree.buildPrefix(entryPrefix), processor);
+				
+				zout = null;
+				entryPrefix = null;
+				solTree = null;
+				endModuleWriteFuture.complete(null);
+				
+				// now wait until the archive is done writing
+				try {
+					endArchiveWriteFuture.get();
+				} catch (Exception e) {
+					throw ExceptionUtils.asRuntimeException(e);
+				}
+			}
+		}
+
+		@Override
+		public SolutionLogicTree build() throws IOException {
+			close();
+			
+			return new ModuleArchive<>(outputFile, SolutionLogicTree.class).requireModule(SolutionLogicTree.class);
+		}
+		
+	}
+	
+	protected static abstract class Builder {
+		
+		public abstract void solution(FaultSystemSolution sol, LogicTreeBranch<?> branch) throws IOException;
+		
+		public abstract SolutionLogicTree build() throws IOException;
+	}
+	
+	@SuppressWarnings("unused") // used for serialization
+	private SolutionLogicTree() {
+		this(null, null);
+	}
+	
+	protected SolutionLogicTree(SolutionProcessor processor, LogicTree<?> logicTree) {
+		this(processor, null, null, logicTree);
 	}
 
-	protected SolutionLogicTree(ZipFile zip, String prefix, LogicTree<?> logicTree) {
+	protected SolutionLogicTree(SolutionProcessor processor, ZipFile zip, String prefix, LogicTree<?> logicTree) {
 		super(zip, prefix, logicTree);
+		this.processor = processor;
 	}
 
 	@Override
@@ -214,57 +343,24 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 	public void setSerializeGridded(boolean serializeGridded) {
 		this.serializeGridded = serializeGridded;
 	}
-	
-	@Override
-	public List<? extends LogicTreeLevel<?>> getLevelsAffectingFile(String fileName) {
-		switch (fileName) {
-		case FaultSystemRupSet.SECTS_FILE_NAME:
-			return getLevelsForFaultSections();
-		case FaultSystemRupSet.RUP_SECTS_FILE_NAME:
-			return getLevelsForRuptureSectionIndices();
-		case FaultSystemRupSet.RUP_PROPS_FILE_NAME:
-			return getLevelsForRuptureProperties();
-		case FaultSystemSolution.RATES_FILE_NAME:
-			return getLevelsForRuptureRates();
-		case AbstractGridSourceProvider.ARCHIVE_GRID_REGION_FILE_NAME:
-			return getLevelsForGridRegion();
-		case AbstractGridSourceProvider.ARCHIVE_MECH_WEIGHT_FILE_NAME:
-			return getLevelsForGridMechs();
-		case AbstractGridSourceProvider.ARCHIVE_SUB_SEIS_FILE_NAME:
-			return getLevelsForGridMFDs();
-		case AbstractGridSourceProvider.ARCHIVE_UNASSOCIATED_FILE_NAME:
-			return getLevelsForGridMFDs();
-
-		default:
-			return getLogicTree().getLevels();
-		}
-	}
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForFaultSections();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForRuptureSectionIndices();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForRuptureProperties();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForRuptureRates();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForGridRegion();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForGridMechs();
-	
-	protected abstract List<? extends LogicTreeLevel<?>> getLevelsForGridMFDs();
 
 	@Override
 	protected void writeBranchFilesToArchive(ZipOutputStream zout, String prefix, LogicTreeBranch<?> branch,
 			HashSet<String> writtenFiles) throws IOException {
+		FaultSystemSolution sol = forBranch(branch);
+		writeBranchFilesToArchive(zout, prefix, branch, writtenFiles, sol);
+	}
+	
+
+	protected void writeBranchFilesToArchive(ZipOutputStream zout, String prefix, LogicTreeBranch<?> branch,
+			HashSet<String> writtenFiles, FaultSystemSolution sol) throws IOException {
 		// could try to be fancy and copy files over without loading, but these things will be written out so rarely
 		// (usually one and done) so it's not worth the added complexity
-		FaultSystemSolution sol = forBranch(branch);
 		FaultSystemRupSet rupSet = sol.getRupSet();
 		
 		String entryPrefix = null; // prefixes will be encoded in the results of getBranchFileName(...) calls
 		
-		String sectsFile = getBranchFileName(branch, prefix, FaultSystemRupSet.SECTS_FILE_NAME);
+		String sectsFile = getBranchFileName(branch, prefix, FaultSystemRupSet.SECTS_FILE_NAME, true);
 		if (!writtenFiles.contains(sectsFile)) {
 			FileBackedModule.initEntry(zout, entryPrefix, sectsFile);
 			OutputStreamWriter writer = new OutputStreamWriter(zout);
@@ -275,19 +371,19 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			writtenFiles.add(sectsFile);
 		}
 		
-		String indicesFile = getBranchFileName(branch, prefix, FaultSystemRupSet.RUP_SECTS_FILE_NAME);
+		String indicesFile = getBranchFileName(branch, prefix, FaultSystemRupSet.RUP_SECTS_FILE_NAME, true);
 		if (!writtenFiles.contains(indicesFile)) {
 			CSV_BackedModule.writeToArchive(FaultSystemRupSet.buildRupSectsCSV(rupSet), zout, entryPrefix, indicesFile);
 			writtenFiles.add(indicesFile);
 		}
 		
-		String propsFile = getBranchFileName(branch, prefix, FaultSystemRupSet.RUP_PROPS_FILE_NAME);
+		String propsFile = getBranchFileName(branch, prefix, FaultSystemRupSet.RUP_PROPS_FILE_NAME, true);
 		if (!writtenFiles.contains(propsFile)) {
 			CSV_BackedModule.writeToArchive(new RuptureProperties(rupSet).buildCSV(), zout, entryPrefix, propsFile);
 			writtenFiles.add(propsFile);
 		}
 		
-		String ratesFile = getBranchFileName(branch, prefix, FaultSystemSolution.RATES_FILE_NAME);
+		String ratesFile = getBranchFileName(branch, prefix, FaultSystemSolution.RATES_FILE_NAME, true);
 		if (!writtenFiles.contains(ratesFile)) {
 			CSV_BackedModule.writeToArchive(FaultSystemSolution.buildRatesCSV(sol), zout, entryPrefix, ratesFile);
 			writtenFiles.add(ratesFile);
@@ -301,7 +397,8 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			else
 				precomputed = new AbstractGridSourceProvider.Precomputed(prov);
 			
-			String gridRegFile = getBranchFileName(branch, prefix, AbstractGridSourceProvider.ARCHIVE_GRID_REGION_FILE_NAME);
+			String gridRegFile = getBranchFileName(branch, prefix,
+					AbstractGridSourceProvider.ARCHIVE_GRID_REGION_FILE_NAME, false);
 			if (gridRegFile != null && !writtenFiles.contains(gridRegFile)) {
 				FileBackedModule.initEntry(zout, entryPrefix, gridRegFile);
 				Feature regFeature = precomputed.getGriddedRegion().toFeature();
@@ -313,12 +410,14 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 				writtenFiles.add(gridRegFile);
 			}
 
-			String mechFile = getBranchFileName(branch, prefix, AbstractGridSourceProvider.ARCHIVE_MECH_WEIGHT_FILE_NAME);
+			String mechFile = getBranchFileName(branch, prefix,
+					AbstractGridSourceProvider.ARCHIVE_MECH_WEIGHT_FILE_NAME, false);
 			if (mechFile != null && !writtenFiles.contains(mechFile)) {
 				CSV_BackedModule.writeToArchive(precomputed.buildWeightsCSV(), zout, entryPrefix, mechFile);
 				writtenFiles.add(mechFile);
 			}
-			String subSeisFile = getBranchFileName(branch, prefix, AbstractGridSourceProvider.ARCHIVE_SUB_SEIS_FILE_NAME);
+			String subSeisFile = getBranchFileName(branch, prefix,
+					AbstractGridSourceProvider.ARCHIVE_SUB_SEIS_FILE_NAME, true);
 			if (subSeisFile != null && !writtenFiles.contains(subSeisFile)) {
 				CSVFile<String> csv = precomputed.buildSubSeisCSV();
 				if (csv != null) {
@@ -326,7 +425,8 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 					writtenFiles.add(subSeisFile);
 				}
 			}
-			String unassociatedFile = getBranchFileName(branch, prefix, AbstractGridSourceProvider.ARCHIVE_UNASSOCIATED_FILE_NAME);
+			String unassociatedFile = getBranchFileName(branch, prefix,
+					AbstractGridSourceProvider.ARCHIVE_UNASSOCIATED_FILE_NAME, true);
 			if (unassociatedFile != null && !writtenFiles.contains(unassociatedFile)) {
 				CSVFile<String> csv = precomputed.buildUnassociatedCSV();
 				if (csv != null) {
@@ -341,7 +441,8 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			misfitStats = sol.requireModule(InversionMisfits.class).getMisfitStats();
 		
 		if (misfitStats != null) {
-			String statsFile = getBranchFileName(branch, prefix, InversionMisfitStats.MISFIT_STATS_FILE_NAME);
+			String statsFile = getBranchFileName(branch, prefix,
+					InversionMisfitStats.MISFIT_STATS_FILE_NAME, true);
 			Preconditions.checkState(!writtenFiles.contains(statsFile));
 			CSV_BackedModule.writeToArchive(misfitStats.getCSV(), zout, entryPrefix, statsFile);
 			writtenFiles.add(statsFile);
@@ -350,19 +451,12 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 		AnnealingProgress progress = sol.getModule(AnnealingProgress.class);
 		
 		if (progress != null) {
-			String progressFile = getBranchFileName(branch, prefix, AnnealingProgress.PROGRESS_FILE_NAME);
+			String progressFile = getBranchFileName(branch, prefix,
+					AnnealingProgress.PROGRESS_FILE_NAME, true);
 			Preconditions.checkState(!writtenFiles.contains(progressFile));
 			CSV_BackedModule.writeToArchive(progress.getCSV(), zout, entryPrefix, progressFile);
 			writtenFiles.add(progressFile);
 		}
-	}
-	
-	protected FaultSystemRupSet processRupSet(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
-		return rupSet;
-	}
-	
-	protected FaultSystemSolution processSolution(FaultSystemSolution sol, LogicTreeBranch<?> branch) {
-		return sol;
 	}
 	
 	// cache files
@@ -386,7 +480,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 		ZipFile zip = getZipFile();
 		String entryPrefix = null; // prefixes will be encoded in the results of getBranchFileName(...) calls
 		
-		String sectsFile = getBranchFileName(branch, FaultSystemRupSet.SECTS_FILE_NAME);
+		String sectsFile = getBranchFileName(branch, FaultSystemRupSet.SECTS_FILE_NAME, true);
 		List<? extends FaultSection> subSects;
 		if (prevSubSects != null && sectsFile.equals(prevSectsFile)) {
 			System.out.println("\tRe-using previous section data");
@@ -402,7 +496,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			prevSectsFile = sectsFile;
 		}
 		
-		String indicesFile = getBranchFileName(branch, FaultSystemRupSet.RUP_SECTS_FILE_NAME);
+		String indicesFile = getBranchFileName(branch, FaultSystemRupSet.RUP_SECTS_FILE_NAME, true);
 		List<List<Integer>> rupIndices;
 		if (prevRupIndices != null && indicesFile.equals(prevIndicesFile)) {
 			System.out.println("\tRe-using previous rupture indices");
@@ -415,7 +509,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			prevIndicesFile = indicesFile;
 		}
 		
-		String propsFile = getBranchFileName(branch, FaultSystemRupSet.RUP_PROPS_FILE_NAME);
+		String propsFile = getBranchFileName(branch, FaultSystemRupSet.RUP_PROPS_FILE_NAME, true);
 		RuptureProperties props;
 		if (prevProps != null && propsFile.equals(prevPropsFile)) {
 			System.out.println("\tRe-using previous rupture properties");
@@ -428,10 +522,12 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			prevPropsFile = propsFile;
 		}
 		
-		FaultSystemRupSet rupSet = processRupSet(new FaultSystemRupSet(subSects, rupIndices,
-				props.mags, props.rakes, props.areas, props.lengths), branch);
+		FaultSystemRupSet rupSet = new FaultSystemRupSet(subSects, rupIndices,
+				props.mags, props.rakes, props.areas, props.lengths);
+		if (processor != null)
+			rupSet = processor.processRupSet(rupSet, branch);
 		
-		String ratesFile = getBranchFileName(branch, FaultSystemSolution.RATES_FILE_NAME);
+		String ratesFile = getBranchFileName(branch, FaultSystemSolution.RATES_FILE_NAME, true);
 		System.out.println("\tLoading rate data from "+ratesFile);
 		CSVFile<String> ratesCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, ratesFile);
 		double[] rates = FaultSystemSolution.loadRatesCSV(ratesCSV);
@@ -439,12 +535,14 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 		
 		rupSet.addModule(branch);
 		
-		FaultSystemSolution sol = processSolution(new FaultSystemSolution(rupSet, rates), branch);
+		FaultSystemSolution sol = new FaultSystemSolution(rupSet, rates);
+		if (processor != null)
+			sol = processor.processSolution(sol, branch);
 		
 		sol.addModule(branch);
 		
-		String gridRegFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_GRID_REGION_FILE_NAME);
-		String mechFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_MECH_WEIGHT_FILE_NAME);
+		String gridRegFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_GRID_REGION_FILE_NAME, false);
+		String mechFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_MECH_WEIGHT_FILE_NAME, false);
 		if (gridRegFile != null && zip.getEntry(gridRegFile) != null && mechFile != null && zip.getEntry(mechFile) != null) {
 			sol.addAvailableModule(new Callable<GridSourceProvider>() {
 
@@ -477,8 +575,8 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 					CSVFile<String> subSeisCSV = null;
 					CSVFile<String> nodeUnassociatedCSV = null;
 					
-					String subSeisFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_SUB_SEIS_FILE_NAME);
-					String nodeUnassociatedFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_UNASSOCIATED_FILE_NAME);
+					String subSeisFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_SUB_SEIS_FILE_NAME, true);
+					String nodeUnassociatedFile = getBranchFileName(branch, AbstractGridSourceProvider.ARCHIVE_UNASSOCIATED_FILE_NAME, true);
 					if (subSeisFile != null && zip.getEntry(subSeisFile) != null)
 						subSeisCSV = AbstractGridSourceProvider.Precomputed.loadCSV(zip, entryPrefix, subSeisFile);
 					if (nodeUnassociatedFile != null && zip.getEntry(nodeUnassociatedFile) != null)
@@ -489,7 +587,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			}, GridSourceProvider.class);
 		}
 		
-		String statsFile = getBranchFileName(branch, InversionMisfitStats.MISFIT_STATS_FILE_NAME);
+		String statsFile = getBranchFileName(branch, InversionMisfitStats.MISFIT_STATS_FILE_NAME, true);
 		if (statsFile != null && zip.getEntry(statsFile) != null) {
 			CSVFile<String> misfitStatsCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, statsFile);
 			InversionMisfitStats stats = new InversionMisfitStats(null);
@@ -497,7 +595,7 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 			sol.addModule(stats);
 		}
 		
-		String progressFile = getBranchFileName(branch, AnnealingProgress.PROGRESS_FILE_NAME);
+		String progressFile = getBranchFileName(branch, AnnealingProgress.PROGRESS_FILE_NAME, true);
 		if (progressFile != null && zip.getEntry(progressFile) != null) {
 			CSVFile<String> progressCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, progressFile);
 			AnnealingProgress progress = new AnnealingProgress(progressCSV);
@@ -522,587 +620,129 @@ public abstract class SolutionLogicTree extends AbstractBranchAveragedModule {
 	}
 	
 	public FaultSystemSolution calcBranchAveraged() throws IOException {
-		double totWeight = 0d; 
-		double[] avgRates = null;
-		double[] avgMags = null;
-		double[] avgAreas = null;
-		double[] avgLengths = null;
-		double[] avgSlips = null;
-		List<List<Double>> avgRakes = null;
-		List<List<Integer>> sectIndices = null;
-		List<DiscretizedFunc> rupMFDs = null;
+		BranchAverageSolutionCreator baCreator = new BranchAverageSolutionCreator();
 		
-		FaultSystemRupSet refRupSet = null;
-		double[] avgSectAseis = null;
-		double[] avgSectCoupling = null;
-		double[] avgSectSlipRates = null;
-		double[] avgSectSlipRateStdDevs = null;
-		List<List<Double>> avgSectRakes = null;
-		
-		// related to gridded seismicity
-		GridSourceProvider refGridProv = null;
-		GriddedRegion gridReg = null;
-		Map<Integer, IncrementalMagFreqDist> nodeSubSeisMFDs = null;
-		Map<Integer, IncrementalMagFreqDist> nodeUnassociatedMFDs = null;
-		List<IncrementalMagFreqDist> sectSubSeisMFDs = null;
-		
-		List<? extends LogicTreeBranch<?>> branches = getLogicTree().getBranches();
-		
-		LogicTreeBranch<LogicTreeNode> combBranch = null;
-		
-		List<Double> weights = new ArrayList<>();
-		
-		PaleoseismicConstraintData paleoData = null;
-		
-		NamedFaults namedFaults = null;
-		
-		Map<LogicTreeNode, Integer> nodeCounts = new HashMap<>();
-		
-		for (LogicTreeBranch<?> branch : branches) {
-			double weight = branch.getBranchWeight();
-			weights.add(weight);
-			totWeight += weight;
-			
+		for (LogicTreeBranch<?> branch : getLogicTree().getBranches()) {
 			FaultSystemSolution sol = forBranch(branch);
-			FaultSystemRupSet rupSet = sol.getRupSet();
-			GridSourceProvider gridProv = sol.getGridSourceProvider();
-			SubSeismoOnFaultMFDs ssMFDs = sol.getModule(SubSeismoOnFaultMFDs.class);
-			
-			if (avgRates == null) {
-				// first time
-				avgRates = new double[rupSet.getNumRuptures()];
-				avgMags = new double[avgRates.length];
-				avgAreas = new double[avgRates.length];
-				avgLengths = new double[avgRates.length];
-				avgRakes = new ArrayList<>();
-				for (int r=0; r<rupSet.getNumRuptures(); r++)
-					avgRakes.add(new ArrayList<>());
-				
-				refRupSet = rupSet;
-				
-				avgSectAseis = new double[rupSet.getNumSections()];
-				avgSectSlipRates = new double[rupSet.getNumSections()];
-				avgSectSlipRateStdDevs = new double[rupSet.getNumSections()];
-				avgSectCoupling = new double[rupSet.getNumSections()];
-				avgSectRakes = new ArrayList<>();
-				for (int s=0; s<rupSet.getNumSections(); s++)
-					avgSectRakes.add(new ArrayList<>());
-				
-				if (gridProv != null) {
-					refGridProv = gridProv;
-					gridReg = gridProv.getGriddedRegion();
-					nodeSubSeisMFDs = new HashMap<>();
-					nodeUnassociatedMFDs = new HashMap<>();
-				}
-				
-				if (ssMFDs != null) {
-					sectSubSeisMFDs = new ArrayList<>();
-					for (int s=0; s<rupSet.getNumSections(); s++)
-						sectSubSeisMFDs.add(null);
-				}
-				
-				if (rupSet.hasModule(AveSlipModule.class))
-					avgSlips = new double[avgRates.length];
-				
-				combBranch = (LogicTreeBranch<LogicTreeNode>)branch.copy();
-				sectIndices = rupSet.getSectionIndicesForAllRups();
-				rupMFDs = new ArrayList<>();
-				for (int r=0; r<avgRates.length; r++)
-					rupMFDs.add(new ArbitrarilyDiscretizedFunc());
-				
-				paleoData = rupSet.getModule(PaleoseismicConstraintData.class);
-				
-				namedFaults = rupSet.getModule(NamedFaults.class);
-			} else {
-				Preconditions.checkState(refRupSet.isEquivalentTo(rupSet), "Rupture sets are not equivalent");
-				if (refGridProv != null)
-					Preconditions.checkNotNull(gridProv, "Some solutions have grid source providers and others don't");
-				
-				if (paleoData != null) {
-					// see if it's the same
-					PaleoseismicConstraintData myPaleoData = rupSet.getModule(PaleoseismicConstraintData.class);
-					if (myPaleoData != null) {
-						boolean same = paleoConstraintsSame(paleoData.getPaleoRateConstraints(),
-								myPaleoData.getPaleoRateConstraints());
-						same = same && paleoConstraintsSame(paleoData.getPaleoSlipConstraints(),
-								myPaleoData.getPaleoSlipConstraints());
-						if (same && paleoData.getPaleoProbModel() != null)
-							same = paleoData.getPaleoProbModel().getClass().equals(myPaleoData.getPaleoProbModel().getClass());
-						if (same && paleoData.getPaleoSlipProbModel() != null)
-							same = paleoData.getPaleoSlipProbModel().getClass().equals(myPaleoData.getPaleoSlipProbModel().getClass());
-						if (!same)
-							paleoData = null;
-					} else {
-						// not all branches have it
-						paleoData = null;
-					}
-				}
-			}
-			
-			for (int i=0; i<combBranch.size(); i++) {
-				LogicTreeNode combVal = combBranch.getValue(i);
-				LogicTreeNode branchVal = branch.getValue(i);
-				if (combVal != null && !combVal.equals(branchVal))
-					combBranch.clearValue(i);
-				int prevCount = nodeCounts.containsKey(branchVal) ? nodeCounts.get(branchVal) : 0;
-				nodeCounts.put(branchVal, prevCount+1);
-			}
-			
-			AveSlipModule slipModule = rupSet.getModule(AveSlipModule.class);
-			if (avgSlips != null)
-				Preconditions.checkNotNull(slipModule);
-			addWeighted(avgRates, sol.getRateForAllRups(), weight);
-			for (int r=0; r<avgRates.length; r++) {
-				double rate = sol.getRateForRup(r);
-				double mag = rupSet.getMagForRup(r);
-				DiscretizedFunc rupMFD = rupMFDs.get(r);
-				double y = rate*weight;
-				if (rupMFD.hasX(mag))
-					y += rupMFD.getY(mag);
-				rupMFD.set(mag, y);
-				avgRakes.get(r).add(rupSet.getAveRakeForRup(r));
-				
-				if (avgSlips != null)
-					avgSlips[r] += weight*slipModule.getAveSlip(r);
-			}
-			addWeighted(avgMags, rupSet.getMagForAllRups(), weight);
-			addWeighted(avgAreas, rupSet.getAreaForAllRups(), weight);
-			addWeighted(avgLengths, rupSet.getLengthForAllRups(), weight);
-			
-			for (int s=0; s<rupSet.getNumSections(); s++) {
-				FaultSection sect = rupSet.getFaultSectionData(s);
-				avgSectAseis[s] += sect.getAseismicSlipFactor()*weight;
-				avgSectSlipRates[s] += sect.getOrigAveSlipRate()*weight;
-				avgSectSlipRateStdDevs[s] += sect.getOrigSlipRateStdDev()*weight;
-				avgSectCoupling[s] += sect.getCouplingCoeff()*weight;
-				avgSectRakes.get(s).add(sect.getAveRake());
-			}
-			
-			if (gridProv != null) {
-				Preconditions.checkNotNull(refGridProv, "Some solutions have grid source providers and others don't");
-				for (int i=0; i<gridReg.getNodeCount(); i++) {
-					addWeighted(nodeSubSeisMFDs, i, gridProv.getNodeSubSeisMFD(i), weight);
-					addWeighted(nodeUnassociatedMFDs, i, gridProv.getNodeUnassociatedMFD(i), weight);
-				}
-			}
-			if (ssMFDs == null) {
-				Preconditions.checkState(sectSubSeisMFDs == null, "Some solutions have sub seismo MFDs and others don't");
-			} else {
-				Preconditions.checkNotNull(sectSubSeisMFDs, "Some solutions have sub seismo MFDs and others don't");
-				for (int s=0; s<rupSet.getNumSections(); s++) {
-					IncrementalMagFreqDist subSeisMFD = ssMFDs.get(s);
-					Preconditions.checkNotNull(subSeisMFD);
-					IncrementalMagFreqDist avgMFD = sectSubSeisMFDs.get(s);
-					if (avgMFD == null) {
-						avgMFD = new IncrementalMagFreqDist(subSeisMFD.getMinX(), subSeisMFD.getMaxX(), subSeisMFD.size());
-						sectSubSeisMFDs.set(s, avgMFD);
-					}
-					addWeighted(avgMFD, subSeisMFD, weight);
-				}
-			}
+			baCreator.addSolution(sol, branch);
 		}
 		
-		System.out.println("Common branches: "+combBranch);
-//		if (!combBranch.hasValue(DeformationModels.class))
-//			combBranch.setValue(DeformationModels.MEAN_UCERF3);
-//		if (!combBranch.hasValue(ScalingRelationships.class))
-//			combBranch.setValue(ScalingRelationships.MEAN_UCERF3);
-//		if (!combBranch.hasValue(SlipAlongRuptureModels.class))
-//			combBranch.setValue(SlipAlongRuptureModels.MEAN_UCERF3);
-		
-		// now scale by total weight
-		System.out.println("Normalizing by total weight");
-		double[] rakes = new double[avgRates.length];
-		for (int r=0; r<avgRates.length; r++) {
-			avgRates[r] /= totWeight;
-			avgMags[r] /= totWeight;
-			avgAreas[r] /= totWeight;
-			avgLengths[r] /= totWeight;
-			DiscretizedFunc rupMFD = rupMFDs.get(r);
-			rupMFD.scale(1d/totWeight);
-			Preconditions.checkState((float)rupMFD.calcSumOfY_Vals() == (float)avgRates[r]);
-			rakes[r] = FaultUtils.getInRakeRange(FaultUtils.getScaledAngleAverage(avgRakes.get(r), weights));
-			if (avgSlips != null)
-				avgSlips[r] /= totWeight;
-		}
-		
-		GridSourceProvider combGridProv = null;
-		if (refGridProv != null) {
-			double[] fractSS = new double[refGridProv.size()];
-			double[] fractR = new double[fractSS.length];
-			double[] fractN = new double[fractSS.length];
-			for (int i=0; i<fractSS.length; i++) {
-				IncrementalMagFreqDist subSeisMFD = nodeSubSeisMFDs.get(i);
-				if (subSeisMFD != null)
-					subSeisMFD.scale(1d/totWeight);
-				IncrementalMagFreqDist nodeUnassociatedMFD = nodeUnassociatedMFDs.get(i);
-				if (nodeUnassociatedMFD != null)
-					nodeUnassociatedMFD.scale(1d/totWeight);
-				fractSS[i] = refGridProv.getFracStrikeSlip(i);
-				fractR[i] = refGridProv.getFracReverse(i);
-				fractN[i] = refGridProv.getFracNormal(i);
-			}
-			
-			
-			combGridProv = new AbstractGridSourceProvider.Precomputed(refGridProv.getGriddedRegion(),
-					nodeSubSeisMFDs, nodeUnassociatedMFDs, fractSS, fractN, fractR);
-		}
-		if (sectSubSeisMFDs != null)
-			for (int s=0; s<sectSubSeisMFDs.size(); s++)
-				sectSubSeisMFDs.get(s).scale(1d/totWeight);
-		
-		List<FaultSection> subSects = new ArrayList<>();
-		for (int s=0; s<refRupSet.getNumSections(); s++) {
-			FaultSection refSect = refRupSet.getFaultSectionData(s);
-			
-			avgSectAseis[s] /= totWeight;
-			avgSectCoupling[s] /= totWeight;
-			avgSectSlipRates[s] /= totWeight;
-			avgSectSlipRateStdDevs[s] /= totWeight;
-			double avgRake = FaultUtils.getInRakeRange(FaultUtils.getScaledAngleAverage(avgSectRakes.get(s), weights));
-			
-			GeoJSONFaultSection avgSect = new GeoJSONFaultSection(new AvgFaultSection(refSect, avgSectAseis[s],
-					avgSectCoupling[s], avgRake, avgSectSlipRates[s], avgSectSlipRateStdDevs[s]));
-			subSects.add(avgSect);
-		}
-		
-//		FaultSystemRupSet avgRupSet = FaultSystemRupSet.builder(subSects, sectIndices).forU3Branch(combBranch).rupMags(avgMags).build();
-//		// remove these as they're not correct for branch-averaged
-//		avgRupSet.removeModuleInstances(InversionTargetMFDs.class);
-//		avgRupSet.removeModuleInstances(SectSlipRates.class);
-		FaultSystemRupSet avgRupSet = FaultSystemRupSet.builder(subSects, sectIndices).rupRakes(rakes)
-				.rupAreas(avgAreas).rupLengths(avgLengths).rupMags(avgMags).build();
-		int numNonNull = 0;
-		boolean haveSlipAlong = false;
-		for (int i=0; i<combBranch.size(); i++) {
-			LogicTreeNode value = combBranch.getValue(i);
-			if (value != null) {
-				numNonNull++;
-				if (value instanceof SlipAlongRuptureModel) {
-					avgRupSet.addModule((SlipAlongRuptureModel)value);
-					haveSlipAlong = true;
-				} else if (value instanceof SlipAlongRuptureModels) {
-					avgRupSet.addModule(((SlipAlongRuptureModels)value).getModel());
-					haveSlipAlong = true;
-				}
-			}
-		}
-		// special cases for UCERF3 branches
-		if (!haveSlipAlong && hasAllEqually(nodeCounts, SlipAlongRuptureModels.UNIFORM, SlipAlongRuptureModels.TAPERED)) {
-			combBranch.setValue(SlipAlongRuptureModels.MEAN_UCERF3);
-			avgRupSet.addModule(SlipAlongRuptureModels.MEAN_UCERF3.getModel());
-			numNonNull++;
-		}
-		if (combBranch.getValue(ScalingRelationships.class) == null && hasAllEqually(nodeCounts, ScalingRelationships.ELLB_SQRT_LENGTH,
-				ScalingRelationships.ELLSWORTH_B, ScalingRelationships.HANKS_BAKUN_08,
-				ScalingRelationships.SHAW_2009_MOD, ScalingRelationships.SHAW_CONST_STRESS_DROP)) {
-			combBranch.setValue(ScalingRelationships.MEAN_UCERF3);
-			if (avgSlips == null)
-				avgRupSet.addModule(AveSlipModule.forModel(avgRupSet, ScalingRelationships.MEAN_UCERF3));
-			numNonNull++;
-		}
-		if (combBranch.getValue(DeformationModels.class) == null && hasAllEqually(nodeCounts, DeformationModels.GEOLOGIC,
-				DeformationModels.ABM, DeformationModels.NEOKINEMA, DeformationModels.ZENGBB)) {
-			combBranch.setValue(DeformationModels.MEAN_UCERF3);
-			numNonNull++;
-		}
-		
-		if (numNonNull > 0) {
-			avgRupSet.addModule(combBranch);
-			System.out.println("Combined logic tre branch: "+combBranch);
-		}
-		if (avgSlips != null)
-			avgRupSet.addModule(AveSlipModule.precomputed(avgRupSet, avgSlips));
-		if (paleoData != null)
-			avgRupSet.addModule(paleoData);
-		if (namedFaults != null)
-			avgRupSet.addModule(namedFaults);
-		
-		FaultSystemSolution sol = new FaultSystemSolution(avgRupSet, avgRates);
-		sol.addModule(combBranch);
-		if (combGridProv != null)
-			sol.setGridSourceProvider(combGridProv);
-		if (sectSubSeisMFDs != null)
-			sol.addModule(new SubSeismoOnFaultMFDs(sectSubSeisMFDs));
-		sol.addModule(new RupMFDsModule(sol, rupMFDs.toArray(new DiscretizedFunc[0])));
-		return sol;
+		return baCreator.build();
 	}
 	
-	private boolean hasAllEqually(Map<LogicTreeNode, Integer> nodeCounts, LogicTreeNode... nodes) {
-		Integer commonCount = null;
-		for (LogicTreeNode node : nodes) {
-			Integer count = nodeCounts.get(node);
-			if (count == null)
-				return false;
-			if (commonCount == null)
-				commonCount = count;
-			else if (commonCount.intValue() != count.intValue())
-				return false;
-		}
-		return true;
+	@Override
+	public Class<? extends ArchivableModule> getLoadingClass() {
+		// default to primary implementation, don't load from files as subclasses
+		return SolutionLogicTree.class;
 	}
 	
-	private static boolean paleoConstraintsSame(List<? extends SectMappedUncertainDataConstraint> constr1,
-			List<? extends SectMappedUncertainDataConstraint> constr2) {
-		if ((constr1 == null) != (constr2 == null))
-			return false;
-		if (constr1 == null && constr2 == null)
-			return true;
-		if (constr1.size() != constr2.size())
-			return false;
-		for (int i=0; i<constr1.size(); i++) {
-			SectMappedUncertainDataConstraint c1 = constr1.get(i);
-			SectMappedUncertainDataConstraint c2 = constr2.get(i);
-			if (c1.sectionIndex != c2.sectionIndex)
-				return false;
-			if ((float)c1.bestEstimate != (float)c2.bestEstimate)
-				return false;
-		}
-		return true;
-	}
-	
-	private class AvgFaultSection implements FaultSection {
+	private static final String PROCESSOR_FILE_NAME = "solution_processor.json";
+
+	@Override
+	public void writeToArchive(ZipOutputStream zout, String entryPrefix) throws IOException {
+		super.writeToArchive(zout, entryPrefix);
 		
-		private FaultSection refSect;
-		private double avgAseis;
-		private double avgCoupling;
-		private double avgRake;
-		private double avgSlip;
-		private double avgSlipStdDev;
+		if (processor != null)
+			writeProcessorJSON(zout, buildPrefix(entryPrefix), processor);
+	}
 
-		public AvgFaultSection(FaultSection refSect, double avgAseis, double avgCoupling, double avgRake, double avgSlip, double avgSlipStdDev) {
-			this.refSect = refSect;
-			this.avgAseis = avgAseis;
-			this.avgCoupling = avgCoupling;
-			this.avgRake = avgRake;
-			this.avgSlip = avgSlip;
-			this.avgSlipStdDev = avgSlipStdDev;
-		}
-
-		@Override
-		public String getName() {
-			return refSect.getName();
-		}
-
-		@Override
-		public Element toXMLMetadata(Element root) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public long getDateOfLastEvent() {
-			return refSect.getDateOfLastEvent();
-		}
-
-		@Override
-		public void setDateOfLastEvent(long dateOfLastEventMillis) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void setSlipInLastEvent(double slipInLastEvent) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getSlipInLastEvent() {
-			return refSect.getSlipInLastEvent();
-		}
-
-		@Override
-		public double getAseismicSlipFactor() {
-			if ((float)avgCoupling == 0f)
-				return 0d;
-			return avgAseis;
-		}
-
-		@Override
-		public void setAseismicSlipFactor(double aseismicSlipFactor) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getCouplingCoeff() {
-			if ((float)avgCoupling == 1f)
-				return 1d;
-			return avgCoupling;
-		}
-
-		@Override
-		public void setCouplingCoeff(double couplingCoeff) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getAveDip() {
-			return refSect.getAveDip();
-		}
-
-		@Override
-		public double getOrigAveSlipRate() {
-			return avgSlip;
-		}
-
-		@Override
-		public void setAveSlipRate(double aveLongTermSlipRate) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getAveLowerDepth() {
-			return refSect.getAveLowerDepth();
-		}
-
-		@Override
-		public double getAveRake() {
-			return avgRake;
-		}
-
-		@Override
-		public void setAveRake(double aveRake) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getOrigAveUpperDepth() {
-			return refSect.getOrigAveUpperDepth();
-		}
-
-		@Override
-		public float getDipDirection() {
-			return refSect.getDipDirection();
-		}
-
-		@Override
-		public FaultTrace getFaultTrace() {
-			return refSect.getFaultTrace();
-		}
-
-		@Override
-		public int getSectionId() {
-			return refSect.getSectionId();
-		}
-
-		@Override
-		public void setSectionId(int sectID) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public void setSectionName(String sectName) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public int getParentSectionId() {
-			return refSect.getParentSectionId();
-		}
-
-		@Override
-		public void setParentSectionId(int parentSectionId) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public String getParentSectionName() {
-			return refSect.getParentSectionName();
-		}
-
-		@Override
-		public void setParentSectionName(String parentSectionName) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public List<? extends FaultSection> getSubSectionsList(double maxSubSectionLen, int startId,
-				int minSubSections) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public double getOrigSlipRateStdDev() {
-			return avgSlipStdDev;
-		}
-
-		@Override
-		public void setSlipRateStdDev(double slipRateStdDev) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public boolean isConnector() {
-			return refSect.isConnector();
-		}
-
-		@Override
-		public Region getZonePolygon() {
-			return refSect.getZonePolygon();
-		}
-
-		@Override
-		public void setZonePolygon(Region zonePolygon) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Element toXMLMetadata(Element root, String name) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public RuptureSurface getFaultSurface(double gridSpacing) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public RuptureSurface getFaultSurface(double gridSpacing, boolean preserveGridSpacingExactly,
-				boolean aseisReducesArea) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public FaultSection clone() {
-			throw new UnsupportedOperationException();
+	private static void writeProcessorJSON(ZipOutputStream zout, String prefix, SolutionProcessor processor)
+			throws IOException {
+		// check for no-arg constructor
+		try {
+			Preconditions.checkNotNull(processor.getClass().getDeclaredConstructor());
+		} catch (Throwable t) {
+			System.err.println("WARNING: Loading class for solution logic tree processor doesn't contain a"
+					+ "no-arg constructor, loading from a zip file will fail: "+processor.getClass().getName());
 		}
 		
+		// write the logic tree
+		FileBackedModule.initEntry(zout, prefix, PROCESSOR_FILE_NAME);
+		Gson gson = new GsonBuilder().setPrettyPrinting().create();
+		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(zout));
+		gson.toJson(processor.getClass().getName(), String.class, writer);
+		writer.flush();
+		zout.flush();
+		zout.closeEntry();
 	}
-	
-	public static void addWeighted(Map<Integer, IncrementalMagFreqDist> mfdMap, int index,
-			IncrementalMagFreqDist newMFD, double weight) {
-		if (newMFD == null)
-			// simple case
-			return;
-		IncrementalMagFreqDist runningMFD = mfdMap.get(index);
-		if (runningMFD == null) {
-			runningMFD = new IncrementalMagFreqDist(newMFD.getMinX(), newMFD.size(), newMFD.getDelta());
-			mfdMap.put(index, runningMFD);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
+		super.initFromArchive(zip, entryPrefix);
+		
+		// see if we have a processor
+		String outPrefix = buildPrefix(entryPrefix);
+		if (FileBackedModule.hasEntry(zip, outPrefix, PROCESSOR_FILE_NAME)) {
+			BufferedInputStream is = FileBackedModule.getInputStream(zip, outPrefix, PROCESSOR_FILE_NAME);
+			
+			Gson gson = new GsonBuilder().setPrettyPrinting().create();
+			InputStreamReader reader = new InputStreamReader(is);
+			String className = gson.fromJson(reader, String.class);
+			
+			Class<?> clazz;
+			try {
+				clazz = Class.forName(className);
+			} catch(Exception e) {
+				System.err.println("WARNING: Skipping solution processor', couldn't locate class: "+className);
+				return;
+			}
+			
+			Class<SolutionProcessor> processorClass;
+			try {
+				processorClass = (Class<SolutionProcessor>)clazz;
+			} catch (Exception e) {
+				System.err.println("WARNING: cannot load solution processor: "+e.getMessage());
+				return;
+			}
+			
+			Constructor<SolutionProcessor> constructor;
+			try {
+				constructor = processorClass.getDeclaredConstructor();
+			} catch (Exception e) {
+				System.err.println("WARNING: cannot load solution processor as the loading class doesn't "
+						+ "have a no-arg constructor: "+clazz.getName()+"");
+				return;
+			}
+			
+			try {
+				constructor.setAccessible(true);
+			} catch (Exception e) {
+				System.err.println("WANRING: couldn't make constructor accessible, loading will likely fail: "+e.getMessage());
+				return;
+			}
+			
+			try {
+				System.out.println("Building instance: "+processorClass.getName());
+				this.processor = constructor.newInstance();
+			} catch (Exception e) {
+				e.printStackTrace();
+				System.err.println("Error loading solution processor, skipping.");
+			}
 		}
-		addWeighted(runningMFD, newMFD, weight);
 	}
-	
-	public static void addWeighted(IncrementalMagFreqDist runningMFD,
-			IncrementalMagFreqDist newMFD, double weight) {
-		Preconditions.checkState(runningMFD.size() == newMFD.size(), "MFD sizes inconsistent");
-		Preconditions.checkState((float)runningMFD.getMinX() == (float)newMFD.getMinX(), "MFD min x inconsistent");
-		Preconditions.checkState((float)runningMFD.getDelta() == (float)newMFD.getDelta(), "MFD delta inconsistent");
-		for (int i=0; i<runningMFD.size(); i++)
-			runningMFD.add(i, newMFD.getY(i)*weight);
-	}
-	
-	private static void addWeighted(double[] running, double[] vals, double weight) {
-		Preconditions.checkState(running.length == vals.length);
-		for (int i=0; i<running.length; i++)
-			running[i] += vals[i]*weight;
-	}
-	
+
 	public static void main(String[] args) throws IOException {
-		File dir = new File("/home/kevin/OpenSHA/UCERF4/batch_inversions/"
-				+ "2021_11_23-u3_branches-FM3_1-5h/");
-		SolutionLogicTree tree = SolutionLogicTree.load(new File(dir, "results.zip"));
+//		File dir = new File("/home/kevin/OpenSHA/UCERF4/batch_inversions/"
+//				+ "2021_11_23-u3_branches-FM3_1-5h/");
+//		SolutionLogicTree tree = SolutionLogicTree.load(new File(dir, "results.zip"));
+//		
+//		FaultSystemSolution ba = tree.calcBranchAveraged();
+//		
+//		ba.write(new File(dir, "branch_averaged.zip"));
 		
-		FaultSystemSolution ba = tree.calcBranchAveraged();
+		SolutionLogicTree tree = SolutionLogicTree.load(new File("/tmp/results.zip"));
+		if (tree.processor == null)
+			System.out.println("No solution processor");
+		else
+			System.out.println("Solution processor type: "+tree.processor.getClass().getName());
 		
-		ba.write(new File(dir, "branch_averaged.zip"));
+		FileBuilder builder = new FileBuilder(tree.processor, new File("/tmp/sol_tree_test.zip"));
+		for (LogicTreeBranch<?> branch : tree.getLogicTree())
+			if (Math.random() < 0.01)
+				builder.solution(tree.forBranch(branch), branch);
+		
+		builder.build();
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -43,7 +43,9 @@ import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import scratch.UCERF3.AverageFaultSystemSolution;
 import scratch.UCERF3.FaultSystemSolutionFetcher;
+import scratch.UCERF3.enumTreeBranches.FaultModels;
 import scratch.UCERF3.enumTreeBranches.MaxMagOffFault;
 import scratch.UCERF3.enumTreeBranches.MomentRateFixes;
 import scratch.UCERF3.enumTreeBranches.SpatialSeisPDF;
@@ -723,26 +725,34 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 	}
 
 	public static void main(String[] args) throws IOException {
-//		File dir = new File("/home/kevin/OpenSHA/UCERF4/batch_inversions/"
-//				+ "2021_11_23-u3_branches-FM3_1-5h/");
-//		SolutionLogicTree tree = SolutionLogicTree.load(new File(dir, "results.zip"));
+		File dir = new File("/home/kevin/OpenSHA/UCERF4/batch_inversions/"
+				+ "2021_11_23-u3_branches-FM3_1-5h/");
+		SolutionLogicTree tree = SolutionLogicTree.load(new File(dir, "results.zip"));
 //		
 //		FaultSystemSolution ba = tree.calcBranchAveraged();
 //		
 //		ba.write(new File(dir, "branch_averaged.zip"));
 		
-		SolutionLogicTree tree = SolutionLogicTree.load(new File("/tmp/results.zip"));
+//		SolutionLogicTree tree = SolutionLogicTree.load(new File("/tmp/results.zip"));
 		if (tree.processor == null)
 			System.out.println("No solution processor");
 		else
 			System.out.println("Solution processor type: "+tree.processor.getClass().getName());
 		
 		FileBuilder builder = new FileBuilder(tree.processor, new File("/tmp/sol_tree_test.zip"));
-		for (LogicTreeBranch<?> branch : tree.getLogicTree())
-			if (Math.random() < 0.01)
-				builder.solution(tree.forBranch(branch), branch);
+		BranchAverageSolutionCreator avgBuilder = new BranchAverageSolutionCreator();
+		for (LogicTreeBranch<?> branch : tree.getLogicTree()) {
+			if (Math.random() < 0.05) {
+				FaultSystemSolution sol = tree.forBranch(branch);
+				builder.solution(sol, branch);
+				if (branch.getValue(FaultModels.class) == FaultModels.FM3_1)
+					avgBuilder.addSolution(sol, branch);
+			}
+		}
 		
 		builder.build();
+		FaultSystemSolution avgSol = avgBuilder.build();
+		avgSol.write(new File("/tmp/sol_tree_test_ba.zip"));
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -58,7 +58,7 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
  * @author kevin
  *
  */
-public class SolutionLogicTree extends AbstractBranchAveragedModule {
+public class SolutionLogicTree extends AbstractLogicTreeModule {
 	
 	private boolean serializeGridded = true;
 	private SolutionProcessor processor;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SubSeismoOnFaultMFDs.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SubSeismoOnFaultMFDs.java
@@ -11,7 +11,7 @@ import org.opensha.sha.magdist.SummedMagFreqDist;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-public class SubSeismoOnFaultMFDs implements CSV_BackedModule {
+public class SubSeismoOnFaultMFDs implements CSV_BackedModule, BranchAverageableModule<SubSeismoOnFaultMFDs> {
 	
 	private ImmutableList<IncrementalMagFreqDist> subSeismoOnFaultMFDs;
 	
@@ -130,6 +130,58 @@ public class SubSeismoOnFaultMFDs implements CSV_BackedModule {
 		SubSeismoOnFaultMFDs mfds = new SubSeismoOnFaultMFDs();
 		mfds.initFromCSV(csv);
 		return mfds;
+	}
+
+	@Override
+	public AveragingAccumulator<SubSeismoOnFaultMFDs> averagingAccumulator() {
+		return new AveragingAccumulator<SubSeismoOnFaultMFDs>() {
+			
+			private List<IncrementalMagFreqDist> avgMFDs;
+			private double totWeight = 0d;
+
+			@Override
+			public void process(SubSeismoOnFaultMFDs module, double relWeight) {
+				if (avgMFDs == null) {
+					avgMFDs = new ArrayList<>();
+					for (int i=0; i<module.size(); i++)
+						avgMFDs.add(null);
+				}
+				for (int i=0; i<module.size(); i++) {
+					IncrementalMagFreqDist avg = avgMFDs.get(i);
+					IncrementalMagFreqDist mine = module.get(i);
+					if (mine == null)
+						continue;
+					if (avg == null) {
+						avg = new IncrementalMagFreqDist(mine.getMinX(), mine.size(), mine.getDelta());
+						avgMFDs.set(i, avg);
+					}
+					Preconditions.checkState((float)mine.getMinX() == (float)avg.getMinX());
+					Preconditions.checkState((float)mine.getDelta() == (float)avg.getDelta());
+					if (mine.size() > avg.size()) {
+						// need to grow it
+						IncrementalMagFreqDist larger = new IncrementalMagFreqDist(mine.getMinX(), mine.size(), mine.getDelta());
+						for (int j=0; j<avg.size(); j++)
+							larger.set(j, avg.getY(j));
+						avg = larger;
+						avgMFDs.set(i, larger);
+					}
+					for (int j=0; j<mine.size(); j++)
+						avg.add(j, mine.getY(j));
+				}
+				totWeight += relWeight;
+			}
+
+			@Override
+			public SubSeismoOnFaultMFDs getAverage() {
+				if (totWeight != 1d) {
+					double scale = 1d/totWeight;
+					for (IncrementalMagFreqDist mfd : avgMFDs)
+						if (mfd != null)
+							mfd.scale(scale);
+				}
+				return new SubSeismoOnFaultMFDs(avgMFDs);
+			}
+		};
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SubSeismoOnFaultMFDs.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SubSeismoOnFaultMFDs.java
@@ -181,6 +181,11 @@ public class SubSeismoOnFaultMFDs implements CSV_BackedModule, BranchAverageable
 				}
 				return new SubSeismoOnFaultMFDs(avgMFDs);
 			}
+
+			@Override
+			public Class<SubSeismoOnFaultMFDs> getType() {
+				return SubSeismoOnFaultMFDs.class;
+			}
 		};
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/WaterLevelRates.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/WaterLevelRates.java
@@ -1,37 +1,32 @@
 package org.opensha.sha.earthquake.faultSysSolution.modules;
 
-import org.opensha.commons.data.CSVFile;
-import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
+import org.opensha.commons.util.modules.helpers.AbstractDoubleArrayCSV_BackedModule;
 
 import com.google.common.base.Preconditions;
 
-public class WaterLevelRates implements CSV_BackedModule {
+public class WaterLevelRates extends AbstractDoubleArrayCSV_BackedModule.Averageable<WaterLevelRates> {
 	
-	private double[] waterlevelRates;
-
 	@SuppressWarnings("unused") // used in deserialization
-	private WaterLevelRates() {}
-	
-	public WaterLevelRates(double[] waterlevelRates) {
-		this.waterlevelRates = waterlevelRates;
+	private WaterLevelRates() {
+		super();
 	}
 	
-	public double[] get() {
-		return waterlevelRates;
+	public WaterLevelRates(double[] waterlevelRates) {
+		super(waterlevelRates);
 	}
 	
 	public double[] subtractFrom(double[] rates) {
-		Preconditions.checkState(rates.length == waterlevelRates.length);
+		Preconditions.checkState(rates.length == values.length);
 		double[] ret = new double[rates.length];
 		for (int i=0; i<rates.length; i++) {
-			ret[i] = rates[i] - waterlevelRates[i];
+			ret[i] = rates[i] - values[i];
 			
 			// deal with floating point precision issues
 			if (ret[i] < 0) {
 				// can happen if post-water-level rates are averaged
 				Preconditions.checkState(ret[i] > -1e-20);
 				ret[i] = 0d;
-			} else if (ret[i] < 1e-20 || (float)rates[i] == (float)waterlevelRates[i]) {
+			} else if (ret[i] < 1e-20 || (float)rates[i] == (float)values[i]) {
 				ret[i] = 0d;
 			}
 		}
@@ -49,24 +44,18 @@ public class WaterLevelRates implements CSV_BackedModule {
 	}
 
 	@Override
-	public CSVFile<String> getCSV() {
-		CSVFile<String> csv = new CSVFile<>(true);
-		csv.addLine("Rupture Index", "Water Level Rate");
-		for (int r=0; r<waterlevelRates.length; r++)
-			csv.addLine(r+"", waterlevelRates[r]+"");
-		return csv;
+	protected WaterLevelRates averageInstance(double[] avgValues) {
+		return new WaterLevelRates(avgValues);
 	}
 
 	@Override
-	public void initFromCSV(CSVFile<String> csv) {
-		double[] vals = new double[csv.getNumRows()-1];
-		for (int row=1; row<csv.getNumRows(); row++) {
-			int r = row-1;
-			Preconditions.checkState(r == csv.getInt(row, 0),
-					"Rupture indexes must be 0-based and in order. Expected %s at row %s", r, row);
-			vals[r] = csv.getDouble(row, 1);
-		}
-		this.waterlevelRates = vals;
+	protected String getIndexHeading() {
+		return "Rupture Index";
+	}
+
+	@Override
+	protected String getValueHeading() {
+		return "Water Level Rate";
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/WaterLevelRates.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/WaterLevelRates.java
@@ -4,7 +4,8 @@ import org.opensha.commons.util.modules.helpers.AbstractDoubleArrayCSV_BackedMod
 
 import com.google.common.base.Preconditions;
 
-public class WaterLevelRates extends AbstractDoubleArrayCSV_BackedModule.Averageable<WaterLevelRates> {
+public class WaterLevelRates extends AbstractDoubleArrayCSV_BackedModule.Averageable<WaterLevelRates>
+implements BranchAverageableModule<WaterLevelRates> {
 	
 	@SuppressWarnings("unused") // used in deserialization
 	private WaterLevelRates() {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/ReportPageGen.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/ReportPageGen.java
@@ -272,6 +272,12 @@ public class ReportPageGen {
 		else
 			plots = getDefaultRupSetPlots(level);
 		
+		if (cmd.hasOption("skip-sect-by-sect")) {
+			for (int i=plots.size(); --i>=0;)
+				if (plots.get(i) instanceof SectBySectDetailPlots)
+					plots.remove(i);
+		}
+		
 		if (cmd.hasOption("skip-plausibility")) {
 			for (int i=plots.size(); --i>=0;)
 				if (plots.get(i) instanceof PlausibilityFilterPlot)
@@ -1113,6 +1119,11 @@ public class ReportPageGen {
 				"Flag to skip plausibility calculations");
 		skipPlausibilityOption.setRequired(false);
 		ops.addOption(skipPlausibilityOption);
+		
+		Option skipSectBySectOption = new Option("ssbs", "skip-sect-by-sect", false,
+				"Flag to skip section-by-section plots, regardless of selected plot level");
+		skipSectBySectOption.setRequired(false);
+		ops.addOption(skipSectBySectOption);
 		
 		Option distAzCacheOption = new Option("cd", "cache-dir", true,
 				"Path to cache files to speed up calculations");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SegmentationPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SegmentationPlot.java
@@ -12,6 +12,7 @@ import org.opensha.commons.util.MarkdownUtils;
 import org.opensha.commons.util.MarkdownUtils.TableBuilder;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateSegmentationConstraint.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractSolutionPlot;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
@@ -19,7 +20,6 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SectionDistanceAzimuthCalculator;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SegmentationCalculator;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SegmentationCalculator.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SegmentationCalculator.Scalars;
 
 public class SegmentationPlot extends AbstractSolutionPlot {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/ClusterRuptureBuilder.java
@@ -964,12 +964,12 @@ public class ClusterRuptureBuilder {
 //		int threads = 62;
 		
 //		RupSetConfig rsConfig = new RuptureSets.CoulombRupSetConfig(FaultModels.FM3_1, ScalingRelationships.MEAN_UCERF3);
-		String state = "CA";
-		RupSetConfig rsConfig = new RuptureSets.CoulombRupSetConfig(RuptureSets.getNSHM23SubSects(state),
-				"nshm23_geo_dm_"+GeoJSONFaultReader.NSHM23_DM_CUR_VERSION+"_"
-						+(state == null ? "all" : state.toLowerCase()), ScalingRelationships.MEAN_UCERF3);
-//		RupSetConfig rsConfig = new RuptureSets.U3RupSetConfig(FaultModels.FM3_1, ScalingRelationships.MEAN_UCERF3);
-//		((U3RupSetConfig)rsConfig).setAdaptiveSectFract(0.1f);
+//		String state = "CA";
+//		RupSetConfig rsConfig = new RuptureSets.CoulombRupSetConfig(RuptureSets.getNSHM23SubSects(state),
+//				"nshm23_geo_dm_"+GeoJSONFaultReader.NSHM23_DM_CUR_VERSION+"_"
+//						+(state == null ? "all" : state.toLowerCase()), ScalingRelationships.MEAN_UCERF3);
+		RupSetConfig rsConfig = new RuptureSets.U3RupSetConfig(FaultModels.FM3_1, ScalingRelationships.MEAN_UCERF3);
+		((U3RupSetConfig)rsConfig).setAdaptiveSectFract(0.1f);
 		FaultSystemRupSet rupSet = rsConfig.build(threads);
 		
 		if (writeRupSet) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RupSetDiagnosticsPageGen.java
@@ -74,6 +74,7 @@ import org.opensha.commons.util.MarkdownUtils.TableBuilder;
 import org.opensha.commons.util.cpt.CPT;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateSegmentationConstraint.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
@@ -105,7 +106,6 @@ import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.pr
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.ClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.DistCutoffClosestSectClusterConnectionStrategy;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.strategies.InputJumpsOrDistClusterConnectionStrategy;
-import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SegmentationCalculator.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.SegmentationCalculator.Scalars;
 import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.simulators.stiffness.AggregatedStiffnessCache;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
@@ -41,6 +41,7 @@ import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
 import org.opensha.commons.util.cpt.CPT;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateSegmentationConstraint.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.modules.AveSlipModule;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
@@ -101,40 +102,6 @@ public class SegmentationCalculator {
 	private final Table<IDPairing, Jump, JumpRates> parentJumpRateTable;
 	// if true, there are multiple jumps between a given parent section pair
 	private final boolean multipleJumpsPerParent;
-	
-	public enum RateCombiner {
-		MIN("Min Rate") {
-			@Override
-			public double combine(double rate1, double rate2) {
-				return Math.min(rate1, rate2);
-			}
-		},
-		MAX("Max Rate") {
-			@Override
-			public double combine(double rate1, double rate2) {
-				return Math.max(rate1, rate2);
-			}
-		},
-		AVERAGE("Avg Rate") {
-			@Override
-			public double combine(double rate1, double rate2) {
-				return 0.5*(rate1 + rate2);
-			}
-		};
-		
-		private String label;
-
-		private RateCombiner(String label) {
-			this.label = label;
-		}
-	
-		@Override
-		public String toString() {
-			return label;
-		}
-		
-		public abstract double combine(double rate1, double rate2);
-	}
 	
 	public enum Scalars {
 		JUMP_DIST("Jump Distance", "km") {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
@@ -97,26 +97,25 @@ public class AverageSolutionCreator {
 		FaultSystemSolution avgSol = new FaultSystemSolution(refRupSet, rates);
 		
 		// now build average modules
-		for (OpenSHA_Module module : inputs[0].getModules()) {
-			if (module instanceof AverageableModule<?>) {
-				System.out.println("Building average instance of "+module.getName());
-				try {
-					AveragingAccumulator<?> accumulator = ((AverageableModule<?>)module).averagingAccumulator();
-					
-					for (FaultSystemSolution sol : inputs)
-						accumulator.processContainer(sol, scale);
-					
-					OpenSHA_Module avgModule = accumulator.getAverage();
-					
-					if (avgModule == null)
-						System.err.println("Averaging returned null for "+module.getName()+", skipping");
-					else
-						avgSol.addModule(avgModule);
-				} catch (Exception e) {
-					System.err.println("Error averaging module: "+module.getName());
-					e.printStackTrace();
-					System.err.flush();
-				}
+		for (OpenSHA_Module module : inputs[0].getModulesAssignableTo(AverageableModule.class, true)) {
+			Preconditions.checkState(module instanceof AverageableModule<?>);
+			System.out.println("Building average instance of "+module.getName());
+			try {
+				AveragingAccumulator<?> accumulator = ((AverageableModule<?>)module).averagingAccumulator();
+				
+				for (FaultSystemSolution sol : inputs)
+					accumulator.processContainer(sol, scale);
+				
+				OpenSHA_Module avgModule = accumulator.getAverage();
+				
+				if (avgModule == null)
+					System.err.println("Averaging returned null for "+module.getName()+", skipping");
+				else
+					avgSol.addModule(avgModule);
+			} catch (Exception e) {
+				System.err.println("Error averaging module: "+module.getName());
+				e.printStackTrace();
+				System.err.flush();
 			}
 		}
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
@@ -5,6 +5,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.opensha.commons.util.modules.AverageableModule;
+import org.opensha.commons.util.modules.AverageableModule.AveragingAccumulator;
+import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
@@ -98,6 +101,17 @@ public class AverageSolutionCreator {
 		}
 		
 		FaultSystemSolution avgSol = new FaultSystemSolution(refRupSet, rates);
+		
+		// now build average modules
+		for (OpenSHA_Module module : inputs[0].getModules()) {
+			if (module instanceof AverageableModule<?>) {
+				// TODO
+//				AveragingAccumulator<?> accumulator = ((AverageableModule<?>)module).averagingAccumulator();
+//				
+//				for (FaultSystemSolution sol : inputs)
+//					accumulator.process(sol.getModule(accumulator.getType()), scale);
+			}
+		}
 		
 		// TODO average grid source provider
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/AverageSolutionCreator.java
@@ -11,16 +11,10 @@ import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.AnnealingProgress;
 import org.opensha.sha.earthquake.faultSysSolution.modules.IndividualSolutionRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.InfoModule;
-import org.opensha.sha.earthquake.faultSysSolution.modules.InitialSolution;
-import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfits;
-import org.opensha.sha.earthquake.faultSysSolution.modules.WaterLevelRates;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 public class AverageSolutionCreator {
 
@@ -105,86 +99,30 @@ public class AverageSolutionCreator {
 		// now build average modules
 		for (OpenSHA_Module module : inputs[0].getModules()) {
 			if (module instanceof AverageableModule<?>) {
-				// TODO
-//				AveragingAccumulator<?> accumulator = ((AverageableModule<?>)module).averagingAccumulator();
-//				
-//				for (FaultSystemSolution sol : inputs)
-//					accumulator.process(sol.getModule(accumulator.getType()), scale);
+				System.out.println("Building average instance of "+module.getName());
+				try {
+					AveragingAccumulator<?> accumulator = ((AverageableModule<?>)module).averagingAccumulator();
+					
+					for (FaultSystemSolution sol : inputs)
+						accumulator.processContainer(sol, scale);
+					
+					OpenSHA_Module avgModule = accumulator.getAverage();
+					
+					if (avgModule == null)
+						System.err.println("Averaging returned null for "+module.getName()+", skipping");
+					else
+						avgSol.addModule(avgModule);
+				} catch (Exception e) {
+					System.err.println("Error averaging module: "+module.getName());
+					e.printStackTrace();
+					System.err.flush();
+				}
 			}
 		}
 		
 		// TODO average grid source provider
 		
-		if (inputs[0].hasModule(InversionMisfits.class)) {
-			List<InversionMisfits> misfits = new ArrayList<>();
-			
-			System.out.println("Trying to average misfits...");
-			for (FaultSystemSolution sol : inputs) {
-				InversionMisfits misfit = sol.getModule(InversionMisfits.class);
-				if (misfit == null || misfits.size() > 0 && !misfit.getConstraintRanges().equals(misfits.get(0).getConstraintRanges())) {
-					misfits = null;
-					System.out.println("Can't average misfits!");
-					break;
-				}
-				misfits.add(misfit);
-			}
-			
-			if (misfits != null)
-				avgSol.addModule(InversionMisfits.average(misfits));
-		}
-		
-		if (inputs[0].hasModule(AnnealingProgress.class)) {
-			List<AnnealingProgress> progresses = new ArrayList<>();
-
-			System.out.println("Trying to average misfits...");
-			for (FaultSystemSolution sol : inputs) {
-				AnnealingProgress progress = sol.getModule(AnnealingProgress.class);
-				if (progress == null || progresses.size() > 0 && !progress.getEnergyTypes().equals(progresses.get(0).getEnergyTypes())) {
-					progresses = null;
-					System.out.println("Can't average progress!");
-					break;
-				}
-				progresses.add(progress);
-			}
-			
-			if (progresses != null)
-				avgSol.addModule(AnnealingProgress.average(progresses));
-		}
-		
-		if (inputs[0].hasModule(WaterLevelRates.class)) {
-			WaterLevelRates wl = inputs[0].getModule(WaterLevelRates.class);
-			for (int i=1; i<inputs.length; i++) {
-				if (!inputs[i].hasModule(WaterLevelRates.class)) {
-					wl = null;
-					break;
-				}
-				WaterLevelRates oWL = inputs[i].getModule(WaterLevelRates.class);
-				if (!equivalent(wl.get(), oWL.get())) {
-					wl = null;
-					break;
-				}
-			}
-			if (wl != null)
-				avgSol.addModule(wl);
-		}
-		
-		if (inputs[0].hasModule(InitialSolution.class)) {
-			InitialSolution initial = inputs[0].getModule(InitialSolution.class);
-			for (int i=1; i<inputs.length; i++) {
-				if (!inputs[i].hasModule(InitialSolution.class)) {
-					initial = null;
-					break;
-				}
-				InitialSolution oInitial = inputs[i].getModule(InitialSolution.class);
-				if (!equivalent(initial.get(), oInitial.get())) {
-					initial = null;
-					break;
-				}
-			}
-			if (initial != null)
-				avgSol.addModule(initial);
-		}
-		
+		// special case, see if inversion config is the same for each, and if so attach to final
 		if (inputs[0].hasModule(InversionConfiguration.class)) {
 			InversionConfiguration config = inputs[0].getModule(InversionConfiguration.class);
 			for (int i=1; i<inputs.length; i++) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
@@ -110,13 +110,15 @@ public class BranchAverageSolutionCreator {
 			
 			// initialize accumulators
 			rupSetAvgAccumulators = new ArrayList<>();
-			for (OpenSHA_Module module : rupSet.getModules())
-				if (module instanceof BranchAverageableModule<?>)
-					rupSetAvgAccumulators.add(((BranchAverageableModule<?>)module).averagingAccumulator());
+			for (OpenSHA_Module module : rupSet.getModulesAssignableTo(BranchAverageableModule.class, true)) {
+				Preconditions.checkState(module instanceof BranchAverageableModule<?>);
+				rupSetAvgAccumulators.add(((BranchAverageableModule<?>)module).averagingAccumulator());
+			}
 			solAvgAccumulators = new ArrayList<>();
-			for (OpenSHA_Module module : sol.getModules())
-				if (module instanceof BranchAverageableModule<?>)
-					solAvgAccumulators.add(((BranchAverageableModule<?>)module).averagingAccumulator());
+			for (OpenSHA_Module module : sol.getModulesAssignableTo(BranchAverageableModule.class, true)) {
+				Preconditions.checkState(module instanceof BranchAverageableModule<?>);
+				solAvgAccumulators.add(((BranchAverageableModule<?>)module).averagingAccumulator());
+			}
 			
 			combBranch = (LogicTreeBranch<LogicTreeNode>)branch.copy();
 			sectIndices = rupSet.getSectionIndicesForAllRups();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
@@ -1,0 +1,649 @@
+package org.opensha.sha.earthquake.faultSysSolution.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.dom4j.Element;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.geo.GriddedRegion;
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.logicTree.LogicTreeBranch;
+import org.opensha.commons.logicTree.LogicTreeLevel;
+import org.opensha.commons.logicTree.LogicTreeNode;
+import org.opensha.commons.util.FaultUtils;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.UncertainDataConstraint.SectMappedUncertainDataConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.modules.AveSlipModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.GridSourceProvider;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InfoModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.NamedFaults;
+import org.opensha.sha.earthquake.faultSysSolution.modules.PaleoseismicConstraintData;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RupMFDsModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SubSeismoOnFaultMFDs;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.faultSurface.FaultTrace;
+import org.opensha.sha.faultSurface.GeoJSONFaultSection;
+import org.opensha.sha.faultSurface.RuptureSurface;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import com.google.common.base.Preconditions;
+
+import scratch.UCERF3.enumTreeBranches.DeformationModels;
+import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
+import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
+import scratch.UCERF3.griddedSeismicity.AbstractGridSourceProvider;
+
+/**
+ * Utility for building branch averaged solutions
+ * 
+ * @author kevin
+ *
+ */
+public class BranchAverageSolutionCreator {
+	
+	private double totWeight = 0d; 
+	private double[] avgRates = null;
+	private double[] avgMags = null;
+	private double[] avgAreas = null;
+	private double[] avgLengths = null;
+	private double[] avgSlips = null;
+	private List<List<Double>> avgRakes = null;
+	private List<List<Integer>> sectIndices = null;
+	private List<DiscretizedFunc> rupMFDs = null;
+	
+	private FaultSystemRupSet refRupSet = null;
+	private double[] avgSectAseis = null;
+	private double[] avgSectCoupling = null;
+	private double[] avgSectSlipRates = null;
+	private double[] avgSectSlipRateStdDevs = null;
+	private List<List<Double>> avgSectRakes = null;
+	
+	// related to gridded seismicity
+	private GridSourceProvider refGridProv = null;
+	private GriddedRegion gridReg = null;
+	private Map<Integer, IncrementalMagFreqDist> nodeSubSeisMFDs = null;
+	private Map<Integer, IncrementalMagFreqDist> nodeUnassociatedMFDs = null;
+	private List<IncrementalMagFreqDist> sectSubSeisMFDs = null;
+	
+//	private List<? extends LogicTreeBranch<?>> branches = getLogicTree().getBranches();
+	
+	private LogicTreeBranch<LogicTreeNode> combBranch = null;
+	
+	private List<Double> weights = new ArrayList<>();
+	
+	private PaleoseismicConstraintData paleoData = null;
+	
+	private NamedFaults namedFaults = null;
+	
+	private Map<LogicTreeNode, Integer> nodeCounts = new HashMap<>();
+	
+	public BranchAverageSolutionCreator() {
+		
+	}
+	
+	public void addSolution(FaultSystemSolution sol, LogicTreeBranch<?> branch) {
+		double weight = branch.getBranchWeight();
+		weights.add(weight);
+		totWeight += weight;
+		FaultSystemRupSet rupSet = sol.getRupSet();
+		GridSourceProvider gridProv = sol.getGridSourceProvider();
+		SubSeismoOnFaultMFDs ssMFDs = sol.getModule(SubSeismoOnFaultMFDs.class);
+		
+		if (avgRates == null) {
+			// first time
+			avgRates = new double[rupSet.getNumRuptures()];
+			avgMags = new double[avgRates.length];
+			avgAreas = new double[avgRates.length];
+			avgLengths = new double[avgRates.length];
+			avgRakes = new ArrayList<>();
+			for (int r=0; r<rupSet.getNumRuptures(); r++)
+				avgRakes.add(new ArrayList<>());
+			
+			refRupSet = rupSet;
+			
+			avgSectAseis = new double[rupSet.getNumSections()];
+			avgSectSlipRates = new double[rupSet.getNumSections()];
+			avgSectSlipRateStdDevs = new double[rupSet.getNumSections()];
+			avgSectCoupling = new double[rupSet.getNumSections()];
+			avgSectRakes = new ArrayList<>();
+			for (int s=0; s<rupSet.getNumSections(); s++)
+				avgSectRakes.add(new ArrayList<>());
+			
+			if (gridProv != null) {
+				refGridProv = gridProv;
+				gridReg = gridProv.getGriddedRegion();
+				nodeSubSeisMFDs = new HashMap<>();
+				nodeUnassociatedMFDs = new HashMap<>();
+			}
+			
+			if (ssMFDs != null) {
+				sectSubSeisMFDs = new ArrayList<>();
+				for (int s=0; s<rupSet.getNumSections(); s++)
+					sectSubSeisMFDs.add(null);
+			}
+			
+			if (rupSet.hasModule(AveSlipModule.class))
+				avgSlips = new double[avgRates.length];
+			
+			combBranch = (LogicTreeBranch<LogicTreeNode>)branch.copy();
+			sectIndices = rupSet.getSectionIndicesForAllRups();
+			rupMFDs = new ArrayList<>();
+			for (int r=0; r<avgRates.length; r++)
+				rupMFDs.add(new ArbitrarilyDiscretizedFunc());
+			
+			paleoData = rupSet.getModule(PaleoseismicConstraintData.class);
+			
+			namedFaults = rupSet.getModule(NamedFaults.class);
+		} else {
+			Preconditions.checkState(refRupSet.isEquivalentTo(rupSet), "Rupture sets are not equivalent");
+			if (refGridProv != null)
+				Preconditions.checkNotNull(gridProv, "Some solutions have grid source providers and others don't");
+			
+			if (paleoData != null) {
+				// see if it's the same
+				PaleoseismicConstraintData myPaleoData = rupSet.getModule(PaleoseismicConstraintData.class);
+				if (myPaleoData != null) {
+					boolean same = paleoConstraintsSame(paleoData.getPaleoRateConstraints(),
+							myPaleoData.getPaleoRateConstraints());
+					same = same && paleoConstraintsSame(paleoData.getPaleoSlipConstraints(),
+							myPaleoData.getPaleoSlipConstraints());
+					if (same && paleoData.getPaleoProbModel() != null)
+						same = paleoData.getPaleoProbModel().getClass().equals(myPaleoData.getPaleoProbModel().getClass());
+					if (same && paleoData.getPaleoSlipProbModel() != null)
+						same = paleoData.getPaleoSlipProbModel().getClass().equals(myPaleoData.getPaleoSlipProbModel().getClass());
+					if (!same)
+						paleoData = null;
+				} else {
+					// not all branches have it
+					paleoData = null;
+				}
+			}
+		}
+		
+		for (int i=0; i<combBranch.size(); i++) {
+			LogicTreeNode combVal = combBranch.getValue(i);
+			LogicTreeNode branchVal = branch.getValue(i);
+			if (combVal != null && !combVal.equals(branchVal))
+				combBranch.clearValue(i);
+			int prevCount = nodeCounts.containsKey(branchVal) ? nodeCounts.get(branchVal) : 0;
+			nodeCounts.put(branchVal, prevCount+1);
+		}
+		
+		AveSlipModule slipModule = rupSet.getModule(AveSlipModule.class);
+		if (avgSlips != null)
+			Preconditions.checkNotNull(slipModule);
+		addWeighted(avgRates, sol.getRateForAllRups(), weight);
+		for (int r=0; r<avgRates.length; r++) {
+			double rate = sol.getRateForRup(r);
+			double mag = rupSet.getMagForRup(r);
+			DiscretizedFunc rupMFD = rupMFDs.get(r);
+			double y = rate*weight;
+			if (rupMFD.hasX(mag))
+				y += rupMFD.getY(mag);
+			rupMFD.set(mag, y);
+			avgRakes.get(r).add(rupSet.getAveRakeForRup(r));
+			
+			if (avgSlips != null)
+				avgSlips[r] += weight*slipModule.getAveSlip(r);
+		}
+		addWeighted(avgMags, rupSet.getMagForAllRups(), weight);
+		addWeighted(avgAreas, rupSet.getAreaForAllRups(), weight);
+		addWeighted(avgLengths, rupSet.getLengthForAllRups(), weight);
+		
+		for (int s=0; s<rupSet.getNumSections(); s++) {
+			FaultSection sect = rupSet.getFaultSectionData(s);
+			avgSectAseis[s] += sect.getAseismicSlipFactor()*weight;
+			avgSectSlipRates[s] += sect.getOrigAveSlipRate()*weight;
+			avgSectSlipRateStdDevs[s] += sect.getOrigSlipRateStdDev()*weight;
+			avgSectCoupling[s] += sect.getCouplingCoeff()*weight;
+			avgSectRakes.get(s).add(sect.getAveRake());
+		}
+		
+		if (gridProv != null) {
+			Preconditions.checkNotNull(refGridProv, "Some solutions have grid source providers and others don't");
+			for (int i=0; i<gridReg.getNodeCount(); i++) {
+				addWeighted(nodeSubSeisMFDs, i, gridProv.getNodeSubSeisMFD(i), weight);
+				addWeighted(nodeUnassociatedMFDs, i, gridProv.getNodeUnassociatedMFD(i), weight);
+			}
+		}
+		if (ssMFDs == null) {
+			Preconditions.checkState(sectSubSeisMFDs == null, "Some solutions have sub seismo MFDs and others don't");
+		} else {
+			Preconditions.checkNotNull(sectSubSeisMFDs, "Some solutions have sub seismo MFDs and others don't");
+			for (int s=0; s<rupSet.getNumSections(); s++) {
+				IncrementalMagFreqDist subSeisMFD = ssMFDs.get(s);
+				Preconditions.checkNotNull(subSeisMFD);
+				IncrementalMagFreqDist avgMFD = sectSubSeisMFDs.get(s);
+				if (avgMFD == null) {
+					avgMFD = new IncrementalMagFreqDist(subSeisMFD.getMinX(), subSeisMFD.getMaxX(), subSeisMFD.size());
+					sectSubSeisMFDs.set(s, avgMFD);
+				}
+				addWeighted(avgMFD, subSeisMFD, weight);
+			}
+		}
+	}
+	
+	public FaultSystemSolution build() {
+		Preconditions.checkState(!weights.isEmpty(), "No solutions added!");
+		Preconditions.checkState(totWeight > 0, "Total weight is not positive: %s", totWeight);
+		
+		System.out.println("Common branches: "+combBranch);
+//		if (!combBranch.hasValue(DeformationModels.class))
+//			combBranch.setValue(DeformationModels.MEAN_UCERF3);
+//		if (!combBranch.hasValue(ScalingRelationships.class))
+//			combBranch.setValue(ScalingRelationships.MEAN_UCERF3);
+//		if (!combBranch.hasValue(SlipAlongRuptureModels.class))
+//			combBranch.setValue(SlipAlongRuptureModels.MEAN_UCERF3);
+		
+		// now scale by total weight
+		System.out.println("Normalizing by total weight: "+totWeight);
+		double[] rakes = new double[avgRates.length];
+		for (int r=0; r<avgRates.length; r++) {
+			avgRates[r] /= totWeight;
+			avgMags[r] /= totWeight;
+			avgAreas[r] /= totWeight;
+			avgLengths[r] /= totWeight;
+			DiscretizedFunc rupMFD = rupMFDs.get(r);
+			rupMFD.scale(1d/totWeight);
+			Preconditions.checkState((float)rupMFD.calcSumOfY_Vals() == (float)avgRates[r]);
+			rakes[r] = FaultUtils.getInRakeRange(FaultUtils.getScaledAngleAverage(avgRakes.get(r), weights));
+			if (avgSlips != null)
+				avgSlips[r] /= totWeight;
+		}
+		
+		GridSourceProvider combGridProv = null;
+		if (refGridProv != null) {
+			double[] fractSS = new double[refGridProv.size()];
+			double[] fractR = new double[fractSS.length];
+			double[] fractN = new double[fractSS.length];
+			for (int i=0; i<fractSS.length; i++) {
+				IncrementalMagFreqDist subSeisMFD = nodeSubSeisMFDs.get(i);
+				if (subSeisMFD != null)
+					subSeisMFD.scale(1d/totWeight);
+				IncrementalMagFreqDist nodeUnassociatedMFD = nodeUnassociatedMFDs.get(i);
+				if (nodeUnassociatedMFD != null)
+					nodeUnassociatedMFD.scale(1d/totWeight);
+				fractSS[i] = refGridProv.getFracStrikeSlip(i);
+				fractR[i] = refGridProv.getFracReverse(i);
+				fractN[i] = refGridProv.getFracNormal(i);
+			}
+			
+			
+			combGridProv = new AbstractGridSourceProvider.Precomputed(refGridProv.getGriddedRegion(),
+					nodeSubSeisMFDs, nodeUnassociatedMFDs, fractSS, fractN, fractR);
+		}
+		if (sectSubSeisMFDs != null)
+			for (int s=0; s<sectSubSeisMFDs.size(); s++)
+				sectSubSeisMFDs.get(s).scale(1d/totWeight);
+		
+		List<FaultSection> subSects = new ArrayList<>();
+		for (int s=0; s<refRupSet.getNumSections(); s++) {
+			FaultSection refSect = refRupSet.getFaultSectionData(s);
+			
+			avgSectAseis[s] /= totWeight;
+			avgSectCoupling[s] /= totWeight;
+			avgSectSlipRates[s] /= totWeight;
+			avgSectSlipRateStdDevs[s] /= totWeight;
+			double avgRake = FaultUtils.getInRakeRange(FaultUtils.getScaledAngleAverage(avgSectRakes.get(s), weights));
+			
+			GeoJSONFaultSection avgSect = new GeoJSONFaultSection(new AvgFaultSection(refSect, avgSectAseis[s],
+					avgSectCoupling[s], avgRake, avgSectSlipRates[s], avgSectSlipRateStdDevs[s]));
+			subSects.add(avgSect);
+		}
+		
+//		FaultSystemRupSet avgRupSet = FaultSystemRupSet.builder(subSects, sectIndices).forU3Branch(combBranch).rupMags(avgMags).build();
+//		// remove these as they're not correct for branch-averaged
+//		avgRupSet.removeModuleInstances(InversionTargetMFDs.class);
+//		avgRupSet.removeModuleInstances(SectSlipRates.class);
+		FaultSystemRupSet avgRupSet = FaultSystemRupSet.builder(subSects, sectIndices).rupRakes(rakes)
+				.rupAreas(avgAreas).rupLengths(avgLengths).rupMags(avgMags).build();
+		int numNonNull = 0;
+		boolean haveSlipAlong = false;
+		for (int i=0; i<combBranch.size(); i++) {
+			LogicTreeNode value = combBranch.getValue(i);
+			if (value != null) {
+				numNonNull++;
+				if (value instanceof SlipAlongRuptureModel) {
+					avgRupSet.addModule((SlipAlongRuptureModel)value);
+					haveSlipAlong = true;
+				} else if (value instanceof SlipAlongRuptureModels) {
+					avgRupSet.addModule(((SlipAlongRuptureModels)value).getModel());
+					haveSlipAlong = true;
+				}
+			}
+		}
+		// special cases for UCERF3 branches
+		if (!haveSlipAlong && hasAllEqually(nodeCounts, SlipAlongRuptureModels.UNIFORM, SlipAlongRuptureModels.TAPERED)) {
+			combBranch.setValue(SlipAlongRuptureModels.MEAN_UCERF3);
+			avgRupSet.addModule(SlipAlongRuptureModels.MEAN_UCERF3.getModel());
+			numNonNull++;
+		}
+		if (combBranch.getValue(ScalingRelationships.class) == null && hasAllEqually(nodeCounts, ScalingRelationships.ELLB_SQRT_LENGTH,
+				ScalingRelationships.ELLSWORTH_B, ScalingRelationships.HANKS_BAKUN_08,
+				ScalingRelationships.SHAW_2009_MOD, ScalingRelationships.SHAW_CONST_STRESS_DROP)) {
+			combBranch.setValue(ScalingRelationships.MEAN_UCERF3);
+			if (avgSlips == null)
+				avgRupSet.addModule(AveSlipModule.forModel(avgRupSet, ScalingRelationships.MEAN_UCERF3));
+			numNonNull++;
+		}
+		if (combBranch.getValue(DeformationModels.class) == null && hasAllEqually(nodeCounts, DeformationModels.GEOLOGIC,
+				DeformationModels.ABM, DeformationModels.NEOKINEMA, DeformationModels.ZENGBB)) {
+			combBranch.setValue(DeformationModels.MEAN_UCERF3);
+			numNonNull++;
+		}
+		
+		if (numNonNull > 0) {
+			avgRupSet.addModule(combBranch);
+			System.out.println("Combined logic tre branch: "+combBranch);
+		}
+		if (avgSlips != null)
+			avgRupSet.addModule(AveSlipModule.precomputed(avgRupSet, avgSlips));
+		if (paleoData != null)
+			avgRupSet.addModule(paleoData);
+		if (namedFaults != null)
+			avgRupSet.addModule(namedFaults);
+		
+		FaultSystemSolution sol = new FaultSystemSolution(avgRupSet, avgRates);
+		sol.addModule(combBranch);
+		if (combGridProv != null)
+			sol.setGridSourceProvider(combGridProv);
+		if (sectSubSeisMFDs != null)
+			sol.addModule(new SubSeismoOnFaultMFDs(sectSubSeisMFDs));
+		sol.addModule(new RupMFDsModule(sol, rupMFDs.toArray(new DiscretizedFunc[0])));
+		
+		String info = "Branch Averaged Fault System Solution, across "+weights.size()
+				+" branches with a total weight of "+totWeight+"."
+				+"\n\nThe utilized branches at each level are (counts in parenthesis):"
+				+ "\n\n";
+		for (int i=0; i<combBranch.size(); i++) {
+			LogicTreeLevel<? extends LogicTreeNode> level = combBranch.getLevel(i);
+			info += level.getName()+":\n";
+			for (LogicTreeNode choice : level.getNodes()) {
+				Integer count = nodeCounts.get(choice);
+				if (count != null)
+					info += "\t"+choice.getName()+" ("+count+")\n";
+			}
+		}
+		
+		sol.addModule(new InfoModule(info));
+		return sol;
+	}
+	
+	private boolean hasAllEqually(Map<LogicTreeNode, Integer> nodeCounts, LogicTreeNode... nodes) {
+		Integer commonCount = null;
+		for (LogicTreeNode node : nodes) {
+			Integer count = nodeCounts.get(node);
+			if (count == null)
+				return false;
+			if (commonCount == null)
+				commonCount = count;
+			else if (commonCount.intValue() != count.intValue())
+				return false;
+		}
+		return true;
+	}
+	
+	private static boolean paleoConstraintsSame(List<? extends SectMappedUncertainDataConstraint> constr1,
+			List<? extends SectMappedUncertainDataConstraint> constr2) {
+		if ((constr1 == null) != (constr2 == null))
+			return false;
+		if (constr1 == null && constr2 == null)
+			return true;
+		if (constr1.size() != constr2.size())
+			return false;
+		for (int i=0; i<constr1.size(); i++) {
+			SectMappedUncertainDataConstraint c1 = constr1.get(i);
+			SectMappedUncertainDataConstraint c2 = constr2.get(i);
+			if (c1.sectionIndex != c2.sectionIndex)
+				return false;
+			if ((float)c1.bestEstimate != (float)c2.bestEstimate)
+				return false;
+		}
+		return true;
+	}
+	
+	private class AvgFaultSection implements FaultSection {
+		
+		private FaultSection refSect;
+		private double avgAseis;
+		private double avgCoupling;
+		private double avgRake;
+		private double avgSlip;
+		private double avgSlipStdDev;
+
+		public AvgFaultSection(FaultSection refSect, double avgAseis, double avgCoupling, double avgRake, double avgSlip, double avgSlipStdDev) {
+			this.refSect = refSect;
+			this.avgAseis = avgAseis;
+			this.avgCoupling = avgCoupling;
+			this.avgRake = avgRake;
+			this.avgSlip = avgSlip;
+			this.avgSlipStdDev = avgSlipStdDev;
+		}
+
+		@Override
+		public String getName() {
+			return refSect.getName();
+		}
+
+		@Override
+		public Element toXMLMetadata(Element root) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public long getDateOfLastEvent() {
+			return refSect.getDateOfLastEvent();
+		}
+
+		@Override
+		public void setDateOfLastEvent(long dateOfLastEventMillis) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void setSlipInLastEvent(double slipInLastEvent) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getSlipInLastEvent() {
+			return refSect.getSlipInLastEvent();
+		}
+
+		@Override
+		public double getAseismicSlipFactor() {
+			if ((float)avgCoupling == 0f)
+				return 0d;
+			return avgAseis;
+		}
+
+		@Override
+		public void setAseismicSlipFactor(double aseismicSlipFactor) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getCouplingCoeff() {
+			if ((float)avgCoupling == 1f)
+				return 1d;
+			return avgCoupling;
+		}
+
+		@Override
+		public void setCouplingCoeff(double couplingCoeff) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getAveDip() {
+			return refSect.getAveDip();
+		}
+
+		@Override
+		public double getOrigAveSlipRate() {
+			return avgSlip;
+		}
+
+		@Override
+		public void setAveSlipRate(double aveLongTermSlipRate) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getAveLowerDepth() {
+			return refSect.getAveLowerDepth();
+		}
+
+		@Override
+		public double getAveRake() {
+			return avgRake;
+		}
+
+		@Override
+		public void setAveRake(double aveRake) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getOrigAveUpperDepth() {
+			return refSect.getOrigAveUpperDepth();
+		}
+
+		@Override
+		public float getDipDirection() {
+			return refSect.getDipDirection();
+		}
+
+		@Override
+		public FaultTrace getFaultTrace() {
+			return refSect.getFaultTrace();
+		}
+
+		@Override
+		public int getSectionId() {
+			return refSect.getSectionId();
+		}
+
+		@Override
+		public void setSectionId(int sectID) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public void setSectionName(String sectName) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public int getParentSectionId() {
+			return refSect.getParentSectionId();
+		}
+
+		@Override
+		public void setParentSectionId(int parentSectionId) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public String getParentSectionName() {
+			return refSect.getParentSectionName();
+		}
+
+		@Override
+		public void setParentSectionName(String parentSectionName) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public List<? extends FaultSection> getSubSectionsList(double maxSubSectionLen, int startId,
+				int minSubSections) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public double getOrigSlipRateStdDev() {
+			return avgSlipStdDev;
+		}
+
+		@Override
+		public void setSlipRateStdDev(double slipRateStdDev) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean isConnector() {
+			return refSect.isConnector();
+		}
+
+		@Override
+		public Region getZonePolygon() {
+			return refSect.getZonePolygon();
+		}
+
+		@Override
+		public void setZonePolygon(Region zonePolygon) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public Element toXMLMetadata(Element root, String name) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public RuptureSurface getFaultSurface(double gridSpacing) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public RuptureSurface getFaultSurface(double gridSpacing, boolean preserveGridSpacingExactly,
+				boolean aseisReducesArea) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public FaultSection clone() {
+			throw new UnsupportedOperationException();
+		}
+		
+	}
+	
+	public static void addWeighted(Map<Integer, IncrementalMagFreqDist> mfdMap, int index,
+			IncrementalMagFreqDist newMFD, double weight) {
+		if (newMFD == null)
+			// simple case
+			return;
+		IncrementalMagFreqDist runningMFD = mfdMap.get(index);
+		if (runningMFD == null) {
+			runningMFD = new IncrementalMagFreqDist(newMFD.getMinX(), newMFD.size(), newMFD.getDelta());
+			mfdMap.put(index, runningMFD);
+		}
+		addWeighted(runningMFD, newMFD, weight);
+	}
+	
+	public static void addWeighted(IncrementalMagFreqDist runningMFD,
+			IncrementalMagFreqDist newMFD, double weight) {
+		Preconditions.checkState(runningMFD.size() == newMFD.size(), "MFD sizes inconsistent");
+		Preconditions.checkState((float)runningMFD.getMinX() == (float)newMFD.getMinX(), "MFD min x inconsistent");
+		Preconditions.checkState((float)runningMFD.getDelta() == (float)newMFD.getDelta(), "MFD delta inconsistent");
+		for (int i=0; i<runningMFD.size(); i++)
+			runningMFD.add(i, newMFD.getY(i)*weight);
+	}
+	
+	private static void addWeighted(double[] running, double[] vals, double weight) {
+		Preconditions.checkState(running.length == vals.length);
+		for (int i=0; i<running.length; i++)
+			running[i] += vals[i]*weight;
+	}
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
@@ -410,6 +410,8 @@ public class SolHazardMapCalc {
 			double min = Double.POSITIVE_INFINITY;
 			double max = Double.NEGATIVE_INFINITY;
 			int exactly0 = 0;
+			int numBelow = 0;
+			int numAbove = 0;
 			int numWithin1 = 0;
 			int numWithin5 = 0;
 			int numWithin10 = 0;
@@ -428,12 +430,18 @@ public class SolHazardMapCalc {
 					numWithin5++;
 				if (val >= -10d && val <= 10d)
 					numWithin10++;
+				if ((float)val < 0f)
+					numBelow++;
+				if ((float)val > 0f)
+					numAbove++;
 			}
 			
 			List<String> labels = new ArrayList<>();
 			labels.add("Range: ["+oDF.format(min)+"%,"+oDF.format(max)+"%]");
 			if (exactly0 >= xyz.size()/2)
 				labels.add("Exactly 0%: "+percentDF.format((double)exactly0/(double)xyz.size()));
+			labels.add(percentDF.format((double)numBelow/(double)xyz.size())
+					+" < 0, "+percentDF.format((double)numAbove/(double)xyz.size())+" > 0");
 			labels.add("Within 1%: "+percentDF.format((double)numWithin1/(double)xyz.size()));
 			labels.add("Within 5%: "+percentDF.format((double)numWithin5/(double)xyz.size()));
 			labels.add("Within 10%: "+percentDF.format((double)numWithin10/(double)xyz.size()));

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
@@ -244,7 +244,7 @@ public class SolHazardMapCalc {
 	}
 	
 	protected static DecimalFormat percentDF = new DecimalFormat("0.00%");
-	
+	protected static DecimalFormat twoDigitsDF = new DecimalFormat("0.00");
 	protected static DecimalFormat oDF = new DecimalFormat("0.#");
 	
 	private class CalcThread extends Thread {
@@ -415,6 +415,8 @@ public class SolHazardMapCalc {
 			int numWithin1 = 0;
 			int numWithin5 = 0;
 			int numWithin10 = 0;
+			double mean = 0d;
+			double meanAbs = 0d;
 			
 			for (int i=0; i<xyz.size(); i++) {
 				double val = xyz.get(i);
@@ -434,10 +436,17 @@ public class SolHazardMapCalc {
 					numBelow++;
 				if ((float)val > 0f)
 					numAbove++;
+				if (Double.isFinite(val)) {
+					mean += val;
+					meanAbs += Math.abs(val);
+				}
 			}
+			mean /= (double)xyz.size();
+			meanAbs /= (double)xyz.size();
 			
 			List<String> labels = new ArrayList<>();
 			labels.add("Range: ["+oDF.format(min)+"%,"+oDF.format(max)+"%]");
+			labels.add("Mean: "+twoDigitsDF.format(mean)+"%, Abs: "+twoDigitsDF.format(meanAbs)+"%");
 			if (exactly0 >= xyz.size()/2)
 				labels.add("Exactly 0%: "+percentDF.format((double)exactly0/(double)xyz.size()));
 			labels.add(percentDF.format((double)numBelow/(double)xyz.size())

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/DeformationModels.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/DeformationModels.java
@@ -8,9 +8,12 @@ import java.util.Collections;
 import java.util.List;
 
 import org.dom4j.Document;
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
 import org.opensha.commons.util.ExceptionUtils;
 import org.opensha.commons.util.XMLUtils;
-import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
@@ -21,6 +24,10 @@ import scratch.UCERF3.utils.DeformationModelFetcher;
 import scratch.UCERF3.utils.U3FaultSystemIO;
 import scratch.UCERF3.utils.UCERF3_DataUtils;
 
+@Affects(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@Affects(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum DeformationModels implements U3LogicTreeBranchNode<DeformationModels> {
 	
 	//						Name					ShortName	Weight	FaultModel			File

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/FaultModels.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/FaultModels.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.dom4j.Document;
 import org.dom4j.DocumentException;
 import org.dom4j.Element;
+import org.opensha.commons.logicTree.Affects;
 import org.opensha.commons.util.ExceptionUtils;
 import org.opensha.commons.util.XMLUtils;
 import org.opensha.refFaultParamDb.dao.db.DB_AccessAPI;
@@ -20,6 +21,8 @@ import org.opensha.refFaultParamDb.dao.db.DB_ConnectionPool;
 import org.opensha.refFaultParamDb.dao.db.FaultModelDB_DAO;
 import org.opensha.refFaultParamDb.dao.db.PrefFaultSectionDataDB_DAO;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
@@ -31,6 +34,10 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 import scratch.UCERF3.utils.U3FaultSystemIO;
 import scratch.UCERF3.utils.UCERF3_DataUtils;
 
+@Affects(FaultSystemRupSet.SECTS_FILE_NAME)
+@Affects(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@Affects(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum FaultModels implements U3LogicTreeBranchNode<FaultModels> {
 
 	FM2_1(	"Fault Model 2.1",	41,		0d),

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/InversionModels.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/InversionModels.java
@@ -1,7 +1,16 @@
 package scratch.UCERF3.enumTreeBranches;
 
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+
 import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum InversionModels implements U3LogicTreeBranchNode<InversionModels> {
 	
 	CHAR_CONSTRAINED(	"Characteristic (Constrained)",			"CharConst",	1d),

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/MaxMagOffFault.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/MaxMagOffFault.java
@@ -1,7 +1,16 @@
 package scratch.UCERF3.enumTreeBranches;
 
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+
 import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum MaxMagOffFault implements U3LogicTreeBranchNode<MaxMagOffFault> {
 	
 	MAG_7p3(7.3, 0.1d, 0.1d),

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/MomentRateFixes.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/MomentRateFixes.java
@@ -1,7 +1,16 @@
 package scratch.UCERF3.enumTreeBranches;
 
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+
 import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum MomentRateFixes implements U3LogicTreeBranchNode<MomentRateFixes> {
 	// TODO set weights for GR
 	APPLY_IMPLIED_CC(		"Apply Implied Coupling Coefficient",		"ApplyCC",			0.0d,	0.5d),

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/ScalingRelationships.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/ScalingRelationships.java
@@ -18,6 +18,10 @@ import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.eq.MagUtils;
 import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
 import org.opensha.commons.gui.plot.PlotLineType;
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.RupSetScalingRelationship;
 import org.opensha.commons.gui.plot.GraphWindow;
 
@@ -29,6 +33,10 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
  * @author field
  *
  */
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@Affects(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum ScalingRelationships implements U3LogicTreeBranchNode<ScalingRelationships>, RupSetScalingRelationship {
 		
 	

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/SlipAlongRuptureModels.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/SlipAlongRuptureModels.java
@@ -1,10 +1,17 @@
 package scratch.UCERF3.enumTreeBranches;
 
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
 
 import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum SlipAlongRuptureModels implements U3LogicTreeBranchNode<SlipAlongRuptureModels> {
 	// DO NOT RENAME THESE - they are used in rupture set files
 	

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/SpatialSeisPDF.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/SpatialSeisPDF.java
@@ -7,6 +7,10 @@ import org.opensha.commons.data.region.CaliforniaRegions;
 import org.opensha.commons.data.xyz.GriddedGeoDataSet;
 import org.opensha.commons.geo.GriddedRegion;
 import org.opensha.commons.geo.Location;
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Doubles;
@@ -25,6 +29,10 @@ import scratch.UCERF3.utils.SmoothSeismicitySpatialPDF_Fetcher;
  * @version $Id:$
  */
 @SuppressWarnings("javadoc")
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum SpatialSeisPDF implements U3LogicTreeBranchNode<SpatialSeisPDF> {
 	
 	UCERF2("UCERF2",												"U2",		0.5d,	0.25d) {

--- a/src/main/java/scratch/UCERF3/enumTreeBranches/TotalMag5Rate.java
+++ b/src/main/java/scratch/UCERF3/enumTreeBranches/TotalMag5Rate.java
@@ -1,7 +1,16 @@
 package scratch.UCERF3.enumTreeBranches;
 
+import org.opensha.commons.logicTree.Affects;
+import org.opensha.commons.logicTree.DoesNotAffect;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+
 import scratch.UCERF3.logicTree.U3LogicTreeBranchNode;
 
+@DoesNotAffect(FaultSystemRupSet.SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
+@DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
+@Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum TotalMag5Rate implements U3LogicTreeBranchNode<TotalMag5Rate> {
 	// new rates
 	RATE_6p5(6.5,	0.1d),

--- a/src/main/java/scratch/UCERF3/inversion/U3InversionTargetMFDs.java
+++ b/src/main/java/scratch/UCERF3/inversion/U3InversionTargetMFDs.java
@@ -15,6 +15,7 @@ import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.commons.util.modules.SubModule;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionTargetMFDs;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ModSectMinMags;
 import org.opensha.sha.earthquake.faultSysSolution.modules.PolygonFaultGridAssociations;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SubSeismoOnFaultMFDs;
@@ -643,7 +644,9 @@ public class U3InversionTargetMFDs extends org.opensha.sha.earthquake.faultSysSo
 		return new U3InversionTargetMFDs(newParent, logicTreeBranch, finalMinMags, polygons);
 	}
 
-
-
+	@Override
+	public AveragingAccumulator<InversionTargetMFDs> averagingAccumulator() {
+		return new Precomputed(this).averagingAccumulator();
+	}
 
 }

--- a/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
+++ b/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
@@ -13,7 +13,6 @@ import scratch.UCERF3.enumTreeBranches.InversionModels;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public class TestLogicTreeBranch {
@@ -152,16 +151,6 @@ public class TestLogicTreeBranch {
             public TestAdapterBackedLevel() {
                 super("test adapter backed", "test adapter backed", TestAdapterBackedNode.class);
             }
-
-			@Override
-			protected Collection<String> getAffected() {
-				return List.of();
-			}
-
-			@Override
-			protected Collection<String> getNotAffected() {
-				return List.of();
-			}
         }
     }
 

--- a/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
+++ b/src/test/java/org/opensha/commons/logicTree/TestLogicTreeBranch.java
@@ -13,6 +13,7 @@ import scratch.UCERF3.enumTreeBranches.InversionModels;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class TestLogicTreeBranch {
@@ -151,6 +152,16 @@ public class TestLogicTreeBranch {
             public TestAdapterBackedLevel() {
                 super("test adapter backed", "test adapter backed", TestAdapterBackedNode.class);
             }
+
+			@Override
+			protected Collection<String> getAffected() {
+				return List.of();
+			}
+
+			@Override
+			protected Collection<String> getNotAffected() {
+				return List.of();
+			}
         }
     }
 

--- a/src/test/java/org/opensha/commons/util/modules/ModuleContainerTest.java
+++ b/src/test/java/org/opensha/commons/util/modules/ModuleContainerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 
 import org.junit.Test;
+import org.opensha.commons.data.Named;
 
 import com.google.common.base.Preconditions;
 
@@ -179,6 +180,50 @@ public class ModuleContainerTest {
 		assertTrue("Module should still have C", containsInstance(container, Module_C.class));
 
 		System.out.println("*** END testAddMultipleSameHelper() ***");
+	}
+	
+	@Test
+	public void testGetAssignableTo() {
+		System.out.println("*** testGetAssignableTo() ***");
+		System.out.println("Testing that we can fetch modules by classes they are assignable to");
+		ModuleContainer<OpenSHA_Module> container = new ModuleContainer<>();
+		
+		Module_A aInst = new Module_A_B(); // does not implement Helper
+		
+		Module_C cInst = new Module_C(); // does implement Helper
+		
+		Module_D dInst = new Module_D(); // does implement Helper
+		
+		container.addModule(aInst);
+		
+		assertEquals("Shouldn't have any modules assignable to Helper class yet",
+				container.getModulesAssignableTo(Helper.class, false).size(), 0);
+		
+		container.addModule(cInst);
+		
+		assertEquals("Should have 1 module assignable to Helper class",
+				container.getModulesAssignableTo(Helper.class, false).size(), 1);
+		
+		// now add d as an available module
+		
+		container.addAvailableModule(new Loader<>(dInst), Module_D.class);
+		
+		// should still be 1 if we don't tell it to load available
+		assertEquals("Should have 1 module assignable to Helper class",
+				container.getModulesAssignableTo(Helper.class, false).size(), 1);
+		
+		// should now be 2
+		assertEquals("Should have 2 modules assignable to Helper class",
+				container.getModulesAssignableTo(Helper.class, true).size(), 2);
+		
+		// should still be 2 even if we don't load available now
+		assertEquals("Should have 2 modules assignable to Helper class",
+				container.getModulesAssignableTo(Helper.class, false).size(), 2);
+		
+		assertEquals("All modules should be assignable to Named",
+				container.getModulesAssignableTo(Named.class, true).size(), container.getModules().size());
+
+		System.out.println("*** END testGetAssignableTo() ***");
 	}
 	
 	/**

--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/InversionConstraintImplTests.java
@@ -352,15 +352,15 @@ public class InversionConstraintImplTests {
 	public void testSlipSegmentation() throws IOException {
 		SegmentationModel segModel = new SlipRateSegmentationConstraint.Shaw07JumpDistSegModel(1d, 3d);
 		SlipRateSegmentationConstraint constr = new SlipRateSegmentationConstraint(
-				rupSet, segModel, RateCombiner.MIN, 1d, false, false, false);
+				rupSet, segModel, RateCombiner.MIN, 1d, false, false);
 		
 		testConstraint(constr);
 		
-		constr = new SlipRateSegmentationConstraint(rupSet, segModel, RateCombiner.MIN, 1d, true, false, false);
+		constr = new SlipRateSegmentationConstraint(rupSet, segModel, RateCombiner.MIN, 1d, true, false);
 		
 		testConstraint(constr);
 		
-		constr = new SlipRateSegmentationConstraint(rupSet, segModel, RateCombiner.MIN, 1d, true, false, true);
+		constr = new SlipRateSegmentationConstraint(rupSet, segModel, RateCombiner.MIN, 1d, true, false, true, true);
 		
 		testConstraint(constr);
 	}


### PR DESCRIPTION
Refactor of `org.opensha.sha.earthquake.faultSysSolution.modules.SolutionLogicTree` to figure out what files are affected by each level of a logic tree automatically.

LogicTreeLevel's can now specify things they affect, and things they don't affect. This is done via `@Affects("file_name.ext")` and `@DoesNotEffect("file_name.ext")` annotations on enum logic tree classes, or by overriding relevant methods in custom LogicTreeLevel implementations. So, for example, when deciding if a given level affects rupture/section mappings, the code will ask each level if they affect `indices.csv`, the file that contains that information in a FaultSystemRupSet.

Note: LogicTreeLevel JSON serialization now explicitly includes these mappings, and the old version of the Adapter will throw an exception if it encounters these new fields.

Averaging of modules is now also delegated to the modules themselves rather than being hardcoded. Anything that implements `AverageableModule` will be automatically averaged in any straight solution averaging operation, and anything that implements BranchAverageableModule will be automatically averaged in any branch-averaging operation.