### PR TITLE
revert renaming of RateDistributionPlot plots

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/RateDistributionPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/RateDistributionPlot.java
@@ -235,13 +235,13 @@ public class RateDistributionPlot extends AbstractSolutionPlot {
 		}
 		
 		if (compSol == null)
-			SimulatedAnnealing.writeRateVsRankPlot(resourcesDir, "rate_dist", ratesNoMin, rates, initial);
+			SimulatedAnnealing.writeRateVsRankPlot(resourcesDir, "sa_progress_rate_dist", ratesNoMin, rates, initial);
 		else
-			SimulatedAnnealing.writeRateVsRankPlot(resourcesDir, "rate_dist", ratesNoMin, rates, initial,
+			SimulatedAnnealing.writeRateVsRankPlot(resourcesDir, "sa_progress_rate_dist", ratesNoMin, rates, initial,
 					crates, cratesNoMin);
-		lines.add("![Rate Distribution]("+relPathToResources+"/rate_dist.png)");
+		lines.add("![Rate Distribution]("+relPathToResources+"/sa_progress_rate_dist.png)");
 		lines.add("");
-		lines.add("![Cumulative Rate Distribution]("+relPathToResources+"/rate_dist_cumulative.png)");
+		lines.add("![Cumulative Rate Distribution]("+relPathToResources+"/sa_progress_rate_dist_cumulative.png)");
 		
 		if (compSol == null)
 			return lines;


### PR DESCRIPTION
RateDistributionPlot plots were renamed in 0b95517fb170b1a80aecca74f33d47d8787f586e causing problems at our end. We've got a web app that displays plots etc to the scientists and renaming plots makes things tricky.