### PR TITLE
Significant simulated annealing efficiency improvements

### DIFF
--- a/src/main/java/org/opensha/commons/hpc/pbs/USC_HPCC_ScriptWriter.java
+++ b/src/main/java/org/opensha/commons/hpc/pbs/USC_HPCC_ScriptWriter.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-
+@Deprecated
 public class USC_HPCC_ScriptWriter extends BatchScriptWriter {
 	
 //	public static final File MPJ_HOME = new File("/home/rcf-12/kmilner/mpj-v0_38");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -1162,7 +1162,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 					p = new CalcProgressBar("Calculating Ruptures for each Parent Section", "Calculating Ruptures for each Parent Section");
 				}
 				// note this assumes that sections are in order
-				rupturesForParentSectionCache = Maps.newConcurrentMap();
+				Map<Integer, List<Integer>> rupturesForParentSectionCache = Maps.newConcurrentMap();
 
 				int numRups = getNumRuptures();
 				for (int rupID=0; rupID<numRups; rupID++) {
@@ -1189,6 +1189,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 				for (Integer key : rupturesForParentSectionCache.keySet())
 					rupturesForParentSectionCache.put(key, Collections.unmodifiableList(rupturesForParentSectionCache.get(key)));
 				if (p != null) p.dispose();
+				this.rupturesForParentSectionCache = rupturesForParentSectionCache;
 			}
 		}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -666,6 +666,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 		Preconditions.checkArgument(sectionForRups.size() == numRups, "array sizes inconsistent!");
 		this.sectionForRups = sectionForRups;
 		
+		// add default model implementations, but only if not already set
 		if (!hasAvailableModule(SectAreas.class)) {
 			addAvailableModule(new Callable<SectAreas>() {
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
@@ -352,7 +352,7 @@ public class InversionConfiguration implements SubModule<ModuleContainer<?>>, JS
 		if (value.endsWith("e")) // TODO add to docs
 			return new EnergyCompletionCriteria(Double.parseDouble(value.substring(0, value.length()-1)));
 		if (value.endsWith("ip")) // TODO add to docs
-			return new IterationsPerVariableCompletionCriteria(Double.parseDouble(value.substring(value.length()-2)));
+			return new IterationsPerVariableCompletionCriteria(Double.parseDouble(value.substring(0, value.length()-2)));
 		if (value.endsWith("i"))
 			value = value.substring(0, value.length()-1);
 		return new IterationCompletionCriteria(Long.parseLong(value));

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
@@ -271,9 +271,20 @@ public class InversionConfiguration implements SubModule<ModuleContainer<?>>, JS
 			return this;
 		}
 		
+		public Builder completion(CompletionCriteria completion) {
+			config.completion = completion;
+			return this;
+		}
+		
 		public Builder avgThreads(int avgThreads, CompletionCriteria avgCompletion) {
 			config.avgThreads = avgThreads;
 			config.avgCompletion = avgCompletion;
+			return this;
+		}
+		
+		public Builder noAvg() {
+			config.avgThreads = null;
+			config.avgCompletion = null;
 			return this;
 		}
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
@@ -32,6 +32,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.Compl
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompoundCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.EnergyCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.IterationCompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.IterationsPerVariableCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.MisfitStdDevCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.TimeCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.CoolingScheduleType;
@@ -349,6 +350,8 @@ public class InversionConfiguration implements SubModule<ModuleContainer<?>>, JS
 			return TimeCompletionCriteria.getInSeconds(Long.parseLong(value.substring(0, value.length()-1)));
 		if (value.endsWith("e")) // TODO add to docs
 			return new EnergyCompletionCriteria(Double.parseDouble(value.substring(0, value.length()-1)));
+		if (value.endsWith("ip")) // TODO add to docs
+			return new IterationsPerVariableCompletionCriteria(Double.parseDouble(value.substring(value.length()-2)));
 		if (value.endsWith("i"))
 			value = value.substring(0, value.length()-1);
 		return new IterationCompletionCriteria(Long.parseLong(value));

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfiguration.java
@@ -24,6 +24,7 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.ConstraintWeightingType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint.Adapter;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ColumnOrganizedAnnealingData;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ReweightEvenFitSimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SerialSimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SimulatedAnnealing;
@@ -439,6 +440,10 @@ public class InversionConfiguration implements SubModule<ModuleContainer<?>>, JS
 	}
 	
 	public SimulatedAnnealing buildSA(InversionInputGenerator inputs) {
+		ColumnOrganizedAnnealingData equalityData = new ColumnOrganizedAnnealingData(inputs.getA(), inputs.getD());
+		ColumnOrganizedAnnealingData inequalityData = null;
+		if (inputs.getA_ineq() != null)
+			inequalityData = new ColumnOrganizedAnnealingData(inputs.getA_ineq(), inputs.getD_ineq());
 		SimulatedAnnealing sa;
 		if (threads > 1) {
 			if (avgThreads != null && avgThreads > 0) {
@@ -453,22 +458,20 @@ public class InversionConfiguration implements SubModule<ModuleContainer<?>>, JS
 				while (threadsLeft > 0) {
 					int myThreads = Integer.min(threadsLeft, threadsPerAvg);
 					if (myThreads > 1)
-						tsas.add(new ThreadedSimulatedAnnealing(inputs.getA(), inputs.getD(),
-								inputs.getInitialSolution(), 0d, inputs.getA_ineq(), inputs.getD_ineq(),
-								myThreads, subCompletion));
+						tsas.add(new ThreadedSimulatedAnnealing(equalityData, inequalityData,
+								inputs.getInitialSolution(), 0d, myThreads, subCompletion));
 					else
-						tsas.add(new SerialSimulatedAnnealing(inputs.getA(), inputs.getD(),
-								inputs.getInitialSolution(), 0d, inputs.getA_ineq(), inputs.getD_ineq()));
+						tsas.add(new SerialSimulatedAnnealing(equalityData, inequalityData,
+								inputs.getInitialSolution(), 0d));
 					threadsLeft -= myThreads;
 				}
 				sa = new ThreadedSimulatedAnnealing(tsas, avgCompletion, true);
 			} else {
-				sa = new ThreadedSimulatedAnnealing(inputs.getA(), inputs.getD(),
-						inputs.getInitialSolution(), 0d, inputs.getA_ineq(), inputs.getD_ineq(), threads, subCompletion);
+				sa = new ThreadedSimulatedAnnealing(equalityData, inequalityData,
+						inputs.getInitialSolution(), 0d, threads, subCompletion);
 			}
 		} else {
-			sa = new SerialSimulatedAnnealing(inputs.getA(), inputs.getD(), inputs.getInitialSolution(), 0d,
-					inputs.getA_ineq(), inputs.getD_ineq());
+			sa = new SerialSimulatedAnnealing(equalityData, inequalityData, inputs.getInitialSolution(), 0d);
 		}
 		sa.setConstraintRanges(inputs.getConstraintRowRanges());
 		if (reweightTargetQuantity != null) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
@@ -25,6 +25,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.Sl
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateSegmentationConstraint.RateCombiner;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.SlipRateSegmentationConstraint.Shaw07JumpDistSegModel;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.TotalRateInversionConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ReweightEvenFitSimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ThreadedSimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
@@ -623,6 +624,8 @@ public class Inversions {
 		sol.addModule(misfits.getMisfitStats());
 		if (info != null)
 			sol.setInfoString(info);
+		if (sa instanceof ReweightEvenFitSimulatedAnnealing)
+			sol.addModule(((ReweightEvenFitSimulatedAnnealing)sa).getMisfitProgress());
 		
 		return sol;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ColumnOrganizedAnnealingData.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ColumnOrganizedAnnealingData.java
@@ -1,0 +1,119 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.sa;
+
+import java.util.Arrays;
+
+import com.google.common.base.Preconditions;
+
+import cern.colt.matrix.tdouble.DoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseCCDoubleMatrix2D;
+import cern.colt.matrix.tdouble.impl.SparseDoubleMatrix2D;
+import edu.emory.mathcs.csparsej.tdouble.Dcs_common.Dcs;
+
+/**
+ * This reorganizes the inversion input data (A matrix and data vector) by column, so that the inversion solver can
+ * quickly access the relevant parts for each perturbation. This directly leads to most of the efficiencies in our
+ * SA implementation.
+ * 
+ * @author kevin
+ *
+ */
+public class ColumnOrganizedAnnealingData {
+	/**
+	 * Input A matrix
+	 */
+	public final DoubleMatrix2D A;
+	/**
+	 * Input data vector
+	 */
+	public final double[] d;
+	/**
+	 * Number of rows in the A matrix/data vector
+	 */
+	public final int nRows;
+	/*
+	 * Number of columns in the A matrix (equal to the number of values we're solving for)
+	 */
+	public final int nCols;
+	/**
+	 * Rows indexes in the A matrix that have nonzero values for each column
+	 */
+	final int[][] colRows;
+	/**
+	 * Nonzero values in the A matrix for each column (at the corresponding row from {@link #colRows} 
+	 */
+	final double[][] colA_values;
+	/**
+	 * The maximum number of nonzero values in any column of the A matrix
+	 */
+	final int maxRowsPerCol;
+	
+	public ColumnOrganizedAnnealingData(DoubleMatrix2D A, double[] d) {
+		Preconditions.checkNotNull(A, "A is null");
+		Preconditions.checkNotNull(d, "d is null");
+		nRows = A.rows();
+		nCols = A.columns();
+		Preconditions.checkArgument(nRows > 0, "nRow of A must be > 0");
+		Preconditions.checkArgument(nCols > 0, "nCol of A must be > 0");
+		Preconditions.checkArgument(d.length == nRows, "d matrix must be same lenth as nRow of A");
+		this.A = A;
+		this.d = d;
+		colRows = new int[nCols][];
+		colA_values = new double[nCols][];
+		
+		if (A instanceof SparseDoubleMatrix2D) {
+			System.out.println("Column compressing A matrix");
+			A = ((SparseDoubleMatrix2D)A).getColumnCompressed(true);
+		}
+		
+		if (A instanceof SparseCCDoubleMatrix2D) {
+			Dcs dcs = ((SparseCCDoubleMatrix2D)A).elements();
+			
+			// for each non-zero value, gives the row index
+			final int[] rowIndexesA = dcs.i;
+			// tells us where the rows associated with this column are in the above array
+			final int[] columnPointersA = dcs.p;
+			// values array
+			final double[] valuesA = dcs.x;
+			
+			int maxRowsPerCol = 0;
+			for (int col=0; col<nCols; col++) {
+				int low = columnPointersA[col];
+				int high = columnPointersA[col+1];
+				int len = high - low;
+				maxRowsPerCol = Integer.max(maxRowsPerCol, len);
+				colRows[col] = new int[len];
+				colA_values[col] = new double[len];
+				int index = 0;
+				for (int k=low; k<high; k++) {
+					colRows[col][index] = rowIndexesA[k];
+					colA_values[col][index] = valuesA[k];
+					
+					index++;
+				}
+			}
+			this.maxRowsPerCol = maxRowsPerCol;
+		} else {
+			System.out.println("Re-organizing A matrix into colmn vectors, this may be slow. Suggest using "
+					+ "SparseDoubleMatrix or SparseCCDoubleMatrix for large matrices.");
+			// do it manually for a dense matrix
+			int maxRowsPerCol = 0;
+			double[] tmpVals = new double[nRows];
+			int[] tmpRows = new int[nRows];
+			for (int col=0; col<nCols; col++) {
+				int index = 0;
+				for (int row=0; row<nRows; row++) {
+					double val = A.get(row, col);
+					if (val != 0d) {
+						tmpVals[index] = val;
+						tmpRows[index] = row;
+						index++;
+					}
+				}
+				maxRowsPerCol = Integer.max(maxRowsPerCol, index);
+				colRows[col] = Arrays.copyOf(tmpRows, index);
+				colA_values[col] = Arrays.copyOf(tmpVals, index);
+			}
+			this.maxRowsPerCol = maxRowsPerCol;
+		}
+	}
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/InversionState.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/InversionState.java
@@ -1,0 +1,72 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.sa;
+
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
+
+/**
+ * Class that tracks the state of a in inversion. Primarily used by {@link CompletionCriteria} to determine if an
+ * inversion is finished, and for tracking progress.
+ * 
+ * @author kevin
+ *
+ */
+public class InversionState {
+	
+	/**
+	 * elapsed total time in milliseconds
+	 */
+	public final long elapsedTimeMillis;
+	/**
+	 * total number of iterations completed
+	 */
+	public final long iterations;
+	/**
+	 * best energy, with total energy stored in the first array position
+	 */
+	public final double[] energy;
+	/**
+	 * the total number of accepted perturbations
+	 */
+	public final long numPerturbsKept;
+	/**
+	 * the total number of worse values kept
+	 */
+	public final long numWorseValuesKept;
+	/**
+	 * the number of non-zero values in the solution
+	 */
+	public final int numNonZero;
+	/**
+	 * the best solution found so far
+	 */
+	public final double[] bestSolution;
+	/**
+	 * current data misfits
+	 */
+	public final double[] misfits;
+	/**
+	 * current misfits for any inequalty constraints
+	 */
+	public final double[] misfits_ineq;
+	/**
+	 * constraint ranges for interpreting misfits, if available
+	 */
+	public final List<ConstraintRange> constraintRanges;
+	
+	public InversionState(long elapsedTimeMillis, long iterations, double[] energy, long numPerturbsKept,
+			long numWorseValuesKept, int numNonZero, double[] bestSolution, double[] misfits, double[] misfits_ineq,
+			List<ConstraintRange> constraintRanges) {
+		super();
+		this.elapsedTimeMillis = elapsedTimeMillis;
+		this.iterations = iterations;
+		this.energy = energy;
+		this.numPerturbsKept = numPerturbsKept;
+		this.numWorseValuesKept = numWorseValuesKept;
+		this.numNonZero = numNonZero;
+		this.bestSolution = bestSolution;
+		this.misfits = misfits;
+		this.misfits_ineq = misfits_ineq;
+		this.constraintRanges = constraintRanges;
+	}
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
@@ -51,7 +51,7 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranch;
  * sensitive to outliers and doesn't account for net bias; if you want to control the total standard deviation (noting
  * that it may be outlier-dominated), use RMSE instead.
  * <p>
- * After each annealing round, the an average misfit quantity is calculated across all uncertainty-weighted constraints.
+ * After each annealing round, the average misfit quantity is calculated across all uncertainty-weighted constraints.
  * Then, each uncertainty-weighted constraint is re-weighted such that:
  * <p>
  * newWeight = prevRate * constrMisfit / avgMisfit
@@ -69,7 +69,7 @@ import scratch.UCERF3.logicTree.U3LogicTreeBranch;
  * poorly fit on average, above {@link #AVG_TARGET_TRANSITION_UPPER_DEFAULT}. If the average fit is between
  * {@link #AVG_TARGET_TRANSITION_UPPER_DEFAULT} and {@link #AVG_TARGET_TRANSITION_LOWER_DEFAULT}, then calculated
  * weights are blended with original weights. This allows the inversion to slowly transition to even fitting as data
- * fits may very wildly (and change quickly) early on.
+ * fits may very wildly (and change quickly) early on. This feature is currently unused.
  * <p>
  * Setting {@link #USE_SQRT_FOR_TARGET_RATIOS_DEFAULT} to true will more conservatively (slowly) adjust weights, which
  * can also prevent wild swings in weighting.

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
@@ -94,7 +94,7 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 	public static final double AVG_TARGET_TRANSITION_UPPER_DEFAULT = Double.POSITIVE_INFINITY;
 	public static final double AVG_TARGET_TRANSITION_LOWER_DEFAULT = Double.POSITIVE_INFINITY;
 	public static final boolean CONSERVE_TOT_WEIGHT_DEFAULT = false;
-	public static final boolean USE_SQRT_FOR_TARGET_RATIOS_DEFAULT = true;
+	public static final boolean USE_SQRT_FOR_TARGET_RATIOS_DEFAULT = false;
 	public static final boolean USE_VALUE_WEIGHTED_AVERAGE_DEFAULT = false;
 	
 	// every x rounds, recompute A/d values as scalars from the original values to correct for any floating point error
@@ -386,7 +386,10 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 			int nRow = modA.rows();
 			int nCol = modA.columns();
 			int ineqRows = 0;
+			ColumnOrganizedAnnealingData modEqualityData = new ColumnOrganizedAnnealingData(modA, modD);
+			ColumnOrganizedAnnealingData modInqualityData = null;
 			if (modA_ineq != null) {
+				modInqualityData = new ColumnOrganizedAnnealingData(modA_ineq, modD_ineq);
 				misfit_ineq = new double[modD_ineq.length];
 				ineqRows = misfit_ineq.length;
 				SerialSimulatedAnnealing.calculateMisfit(modA_ineq, modD_ineq, xbest, misfit_ineq);
@@ -405,7 +408,7 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 			eStr += pDF.format(diffE/prevE)+")";
 			System.out.println(eStr);
 			
-			setAll(modA, modD, modA_ineq, modD_ineq, Ebest, xbest, misfit, misfit_ineq, getNumNonZero());
+			setAll(modEqualityData, modInqualityData, Ebest, xbest, misfit, misfit_ineq, getNumNonZero());
 			setConstraintRanges(modRanges);
 			
 			watch.stop();
@@ -549,10 +552,10 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 		constrBuilder.sectSupraNuclMFDs().weight(0.1d);
 		dirName += "-nucl_mfd";
 		
-//		boolean reweight = false;
+		boolean reweight = false;
 		
-		boolean reweight = true;
-		dirName += "-reweight_"+QUANTITY_DEFAULT.name();
+//		boolean reweight = true;
+//		dirName += "-reweight_"+QUANTITY_DEFAULT.name();
 		
 		if (reweight && CONSERVE_TOT_WEIGHT_DEFAULT)
 			dirName += "-conserve";
@@ -591,7 +594,7 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 //		builder.except(SectionTotalRateConstraint.class);
 //		dirName += "-no_sect";
 		
-//		builder.threads(1).noAvg();
+		builder.threads(2).noAvg();
 		
 		InversionConfiguration config = builder.build();
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
@@ -561,7 +561,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 			if (misfit_ineq_best != null) {
 				misfit_ineq = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length);
 			}
-			misfit_ineq_buffers = new double[num_buffers][nRow];
+			misfit_ineq_buffers = new double[num_buffers][d_ineq.length];
 			misfit_ineq_cur_purtub = misfit_ineq_buffers[cur_buffer];
 		}
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
@@ -46,7 +46,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	// it's actually less accurate. In fact, the full energy calculation will likely ignore any tiny energy changes.
 	public final static boolean ENERGY_SHORTCUT = true;
 	
-	private final static boolean ENERGY_SHORTCUT_DEBUG = true;
+	private final static boolean ENERGY_SHORTCUT_DEBUG = false;
 	private final static boolean COLUMN_MULT_SPEEDUP_DEBUG = false;
 	private final static boolean XBEST_ACCURACY_CHECK = false;
 	private double[] xbest_check_storage;
@@ -692,7 +692,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 								+Enew[i]+"\tE["+i+"]="+E[i]+"\tmyDelta="+myDelta+"\tcalcDelta="+calcDelta
 								+"\tdiff="+diff+"\tfractError="+fractError);
 //						Preconditions.checkState((float)Etest[i] == (float)Enew[i],
-						Preconditions.checkState((float)Etest[i] == (float)Enew[i] || fractError < 1e-5,
+						Preconditions.checkState((float)Etest[i] == (float)Enew[i] || fractError < 1e-5 || error < 1e-10,
 								"Energy[%s] shortcut fail! %s != %s, oldE=%s, deltaE=%s, deltaE_ineq=%s, myDelta=%s, "
 								+ "calcDelta=%s, diff=%s, fractError=%s",
 								i, Enew[i], Etest[i], E[i], deltaE, deltaE_ineq, myDelta, calcDelta, diff, fractError);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
@@ -763,6 +763,10 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 			
 			// Use transition probability to determine (via random number draw) if solution is kept
 			if (P == 1 || P > r.nextDouble()) {
+				if (Enew[0] > E[0])
+					// we're keeping one that made energy worse
+					worseValsNotYetSaved++;
+				
 				/* 
 				 * The buffers are a bit confusing, let me explain. Arrays.copyOf(...) calls are costly in this inner
 				 * loop, so we avoid them by reusing various misfit buffers. With buffers in use, we only need to
@@ -790,8 +794,6 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					numNonZero = curNumNonZero;
 					worseKept += worseValsNotYetSaved;
 					worseValsNotYetSaved = 0;
-				} else {
-					worseValsNotYetSaved++;
 				}
 				
 				// now switch buffers so that we're not overwriting a kept solution

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SerialSimulatedAnnealing.java
@@ -20,21 +20,15 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.Nonnegati
 import cern.colt.matrix.tdouble.DoubleMatrix1D;
 import cern.colt.matrix.tdouble.DoubleMatrix2D;
 import cern.colt.matrix.tdouble.impl.DenseDoubleMatrix1D;
-import cern.colt.matrix.tdouble.impl.DenseDoubleMatrix2D;
-import cern.colt.matrix.tdouble.impl.SparseCCDoubleMatrix2D;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Doubles;
-
-import edu.emory.mathcs.csparsej.tdouble.Dcs_common.Dcs;
 
 /**
  * 
  * @author Morgan Page and Kevin Milner
  *
  */
-
-
 public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 
 	protected static final String XML_METADATA_NAME = "SimulatedAnnealing";
@@ -44,7 +38,15 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	// if true, energy change will be calculated during misfit calculation rather than recalculating the full energy
 	// this can lead to tiny floating point drift errors relative to recalculating each time, but it's not clear that
 	// it's actually less accurate. In fact, the full energy calculation will likely ignore any tiny energy changes.
-	public final static boolean ENERGY_SHORTCUT = true;
+	private final static boolean ENERGY_SHORTCUT = true;
+	
+	// do a full energy recalculation every X iterations in order to correct any floating error accumulation
+	// a setting of 100k leads to maximum fractional error of ~1e-14
+	private final static long ENERGY_SHORTCUT_DRIFT_MOD = 100000l;
+	
+	// if true, an alternative energy calculator is used that unrolls the inner loop for additional efficiency.
+	// this technique allows the JVM to vectorize the calculations, sometimes performing multiple per clock cycle
+	private final static boolean UNROLL_ENERGY_CALCS = true;
 	
 	private final static boolean ENERGY_SHORTCUT_DEBUG = false;
 	private final static boolean COLUMN_MULT_SPEEDUP_DEBUG = false;
@@ -79,18 +81,21 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	
 	private double[] variablePerturbBasis;
 	
-	private DoubleMatrix2D A, A_ineq;
-	private double[] d, d_ineq;
+	/*
+	 * Column organized input data
+	 */
+	private ColumnOrganizedAnnealingData equalityData;
+	private ColumnOrganizedAnnealingData inequalityData;
+	
+	/*
+	 * Other non-equality options
+	 */
 	private double relativeSmoothnessWt;
 	private boolean hasInequalityConstraint;
 	
-	private int nCol;
-	private int nRow;
-	
 	private double[] xbest;  // best model seen so far
-	private double[] perturb; // perturbation to current model
 	private double[] misfit_best, misfit_ineq_best; // misfit between data and synthetics
-	private int numNonZero;
+	private int numNonZero; // number of nonzero values in xbest
 	
 	private double[] Ebest; // [total, from A, from entropy, from A_ineq]
 
@@ -120,52 +125,50 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	 */
 	public SerialSimulatedAnnealing(DoubleMatrix2D A, double[] d, double[] initialState, double relativeSmoothnessWt, 
 			DoubleMatrix2D A_ineq,  double[] d_ineq) {
-		this.relativeSmoothnessWt=relativeSmoothnessWt;
-		this.hasInequalityConstraint = A_ineq != null;
-		if (hasInequalityConstraint)
-			Preconditions.checkArgument(d_ineq != null, "we have an A_ineq matrix but no d_ineq vector!");
-		else
-			Preconditions.checkArgument(d_ineq == null, "we have a d_ineq vector but no A_ineq matrix!");
-		this.A_ineq=A_ineq;
-		this.d_ineq=d_ineq;
-		
-		setup(A, d, initialState);
+		this(new ColumnOrganizedAnnealingData(A, d), A_ineq == null ? null : new ColumnOrganizedAnnealingData(A_ineq, d_ineq),
+				initialState, relativeSmoothnessWt);
 	}
 	
-	private void setup(DoubleMatrix2D A, double[] d, double[] initialState) {
-		this.initialState = initialState;
-		Preconditions.checkNotNull(A, "A matrix cannot be null");
-		Preconditions.checkNotNull(d, "d matrix cannot be null");
+	/**
+	 * 
+	 * @param equalityData equality constraint data
+	 * @param inequalityData inequality constraint data, can be null
+	 * @param initialState initial state
+	 * @param relativeSmoothnessWt relative weight for smoothness (entropy) constraint, or zero to disable
+	 */
+	public SerialSimulatedAnnealing(ColumnOrganizedAnnealingData equalityData,
+			ColumnOrganizedAnnealingData inequalityData, double[] initialState, double relativeSmoothnessWt) {
+		this.relativeSmoothnessWt=relativeSmoothnessWt;
+		setup(equalityData, inequalityData, initialState);
+	}
+	
+	private void setup(ColumnOrganizedAnnealingData equalityData,
+			ColumnOrganizedAnnealingData inequalityData, double[] initialState) {
+		Preconditions.checkNotNull(equalityData, "Equality data cannot be null");
+		this.equalityData = equalityData;
+		this.inequalityData = inequalityData;
+		this.hasInequalityConstraint = inequalityData != null;
 		Preconditions.checkNotNull(initialState, "initial state cannot be null");
+		Preconditions.checkArgument(initialState.length == equalityData.nCols,
+				"initial state must be same lenth as nCol of A");
+		if (inequalityData != null)
+			Preconditions.checkArgument(initialState.length == inequalityData.nCols,
+					"initial state must be same lenth as nCol of A_ineq");
+		this.initialState = initialState;
 		
-		nRow = A.rows();
-		nCol = A.columns();
-		Preconditions.checkArgument(nRow > 0, "nRow of A must be > 0");
-		Preconditions.checkArgument(nCol > 0, "nCol of A must be > 0");
-		
-		Preconditions.checkArgument(d.length == nRow, "d matrix must be same lenth as nRow of A");
-		Preconditions.checkArgument(initialState.length == nCol, "initial state must be same lenth as nCol of A");
-		
-		if (!(A instanceof SparseCCDoubleMatrix2D) && !(A instanceof DenseDoubleMatrix2D))
-			System.err.println("WARNING: A matrix is not column-compressed, annealing will be SLOW!");
-		
-		this.A = A;
-		this.d = d;
-		
-
-		xbest = Arrays.copyOf(initialState, nCol);  // best model seen so far
+		xbest = Arrays.copyOf(initialState, initialState.length);  // best model seen so far
 		for (int i=0; i<xbest.length; i++) {
 			Preconditions.checkState(xbest[i] >= 0, "initial solution has negative or NaN value: %s", xbest[i]);
 			if (xbest[i] > 0)
 				numNonZero++;
 		}
-		perturb = new double[nCol]; // perturbation to current model
 		
-		misfit_best = new double[nRow];
-		calculateMisfit(A, d, xbest, misfit_best);
+		// initial misfits
+		misfit_best = new double[equalityData.nRows];
+		calculateMisfit(equalityData, xbest, misfit_best);
 		if (hasInequalityConstraint) {
-			misfit_ineq_best = new double[d_ineq.length];
-			calculateMisfit(A_ineq, d_ineq, xbest, misfit_ineq_best);
+			misfit_ineq_best = new double[inequalityData.nRows];
+			calculateMisfit(inequalityData, xbest, misfit_ineq_best);
 		}
 		
 		Ebest = calculateEnergy(xbest, misfit_best, misfit_ineq_best);
@@ -260,14 +263,12 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	public void setResults(double[] Ebest, double[] xbest, double[] misfit_best, double[] misfit_ineq_best, int numNonZero) {
 		this.Ebest = Arrays.copyOf(Ebest, Ebest.length);
 		this.xbest = Arrays.copyOf(xbest, xbest.length);
-		if (misfit_best == null)
-			this.misfit_best = null;
-		else
-			this.misfit_best = Arrays.copyOf(misfit_best, misfit_best.length);
-		if (misfit_ineq_best == null)
-			this.misfit_ineq_best = null;
-		else
+		Preconditions.checkNotNull(misfit_best, "Misfits must be supplied");
+		this.misfit_best = Arrays.copyOf(misfit_best, misfit_best.length);
+		if (hasInequalityConstraint) {
+			Preconditions.checkNotNull(misfit_ineq_best, "Inequality misfits must be supplied");
 			this.misfit_ineq_best = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length);
+		}
 		this.numNonZero = numNonZero;
 	}
 	
@@ -289,7 +290,20 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	}
 	
 	/**
-	 * Calculates misfits (synthetics - date) for the given solution
+	 * Calculates misfits (synthetics - date) for the given solution. This is slow as it does a complete matrix
+	 * multiplication, and is not used in the inner annealing loops.
+	 * 
+	 * @param data constraint data
+	 * @param solution solution
+	 * @param misfit array where misfits will be stored
+	 */
+	public static void calculateMisfit(ColumnOrganizedAnnealingData data, double[] solution, double[] misfit) {
+		calculateMisfit(data.A, data.d, solution, misfit);
+	}
+	
+	/**
+	 * Calculates misfits (synthetics - date) for the given solution. This is slow as it does a complete matrix
+	 * multiplication, and is not used in the inner annealing loops.
 	 * 
 	 * @param mat A matrix
 	 * @param data data
@@ -297,113 +311,174 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	 * @param misfit array where misfits will be stored
 	 */
 	public static void calculateMisfit(DoubleMatrix2D mat, double[] data, double[] solution, double[] misfit) {
-		calculateMisfit(mat, data, null, solution, -1, Double.NaN, misfit, false);
-	}
-	
-	/**
-	 * Calculates misfits (synthetics - date) for the given solution, with optional efficiencies
-	 * 
-	 * @param mat A matrix
-	 * @param data data
-	 * @param prev_misfit previous misfits
-	 * @param solution solution
-	 * @param perturbCol column in the A matrix where the corresoponding solution value was perturbed
-	 * @param perturbation perturbation amount
-	 * @param misfit array where misfits will be stored
-	 * @param ineq true if an inequality constraint
-	 * @return if {@link SerialSimulatedAnnealing#ENERGY_SHORTCUT} is enabled, energy change due to this perturbation
-	 * will be returned, else NaN
-	 */
-	private static double calculateMisfit(DoubleMatrix2D mat, double[] data, double[] prev_misfit,
-			double[] solution, int perturbCol, double perturbation, double[] misfit, boolean ineq) {
-		if (mat instanceof SparseCCDoubleMatrix2D && perturbCol >= 0 && prev_misfit != null) {
-			// we have previous misfits and a column-compressed A matrix, don't redo the whole matrix multiplication,
-			// only update misfut changes due to the perturbed column
-			
-			if (prev_misfit != misfit)
-				// copy over previous misfits to output, which we will update
-				System.arraycopy(prev_misfit, 0, misfit, 0, prev_misfit.length);
-			
-			Dcs dcs = ((SparseCCDoubleMatrix2D)mat).elements();
-			// for each non-zero value, gives the row index
-			final int[] rowIndexesA = dcs.i;
-			// tells us where the rows associated with this column are in the above array
-			final int[] columnPointersA = dcs.p;
-			// values array
-			final double[] valuesA = dcs.x;
-			
-			int low = columnPointersA[perturbCol];
-			
-			// if ENERGY_SHORTCUT is true, we'll calculate energy change which can be used instead of recalculating
-			// full energy
-			double deltaE = ENERGY_SHORTCUT ? 0d : Double.NaN;
-			
-			int row;
-			double value;
-			double prevRowMisfit;
-			if (ineq) {
-				for (int k = columnPointersA[perturbCol + 1]; --k >= low;) {
-					row = rowIndexesA[k];
-					value = valuesA[k];
-					// store it separately as misfit and prev_misfit can be the same array
-					prevRowMisfit = prev_misfit[row];
-					misfit[row] += value * perturbation;
-					if (ENERGY_SHORTCUT) {
-						if (prevRowMisfit > 0)
-							// we were previously >0, thus we need to remove the old energy
-							deltaE -= prevRowMisfit*prevRowMisfit;
-						if (misfit[row] > 0)
-							// we're now >0, add new energy
-							deltaE += misfit[row]*misfit[row];
-					}
-				}
-			} else {
-				for (int k = columnPointersA[perturbCol + 1]; --k >= low;) {
-					row = rowIndexesA[k];
-					value = valuesA[k];
-					// store it separately as misfit and prev_misfit can be the same array
-					prevRowMisfit = prev_misfit[row];
-					misfit[row] += value * perturbation;
-					if (ENERGY_SHORTCUT)
-						// calculate energy difference due to this perturbation
-						deltaE += misfit[row]*misfit[row] - prevRowMisfit*prevRowMisfit;
-				}
-			}
-//			System.out.println("deltaE = "+deltaE);
-			return deltaE;
-		} else {
-			DoubleMatrix1D sol_clone = new DenseDoubleMatrix1D(solution);
-			
-			DenseDoubleMatrix1D syn = new DenseDoubleMatrix1D(mat.rows());
-			mat.zMult(sol_clone, syn);
-			
-			for (int i = 0; i < mat.rows(); i++) {
-				misfit[i] = syn.get(i) - data[i];  // misfit between synthetics and data
-			}
-			
-			return Double.NaN;
+		DoubleMatrix1D sol_clone = new DenseDoubleMatrix1D(solution);
+		
+		DenseDoubleMatrix1D syn = new DenseDoubleMatrix1D(mat.rows());
+		mat.zMult(sol_clone, syn);
+		
+		for (int i = 0; i < mat.rows(); i++) {
+			misfit[i] = syn.get(i) - data[i];  // misfit between synthetics and data
 		}
 	}
 	
+	/**
+	 * This updates misfits in place due to the given perturbation. It returns the final energy change as a reult
+	 * of this perturbation
+	 * 
+	 * @param inputs column-organized data inputs
+	 * @param misfits misfits to be updated
+	 * @param perturbCol column of the value being perturbed
+	 * @param perturbation perturbation
+	 * @param ineq true if this is an inequality constraint (affects energy change calculation)
+	 * @param scratch scratch array that is at least the size of the number of rows that depend on this column
+	 * @return
+	 */
+	private static double updateMisfitsCalcDeltaEnergy(final ColumnOrganizedAnnealingData inputs, final double[] misfits,
+			final int perturbCol, final double perturbation, final boolean ineq, final double[] scratch) {
+		// nonzero values in the A matrix related to the perturbed column
+		final double[] As = inputs.colA_values[perturbCol];
+		// rows assocated with the values above
+		final int[] rows = inputs.colRows[perturbCol];
+		
+		final int NUM = rows.length;
+		// make sure that our scratch array is big enough
+		Preconditions.checkState(scratch.length >= NUM);
+		// fill the scratch array with misfit values before this perturbation
+		// it's more efficient to calculate 
+		for (int i=0; i<NUM; i++)
+			scratch[i] = misfits[rows[i]];
+		
+		double prevE;
+		if (ineq)
+			prevE = sumSquaresIneq(scratch, NUM);
+		else if (UNROLL_ENERGY_CALCS)
+			prevE = sumSquaresUnrolled(scratch, NUM);
+		else
+			prevE = sumSquares(scratch, NUM);
+		
+		// now update the misfits array with the purturbation
+		// this also stores the updated misfits in the scratch array
+		updateMisfits(misfits, perturbation, scratch, As, rows, NUM);
+		
+		// calculate energy change due to this perturbation
+		if (ineq)
+			return sumSquaresIneq(scratch, NUM) - prevE;
+		if (UNROLL_ENERGY_CALCS)
+			return sumSquaresUnrolled(scratch, NUM) - prevE;
+		return sumSquares(scratch, NUM) - prevE;
+	}
+
+	private static void updateMisfits(final double[] misfits, final double perturbation, final double[] scratch,
+			final double[] As, final int[] rows, final int NUM) {
+		for (int i=0; i<NUM; i++) {
+			misfits[rows[i]] += As[i] * perturbation;
+			scratch[i] = misfits[rows[i]];
+		}
+	}
+	
+	/**
+	 * Simple method to calculate the sum of squared values
+	 * 
+	 * @param values
+	 * @param NUM
+	 * @return
+	 */
+	private static double sumSquares(final double[] values, final int NUM) {
+		double ret = 0d;
+		for (int i=0; i<NUM; i++)
+			// Math.fma does the multiplication and add in a single floating point operation and is
+			// both more efficient and precise
+			ret = Math.fma(values[i], values[i], ret);
+		return ret;
+	}
+	
+	// DO NOT CHANGE this without also updating the code in the method below
+	private final static int ROLLS = 10;
+	
+	/**
+	 * More complicated method to calculate the sum of squared values in a way that the JVM will run more efficiently.
+	 * <p>
+	 * Basically, I 'unroll' each loop to have many separate sums, which allows the JVM to convert it to scalar
+	 * operations. Idea from https://stackoverflow.com/a/51429748, also see https://en.wikipedia.org/wiki/Loop_unrolling
+	 * <p>
+	 * This is about 15% faster than the regular rolled version
+	 * 
+	 * @param values
+	 * @param NUM
+	 * @return
+	 */
+	private static double sumSquaresUnrolled(final double[] values, final int NUM) {
+		int ROUNDS = NUM/ROLLS;
+		if (ROUNDS < 2)
+			return sumSquares(values, NUM);
+		
+		double s0 = 0d;
+		double s1 = 0d;
+		double s2 = 0d;
+		double s3 = 0d;
+		double s4 = 0d;
+		double s5 = 0d;
+		double s6 = 0d;
+		double s7 = 0d;
+		double s8 = 0d;
+		double s9 = 0d;
+		
+		int i;
+		for (int r=0; r<ROUNDS; r++) {
+			i = r*ROLLS;
+			s0 = Math.fma(values[i], values[i], s0);
+			s1 = Math.fma(values[i+1], values[i+1], s1);
+			s2 = Math.fma(values[i+2], values[i+2], s2);
+			s3 = Math.fma(values[i+3], values[i+3], s3);
+			s4 = Math.fma(values[i+4], values[i+4], s4);
+			s5 = Math.fma(values[i+5], values[i+5], s5);
+			s6 = Math.fma(values[i+6], values[i+6], s6);
+			s7 = Math.fma(values[i+7], values[i+7], s7);
+			s8 = Math.fma(values[i+8], values[i+8], s8);
+			s9 = Math.fma(values[i+9], values[i+9], s9);
+		}
+		
+		double ret = s0+s1+s2+s3+s4+s5+s6+s7+s8+s9;
+		
+		for (i=ROUNDS*ROLLS; i<NUM; i++)
+			// now fill in any remainder
+			ret = Math.fma(values[i], values[i], ret);
+		
+		return ret;
+	}
+	
+	private static double sumSquaresIneq(final double[] values, final int NUM) {
+		double ret = 0d;
+		double val;
+		for (int i=0; i<NUM; i++) {
+			val = values[i];
+			if (val > 0)
+				ret = Math.fma(val, val, ret);
+		}
+		return ret;
+	}
+	
 	public double[] calculateEnergy(double[] solution) {
-		double[] misfit = new double[d.length];
-		calculateMisfit(A, d, solution, misfit);
+		double[] misfit = new double[equalityData.nRows];
+		calculateMisfit(equalityData, solution, misfit);
 		double[] misfit_ineq = null;
 		if (hasInequalityConstraint) {
-			misfit_ineq = new double[d_ineq.length];
-			calculateMisfit(A_ineq, d_ineq, solution, misfit_ineq);
+			misfit_ineq = new double[inequalityData.nRows];
+			calculateMisfit(inequalityData, solution, misfit_ineq);
 		}
 		return calculateEnergy(solution, misfit, misfit_ineq);
 	}
 	
 	public double[] calculateEnergy(double[] solution, double[] misfit, double[] misfit_ineq, List<ConstraintRange> constraintRanges) {
-		int ineqRows = hasInequalityConstraint ? d_ineq.length : 0;
-		return calculateEnergy(solution, misfit, misfit_ineq, nRow, nCol, ineqRows, constraintRanges, relativeSmoothnessWt);
+		int ineqRows = hasInequalityConstraint ? inequalityData.nRows : 0;
+		return calculateEnergy(solution, misfit, misfit_ineq, equalityData.nRows, equalityData.nCols,
+				ineqRows, constraintRanges, relativeSmoothnessWt);
 	}
 	
 	public double[] calculateEnergy(double[] solution, double[] misfit, double[] misfit_ineq) {
-		int ineqRows = hasInequalityConstraint ? d_ineq.length : 0;
-		return calculateEnergy(solution, misfit, misfit_ineq, nRow, nCol, ineqRows, constraintRanges, relativeSmoothnessWt);
+		int ineqRows = hasInequalityConstraint ? inequalityData.nRows : 0;
+		return calculateEnergy(solution, misfit, misfit_ineq, equalityData.nRows, equalityData.nCols,
+				ineqRows, constraintRanges, relativeSmoothnessWt);
 	}
 	
 	public static double[] calculateEnergy(final double[] solution, final double[] misfit, final double[] misfit_ineq,
@@ -417,12 +492,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 		if (constraintRanges == null) {
 			ret = new double[4];
 			
-			for (int i = 0; i < nRow; i++) {
-				// NOTE: it is important that we loop over nRow and not the actual misfit array
-				// as it may be larger than nRow (for efficiency and fewer array copies)
-				
-				Eequality += misfit[i]*misfit[i];  // L2 norm of misfit vector
-			}
+			Eequality = UNROLL_ENERGY_CALCS ? sumSquaresUnrolled(misfit, nRow) : sumSquares(misfit, nRow);
 		} else {
 			ret = new double[4+constraintRanges.size()];
 			double val;
@@ -466,13 +536,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 		double Einequality = 0;
 		if (ineqRows > 0) {
 			if (constraintRanges == null) {
-				for (int i = 0; i < ineqRows; i++) {
-					// NOTE: it is important that we loop over nRow and not the actual misfit array
-					// as it may be larger than nRow (for efficiency and fewer array copies)
-					
-					if (misfit_ineq[i] > 0d)
-						Einequality += misfit_ineq[i]*misfit_ineq[i];  // L2 norm of misfit vector
-				}
+				Einequality = sumSquaresIneq(misfit_ineq, ineqRows);
 			} else {
 				double val;
 				for (int i = 0; i < ineqRows; i++) {
@@ -508,8 +572,6 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	public synchronized InversionState iterate(CompletionCriteria completion) {
 		return iterate(null, completion);
 	}
-	
-	private static final int num_buffers = 3;
 
 	@Override
 	public synchronized InversionState iterate(InversionState startingState, CompletionCriteria criteria) {
@@ -543,38 +605,44 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 		int curNumNonZero = numNonZero;
 		double[] E = Ebest;
 		double T;
-		// this is where we store previous misfits
-		double[] misfit;
-		if (misfit_best == null) {
-			misfit = null;
-		} else {
-			misfit = Arrays.copyOf(misfit_best, misfit_best.length);
-		}
-		// this is where we store new candidate misfits
-		int cur_buffer = 0;
-		double[][] misfit_buffers = new double[num_buffers][nRow];
-		double[] misfit_cur_purtub = misfit_buffers[cur_buffer];
-		double[] misfit_ineq = null;
-		double[][] misfit_ineq_buffers = null;
-		double[] misfit_ineq_cur_purtub = null;
+		double perturb;
+		int nCol = xbest.length;
+		
+		// keep track of 3 misfit arrays simultaneously to avoid expensive array copy operations in the inner loop
+		Preconditions.checkNotNull(misfit_best); // best ever encountered
+		double[] misfit_working = Arrays.copyOf(misfit_best, misfit_best.length); // current kept model
+		double[] misfit_perturbed = Arrays.copyOf(misfit_best, misfit_best.length); // updated each iteration
+		
+		double[] misfit_working_ineq = null;
+		double[] misfit_perturbed_ineq = null;
 		if (hasInequalityConstraint) {
-			if (misfit_ineq_best != null) {
-				misfit_ineq = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length);
-			}
-			misfit_ineq_buffers = new double[num_buffers][d_ineq.length];
-			misfit_ineq_cur_purtub = misfit_ineq_buffers[cur_buffer];
+			Preconditions.checkNotNull(misfit_ineq_best); // best ever encountered
+			misfit_working_ineq = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length); // current kept model
+			misfit_perturbed_ineq = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length); // updated each iteration
 		}
 		
+		// this array will be used in energy change calculations, and needs to be at least as big as the largest number
+		// of rows with a non-zero value in the A matrix for any column
+		double[] scratch;
+		if (hasInequalityConstraint) {
+			int maxCount = Integer.max(equalityData.maxRowsPerCol, inequalityData.maxRowsPerCol);
+			scratch = new double[maxCount];
+		} else {
+			scratch = new double[equalityData.maxRowsPerCol];
+		}
+		
+		// this will keep track of 'worse' perturbations that we kept, but have not yet led to a new 'best' solution
 		long worseValsNotYetSaved = 0l;
+		
+		double worstEnergyShortcutFract = 0;
+		double worstEnergyShortcutAbs = 0;
 
 		// we do iter-1 because iter here is 1-based, not 0-based
 		InversionState state = null;
-//		while (!criteria.isSatisfied(watch, iter-1, Ebest, perturbs, numNonZero, misfit_best, misfit_ineq_best, constraintRanges)) {
 		while (!criteria.isSatisfied(state = new InversionState(watch.getTime(), iter-1, Ebest, perturbs, worseKept,
 				numNonZero, xbest, misfit_best, misfit_ineq_best, constraintRanges))) {
 
 			// Find current simulated annealing "temperature" based on chosen cooling schedule
-//			double coolIter = (double)iter / coolingFuncSlowdown;
 			double coolIter = iter;
 			if (coolingFuncSlowdown != 1)
 				coolIter = ((double)iter - 1) / coolingFuncSlowdown + 1;
@@ -613,7 +681,7 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 
 
 			// How much to perturb index (some perturbation functions are a function of T)	
-			perturb[index] = perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
+			perturb = perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
 			
 			boolean wasZero = x[index] == 0;
 
@@ -623,47 +691,56 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 				// This way will result in many zeros in the solution, 
 				// which may be desirable since global minimum is likely near a boundary
 				if (wasZero) { // if that rate was already zero do not keep it at zero
-					while (x[index] + perturb[index] < 0) 
-						perturb[index] =  perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
+					while (x[index] + perturb < 0) 
+						perturb =  perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
 				} else { // if that rate was not already zero, and it goes negative, set it equal to zero
-					if (x[index] + perturb[index] < 0) 
-						perturb[index] = -x[index];
+					if (x[index] + perturb < 0) 
+						perturb = -x[index];
 				}
 				break;
 			case LIMIT_ZERO_RATES:    // re-perturb rates if they are perturbed to negative values 
 				// This way will result in not a lot of zero rates (none if numIterations >> length(x)),
 				// which may be desirable if we don't want a lot of zero rates
-				while (x[index] + perturb[index] < 0) {
-					perturb[index] =  perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
+				while (x[index] + perturb < 0) {
+					perturb =  perturbationFunc.getPerturbation(r, T, index, variablePerturbBasis);
 				}
 				break;
 			case PREVENT_ZERO_RATES:    // Only perturb rates to positive values; any perturbations of zero rates MUST be accepted.
 				// Final model will only have zero rates if rate was never selected to be perturbed AND starting model contains zero rates.
 				if (!wasZero) {
-					perturb[index] = (r.nextDouble() -0.5) * 2 * x[index]; 	
+					perturb = (r.nextDouble() -0.5) * 2 * x[index]; 	
 					}
 				else {
-					perturb[index] = (r.nextDouble()) * 0.00000001;
+					perturb = (r.nextDouble()) * 0.00000001;
 				}
 				break;
 			default:
 				throw new IllegalStateException("You missed a Nonnegativity Constraint Algorithm type.");
 			}
 			
-			x[index] += perturb[index];
+			if (ENERGY_SHORTCUT && relativeSmoothnessWt == 0d && iter % ENERGY_SHORTCUT_DRIFT_MOD == 0) {
+				// recalculate full energy every once in a while to prevent slow accumulation of floating point errors
+				// we'll do this based on the original energy (before this perturbation) as the energy delta calculation
+				// is actually more accurate than the full one for determining if we should change states
+				E = calculateEnergy(x, misfit_working, misfit_working_ineq);
+			}
+			
+			x[index] += perturb;
 			
 			// calculate new misfit vectors
-			double deltaE = calculateMisfit(A, d, misfit, x, index,
-					perturb[index], misfit_cur_purtub, false);
+			// this will simultaneously calculate misfit change
+			double deltaE = updateMisfitsCalcDeltaEnergy(equalityData, misfit_perturbed, index,
+					perturb, false, scratch);
 			double deltaE_ineq = Double.NaN;
 			if (hasInequalityConstraint)
-				deltaE_ineq = calculateMisfit(A_ineq, d_ineq, misfit_ineq, x, index,
-						perturb[index], misfit_ineq_cur_purtub, true);
+				deltaE_ineq = updateMisfitsCalcDeltaEnergy(inequalityData, misfit_perturbed_ineq, index,
+						perturb, true, scratch);
 
 			// Calculate "energy" of new model (high misfit -> high energy)
 			double[] Enew;
-			if (ENERGY_SHORTCUT && relativeSmoothnessWt == 0d && Double.isFinite(deltaE) &&
-					constraintRanges == null && E != null) {
+			
+			if (ENERGY_SHORTCUT && relativeSmoothnessWt == 0d) {
+				// use the energy shortcut: add change to previous energy
 				// shortcut
 				Enew = new double[4];
 				Enew[0] = E[0] + deltaE;
@@ -673,14 +750,14 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					Enew[0] += deltaE_ineq;
 					Enew[3] = E[3] + deltaE_ineq;
 				}
-				if (D) {
-					double[] Etest2 = calculateEnergy(x, misfit_cur_purtub, misfit_ineq_cur_purtub);
-					double cDelt = Etest2[0] - E[0];
-					System.out.println("Energy shortcut with deltaE="+deltaE+", calcDelta="+cDelt+", diff="+(float)(deltaE - cDelt));
-				}
+//				if (D) {
+//					double[] Etest2 = calculateEnergy(x, misfit_perturbed, misfit_perturbed_ineq);
+//					double cDelt = Etest2[0] - E[0];
+//					System.out.println("Energy shortcut with deltaE="+deltaE+", calcDelta="+cDelt+", diff="+(float)(deltaE - cDelt));
+//				}
 				if (ENERGY_SHORTCUT_DEBUG && (iter-1) % 1000 == 0 && iter > 1) {
 					// calculate it manually as well
-					double[] Etest = calculateEnergy(x, misfit_cur_purtub, misfit_ineq_cur_purtub);
+					double[] Etest = calculateEnergy(x, misfit_perturbed, misfit_perturbed_ineq);
 					if (D) System.out.println("ENERGY SHORTCUT DEBUG");
 					for (int i=0; i<Enew.length; i++) {
 						double myDelta = Enew[i]-E[i];
@@ -688,14 +765,17 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 						double diff = myDelta-calcDelta;
 						double error = Math.abs(Enew[i]-Etest[i]);
 						double fractError = error/Etest[i];
+						worstEnergyShortcutAbs = Math.max(error, worstEnergyShortcutAbs);
+						if (Etest[i] > 0d)
+							worstEnergyShortcutFract = Math.max(fractError, worstEnergyShortcutFract);
 						if (D) System.out.println("\tEtest["+i+"]="+Etest[i]+"\tEnew["+i+"]="
 								+Enew[i]+"\tE["+i+"]="+E[i]+"\tmyDelta="+myDelta+"\tcalcDelta="+calcDelta
 								+"\tdiff="+diff+"\tfractError="+fractError);
 //						Preconditions.checkState((float)Etest[i] == (float)Enew[i],
-						Preconditions.checkState((float)Etest[i] == (float)Enew[i] || fractError < 1e-5 || error < 1e-10,
-								"Energy[%s] shortcut fail! %s != %s, oldE=%s, deltaE=%s, deltaE_ineq=%s, myDelta=%s, "
-								+ "calcDelta=%s, diff=%s, fractError=%s",
-								i, Enew[i], Etest[i], E[i], deltaE, deltaE_ineq, myDelta, calcDelta, diff, fractError);
+						Preconditions.checkState((float)Etest[i] == (float)Enew[i] || fractError < 1e-4 || error < 1e-10,
+								"Energy[%s] shortcut failfor iteration %s! %s != %s, oldE=%s, deltaE=%s, deltaE_ineq=%s,"
+								+ "\nmyDelta=%s, calcDelta=%s, diff=%s, fractError=%s",
+								i, iter, Enew[i], Etest[i], E[i], deltaE, deltaE_ineq, myDelta, calcDelta, diff, fractError);
 						// disabling the sign test, as it's not clear that energy changes are actually less accurate
 						// they may be more accurate as we're accumulating small value changes separately rather than
 						// accumulating them in large (energy) space where some small changes may be ignored if small
@@ -707,7 +787,8 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					}
 				}
 			} else {
-				Enew = calculateEnergy(x, misfit_cur_purtub, misfit_ineq_cur_purtub);
+				// if we're here, we probably have the entropy constraint enabled, which will be slower
+				Enew = calculateEnergy(x, misfit_perturbed, misfit_perturbed_ineq);
 			}
 			
 			if (D) {
@@ -716,12 +797,12 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					// only do this if debug is enabled, and do it every 100 iterations
 					
 					// calculate it the "slow" way
-					double[] comp_misfit_new = new double[misfit.length];
-					calculateMisfit(A, d, x, comp_misfit_new);
+					double[] comp_misfit_new = new double[misfit_perturbed.length];
+					calculateMisfit(equalityData, x, comp_misfit_new);
 					double[] comp_misfit_ineq_new = null;
 					if (hasInequalityConstraint) {
-						comp_misfit_ineq_new = new double[misfit_ineq.length];
-						calculateMisfit(A_ineq, d_ineq, x, comp_misfit_ineq_new);
+						comp_misfit_ineq_new = new double[misfit_perturbed.length];
+						calculateMisfit(inequalityData, x, comp_misfit_ineq_new);
 					}
 					double[] Enew_temp = calculateEnergy(x, comp_misfit_new, comp_misfit_ineq_new);
 					double pDiff = DataUtils.getPercentDiff(Enew[0], Enew_temp[0]);
@@ -769,14 +850,17 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 				
 				/* 
 				 * The buffers are a bit confusing, let me explain. Arrays.copyOf(...) calls are costly in this inner
-				 * loop, so we avoid them by reusing various misfit buffers. With buffers in use, we only need to
-				 * do an array copy in the worst case scenario, where there are num_buffers consecutive kept
-				 * perturbations that do not lead to a lower energy. With num_buffers >= 3, this should be exceedingly
-				 * rare
+				 * loop, so we avoid them by reusing 3 misfit buffers. With 3 buffers, there's always one availbe to
+				 * store the current best misfit, the current solution misfit, and the misfit to be perturbed in the
+				 * next round, without ever doing an array copy.
 				 */
 				E = Enew;
-				misfit = misfit_cur_purtub;
-				misfit_ineq = misfit_ineq_cur_purtub;
+				// keep these misfits
+				for (int row : equalityData.colRows[index])
+					misfit_working[row] = misfit_perturbed[row];
+				if (hasInequalityConstraint)
+					for (int row : inequalityData.colRows[index])
+						misfit_working_ineq[row] = misfit_perturbed_ineq[row];
 				perturbs++;
 				curNumNonZero = newNonZero;
 				
@@ -786,32 +870,33 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					// we now keep xbest isolated so we never have to do an array copy
 					xbest[index] = x[index];
 					if (XBEST_ACCURACY_CHECK) xbest_check_storage = Arrays.copyOf(x, x.length);
-					misfit_best = misfit;
-					if (hasInequalityConstraint) {
-						misfit_ineq_best = misfit_ineq;
+					// keep these misfits permanently
+					for (int row : equalityData.colRows[index])
+						misfit_best[row] = misfit_perturbed[row];
+					if (hasInequalityConstraint)
+						for (int row : inequalityData.colRows[index])
+							misfit_ineq_best[row] = misfit_perturbed_ineq[row];
+					
+					if (constraintRanges != null && !constraintRanges.isEmpty()) {
+						// we need to recalculate energy the old fashioned way in order to update constraint-specific
+						// energy, this will be slower
+						Enew = calculateEnergy(x, misfit_perturbed, misfit_perturbed_ineq);
 					}
+					
 					Ebest = Enew;
 					numNonZero = curNumNonZero;
 					worseKept += worseValsNotYetSaved;
 					worseValsNotYetSaved = 0;
+					
 				}
-				
-				// now switch buffers so that we're not overwriting a kept solution
-				int next_buf = (cur_buffer + 1) % num_buffers;
-				misfit_cur_purtub = misfit_buffers[next_buf];
-				if (hasInequalityConstraint)
-					misfit_ineq_cur_purtub = misfit_ineq_buffers[next_buf];
-				if (misfit_best == misfit_cur_purtub) {
-					// worst case scenario - we've kept num_buffers non-ideal values in a row, and need to store
-					// current best misfits so as to not overwrite them
-					misfit_best = Arrays.copyOf(misfit_best, misfit_best.length);
-					if (hasInequalityConstraint)
-						misfit_ineq_best = Arrays.copyOf(misfit_ineq_best, misfit_ineq_best.length);
-				}
-				cur_buffer = next_buf;
 			} else {
 				// undo the perturbation
-				x[index] -= perturb[index];
+				x[index] -= perturb;
+				for (int row : equalityData.colRows[index])
+					misfit_perturbed[row] = misfit_working[row];
+				if (hasInequalityConstraint)
+					for (int row : inequalityData.colRows[index])
+						misfit_perturbed_ineq[row] = misfit_working_ineq[row];
 			}
 			
 			if (D) {
@@ -831,12 +916,12 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 					// only do this if debug is enabled, and do it every 100 iterations
 					
 					// calculate it the "slow" way
-					double[] comp_misfit_new = new double[misfit.length];
-					calculateMisfit(A, d, xbest, comp_misfit_new);
+					double[] comp_misfit_new = new double[misfit_working.length];
+					calculateMisfit(equalityData, xbest, comp_misfit_new);
 					double[] comp_misfit_ineq_new = null;
 					if (hasInequalityConstraint) {
-						comp_misfit_ineq_new = new double[misfit_ineq.length];
-						calculateMisfit(A_ineq, d_ineq, xbest, comp_misfit_ineq_new);
+						comp_misfit_ineq_new = new double[misfit_working.length];
+						calculateMisfit(inequalityData, xbest, comp_misfit_ineq_new);
 					}
 					double[] Ebest_temp = calculateEnergy(xbest, comp_misfit_new, comp_misfit_ineq_new);
 					double pDiff = DataUtils.getPercentDiff(Ebest[0], Ebest_temp[0]);
@@ -853,12 +938,22 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 		
 		watch.stop();
 		
+		if (ENERGY_SHORTCUT) {
+			// do it the slow way for the final energy
+			// this will reduce slow drift in threaded applications
+			Ebest = calculateEnergy(xbest, misfit_best, misfit_ineq_best);
+			
+			if (ENERGY_SHORTCUT_DEBUG)
+				System.out.println("Worst energy shortcut misfit: abs="+worstEnergyShortcutAbs+"\tfract="+worstEnergyShortcutFract);
+		}
+		
 		// Preferred model is best model seen during annealing process
 		if(D) {
 			System.out.println("Annealing schedule completed. Ebest = "+Doubles.join(", ", Ebest));
 			double runSecs = watch.getTime() / 1000d;
 			System.out.println("Done with Inversion after " + runSecs + " seconds.");
 		}
+		
 		return state;
 	}
 	
@@ -945,69 +1040,73 @@ public class SerialSimulatedAnnealing implements SimulatedAnnealing {
 	}
 
 	@Override
-	public DoubleMatrix2D getA_ineq() {
-		return A_ineq;
+	public ColumnOrganizedAnnealingData getEqualityData() {
+		return equalityData;
 	}
 
 	@Override
 	public DoubleMatrix2D getA() {
-		return A;
+		return equalityData.A;
 	}
 
 	@Override
 	public double[] getD() {
-		return d;
+		return equalityData.d;
+	}
+
+	@Override
+	public ColumnOrganizedAnnealingData getInequalityData() {
+		return inequalityData;
+	}
+
+	@Override
+	public DoubleMatrix2D getA_ineq() {
+		return inequalityData == null ? null : inequalityData.A;
 	}
 
 	@Override
 	public double[] getD_ineq() {
-		return d_ineq;
+		return inequalityData == null ? null : inequalityData.d;
 	}
 
 	@Override
-	public void setInputs(DoubleMatrix2D A, double[] d, DoubleMatrix2D A_ineq, double[] d_ineq) {
-		this.A = A;
-		this.d = d;
-		this.A_ineq = A_ineq;
-		this.d_ineq = d_ineq;
-		setup(A_ineq, d, xbest);
+	public void setInputs(ColumnOrganizedAnnealingData equalityData, ColumnOrganizedAnnealingData inequalityData) {
+		setup(equalityData, inequalityData, xbest);
 	}
 
 	@Override
-	public void setAll(DoubleMatrix2D A, double[] d, DoubleMatrix2D A_ineq, double[] d_ineq, double[] Ebest,
-			double[] xbest, double[] misfit, double[] misfit_ineq, int numNonZero) {
-		this.A = A;
-		this.d = d;
-		this.A_ineq = A_ineq;
-		this.d_ineq = d_ineq;
+	public void setAll(ColumnOrganizedAnnealingData equalityData, ColumnOrganizedAnnealingData inequalityData,
+			double[] Ebest, double[] xbest, double[] misfit, double[] misfit_ineq, int numNonZero) {
+		this.equalityData = equalityData;
+		this.inequalityData = inequalityData;
 		setResults(Ebest, xbest, misfit, misfit_ineq, numNonZero);
 	}
 	
-	public static void main(String[] args) {
-		int rups = 1;
-		int rows = 1;
-		double[] initial = new double[rups];
+//	public static void main(String[] args) {
+//		int rups = 1;
+//		int rows = 1;
+//		double[] initial = new double[rups];
 //		DoubleMatrix2D A = new DenseDoubleMatrix2D(rows, rups);
-		SparseCCDoubleMatrix2D A = new SparseCCDoubleMatrix2D(rows, rups);
-		for (int row=0; row<rows; row++)
-			for (int col=0; col<rups; col++)
-				A.set(row, col, 1d);
-		double[] d = new double[rows];
-		for (int row=0; row<rows; row++)
-			d[row] = 100;
-		
-		SerialSimulatedAnnealing sa = new SerialSimulatedAnnealing(A, d, initial);
-		
-		sa.setRandom(new Random(1234l));
-		sa.setPerturbationFunc(GenerationFunctionType.FIXED_DEBUG);
-		
-		InversionState state = sa.iterate(1000);
-		
-		System.out.println("Iters: "+state.iterations+"\tperturbs: "+state.numPerturbsKept+"\tworse: "+state.numWorseValuesKept);
-		System.out.println("Energy: "+state.energy[0]);
-		
-		double[] sol = sa.getBestSolution();
-		System.out.println(sol[0]);
-	}
+////		SparseCCDoubleMatrix2D A = new SparseCCDoubleMatrix2D(rows, rups);
+//		for (int row=0; row<rows; row++)
+//			for (int col=0; col<rups; col++)
+//				A.set(row, col, 1d);
+//		double[] d = new double[rows];
+//		for (int row=0; row<rows; row++)
+//			d[row] = 100;
+//		
+//		SerialSimulatedAnnealing sa = new SerialSimulatedAnnealing(A, d, initial);
+//		
+//		sa.setRandom(new Random(1234l));
+//		sa.setPerturbationFunc(GenerationFunctionType.FIXED_DEBUG);
+//		
+//		InversionState state = sa.iterate(1000);
+//		
+//		System.out.println("Iters: "+state.iterations+"\tperturbs: "+state.numPerturbsKept+"\tworse: "+state.numWorseValuesKept);
+//		System.out.println("Energy: "+state.energy[0]);
+//		
+//		double[] sol = sa.getBestSolution();
+//		System.out.println(sol[0]);
+//	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SimulatedAnnealing.java
@@ -80,19 +80,23 @@ public interface SimulatedAnnealing {
 	public double[] getBestMisfit();
 	
 	public double[] getBestInequalityMisfit();
-	
-	public DoubleMatrix2D getA_ineq();
+
+	public ColumnOrganizedAnnealingData getEqualityData();
 	
 	public DoubleMatrix2D getA();
 	
 	public double[] getD();
 	
+	public ColumnOrganizedAnnealingData getInequalityData();
+	
+	public DoubleMatrix2D getA_ineq();
+	
 	public double[] getD_ineq();
 	
-	public void setInputs(DoubleMatrix2D A, double[] d, DoubleMatrix2D A_ineq, double[] d_ineq);
+	public void setInputs(ColumnOrganizedAnnealingData equalityData, ColumnOrganizedAnnealingData inequalityData);
 	
-	public void setAll(DoubleMatrix2D A, double[] d, DoubleMatrix2D A_ineq, double[] d_ineq, double[] Ebest,
-			double[] xbest, double[] misfit, double[] misfit_ineq, int numNonZero);
+	public void setAll(ColumnOrganizedAnnealingData equalityData, ColumnOrganizedAnnealingData inequalityData,
+			double[] Ebest, double[] xbest, double[] misfit, double[] misfit_ineq, int numNonZero);
 
 	public void setResults(double[] Ebest, double[] xbest);
 	

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/SimulatedAnnealing.java
@@ -105,16 +105,16 @@ public interface SimulatedAnnealing {
 	/**
 	 * Iterate for the given number of iterations
 	 * @param numIterations
-	 * @return
+	 * @return inversion state
 	 */
-	public long iterate(long numIterations);
+	public InversionState iterate(long numIterations);
 
 	/**
 	 * Iterate until the given CompletionCriteria is satisfied
 	 * @param completion
-	 * @return
+	 * @return inversion state
 	 */
-	public long iterate(CompletionCriteria completion);
+	public InversionState iterate(CompletionCriteria completion);
 	
 	/**
 	 * Sets the random number generator used - helpful for reproducing results for testing purposes
@@ -122,7 +122,15 @@ public interface SimulatedAnnealing {
 	 */
 	public void setRandom(Random r);
 
-	public long[] iterate(long startIter, long startPerturbs, CompletionCriteria criteria);
+	/**
+	 * Iterate with the given starting iteration count, perturbation count, and completion criteria
+	 * 
+	 * @param startIter
+	 * @param startPerturbs
+	 * @param criteria
+	 * @return inversion state
+	 */
+	public InversionState iterate(InversionState startingState, CompletionCriteria criteria);
 	
 	public default void writeRateVsRankPlot(File outputDir, String prefix, double[] minimumRuptureRates) throws IOException {
 		double[] solutionRates = getBestSolution();
@@ -322,6 +330,7 @@ public interface SimulatedAnnealing {
 	public static void writeProgressPlots(AnnealingProgress track, File outputDir, String prefix, int numRuptures,
 			AnnealingProgress compTrack) throws IOException {
 		ArbitrarilyDiscretizedFunc perturbsVsIters = new ArbitrarilyDiscretizedFunc();
+		ArbitrarilyDiscretizedFunc worseKeptsVsIters = track.hasWorseKepts() ? new ArbitrarilyDiscretizedFunc() : null;
 		ArbitrarilyDiscretizedFunc nonZerosVsIters = new ArbitrarilyDiscretizedFunc();
 		ArbitrarilyDiscretizedFunc percentNonZerosVsIters = new ArbitrarilyDiscretizedFunc();
 		
@@ -385,6 +394,8 @@ public interface SimulatedAnnealing {
 					hasNonZeros[j] = true;
 			}
 			perturbsVsIters.set((double)iter, (double)perturb);
+			if (worseKeptsVsIters != null)
+				worseKeptsVsIters.set((double)iter, (double)track.getNumWorseKept(i));
 			nonZerosVsIters.set((double)iter, (double)nonZeros);
 			if (numRuptures > 0)
 				percentNonZerosVsIters.set((double)iter, 100d*(double)nonZeros/(double)numRuptures);
@@ -425,7 +436,7 @@ public interface SimulatedAnnealing {
 			new PlotCurveCharacterstics(PlotLineType.SOLID, 4f, Color.CYAN.darker());
 		PlotCurveCharacterstics nzChar =
 				new PlotCurveCharacterstics(PlotLineType.SOLID, 4f, Color.ORANGE.darker());
-		PlotCurveCharacterstics pnzChar =
+		PlotCurveCharacterstics worseChar =
 			new PlotCurveCharacterstics(PlotLineType.SOLID, 4f, Color.RED.darker());
 		
 		String timeLabel = "Time (minutes)";
@@ -488,7 +499,10 @@ public interface SimulatedAnnealing {
 		perturbChars.add(perturbChar);
 		List<ArbitrarilyDiscretizedFunc> nzFuncs = new ArrayList<ArbitrarilyDiscretizedFunc>();
 		List<PlotCurveCharacterstics> nzChars = new ArrayList<>();
-		nzFuncs.add(nonZerosVsIters);
+		if (numRuptures > 0)
+			nzFuncs.add(percentNonZerosVsIters);
+		else
+			nzFuncs.add(nonZerosVsIters);
 		nzChars.add(nzChar);
 		
 		if (compTrack != null) {
@@ -503,20 +517,16 @@ public interface SimulatedAnnealing {
 		PlotSpec pSpec = new PlotSpec(perturbFuncs, perturbChars,
 				combTitle, iterationsLabel, "# Perturbations");
 		PlotSpec nzSpec = new PlotSpec(nzFuncs, nzChars,
-				combTitle, iterationsLabel, "# Non-Zero Rates");
+				combTitle, iterationsLabel, numRuptures > 0 ? "% Non-Zero Rates" : "# Non-Zero Rates");
 		List<PlotSpec> combSpecs;
-		if (numRuptures > 0) {
-			List<ArbitrarilyDiscretizedFunc> pnzFuncs = new ArrayList<ArbitrarilyDiscretizedFunc>();
-			List<PlotCurveCharacterstics> pnzChars = new ArrayList<>();
-			pnzFuncs.add(percentNonZerosVsIters);
-			pnzChars.add(pnzChar);
-			if (compPercentNonZeros != null) {
-				pnzFuncs.add(compPercentNonZeros);
-				pnzChars.add(compChar);
-			}
-			PlotSpec pnzSpec = new PlotSpec(pnzFuncs, pnzChars,
-					combTitle, iterationsLabel, "% Non-Zero Rates");
-			combSpecs = List.of(pnzSpec, nzSpec, pSpec);
+		if (worseKeptsVsIters != null) {
+			List<ArbitrarilyDiscretizedFunc> worseFuncs = new ArrayList<ArbitrarilyDiscretizedFunc>();
+			List<PlotCurveCharacterstics> worseChars = new ArrayList<>();
+			worseFuncs.add(worseKeptsVsIters);
+			worseChars.add(worseChar);
+			PlotSpec worseSpec = new PlotSpec(worseFuncs, worseChars,
+					combTitle, iterationsLabel, "# Worse Pertubs Kept");
+			combSpecs = List.of(nzSpec, worseSpec, pSpec);
 		} else {
 			combSpecs = List.of(nzSpec, pSpec);
 		}
@@ -524,7 +534,7 @@ public interface SimulatedAnnealing {
 		List<Range> combXRanges = List.of(new Range(0d, iterMax));
 		gp.drawGraphPanel(combSpecs, false, false, combXRanges, null);
 		gp.saveAsPNG(new File(outputDir, prefix+"_perturb_vs_iters.png").getAbsolutePath(),
-				plot_width, numRuptures > 0 ? (int)(plot_height*1.4) : plot_height);
+				plot_width, worseKeptsVsIters != null ? (int)(plot_height*1.4) : plot_height);
 		
 //		ArrayList<PlotCurveCharacterstics> normChars = new ArrayList<PlotCurveCharacterstics>();
 //		normChars.addAll(energyChars);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/CompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/CompletionCriteria.java
@@ -1,11 +1,9 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
 import java.io.IOException;
-import java.util.List;
 
-import org.apache.commons.lang3.time.StopWatch;
 import org.opensha.commons.util.ExceptionUtils;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
@@ -20,18 +18,10 @@ public interface CompletionCriteria {
 	/**
 	 * Evaluates if the completion criteria is satisfied
 	 * 
-	 * @param watch stop watch for keeping track of time
-	 * @param iter number of iterations completed
-	 * @param energy energy of the best solution
-	 * @param numPerturbsKept the total number of perturbations kept
-	 * @param numNonZero the number of non-zero rates
-	 * @param misfits misfit values for each row
-	 * @param misfits_ineq misfit values for each inequalty row (note that values below zero should be ignored)
-	 * @param constraintRanges constraint ranges, for interpreting misfits and or analyzing individual constraint energies
+	 * @param state current state of the inversion
 	 * @return true if completions criteria is satisfied
 	 */
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero,
-			double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges);
+	public boolean isSatisfied(InversionState state);
 	
 	public static class Adapter extends TypeAdapter<CompletionCriteria> {
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/CompoundCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/CompoundCompletionCriteria.java
@@ -1,10 +1,8 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
 import java.util.Collection;
-import java.util.List;
 
-import org.apache.commons.lang3.time.StopWatch;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class CompoundCompletionCriteria implements CompletionCriteria {
 	
@@ -15,9 +13,9 @@ public class CompoundCompletionCriteria implements CompletionCriteria {
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
+	public boolean isSatisfied(InversionState state) {
 		for (CompletionCriteria criteria : criteria) {
-			if (criteria.isSatisfied(watch, iter, energy, numPerturbsKept, numNonZero, misfits, misfits_ineq, constraintRanges))
+			if (criteria.isSatisfied(state))
 				return true;
 		}
 		return false;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/EnergyChangeCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/EnergyChangeCompletionCriteria.java
@@ -1,12 +1,10 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
 import java.util.Iterator;
-import java.util.List;
 
-import org.apache.commons.lang3.time.StopWatch;
 import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.util.DataUtils;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 import com.google.common.base.Splitter;
 
@@ -30,10 +28,9 @@ public class EnergyChangeCompletionCriteria implements CompletionCriteria {
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy,
-			long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
-		double mins = watch.getTime()/1000d/60d;
-		double e = energy[0];
+	public boolean isSatisfied(InversionState state) {
+		double mins = state.elapsedTimeMillis/1000d/60d;
+		double e = state.energy[0];
 		energyVsTime.set(mins, e);
 		if (lookBackStart <= 0)
 			lookBackStart = energyVsTime.getMinX() + lookBackMins;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/EnergyCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/EnergyCompletionCriteria.java
@@ -1,9 +1,6 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
-import java.util.List;
-
-import org.apache.commons.lang3.time.StopWatch;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class EnergyCompletionCriteria implements CompletionCriteria {
 	
@@ -19,8 +16,8 @@ public class EnergyCompletionCriteria implements CompletionCriteria {
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
-		return energy[0] <= maxEnergy;
+	public boolean isSatisfied(InversionState state) {
+		return state.energy[0] <= maxEnergy;
 	}
 	
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/IterationCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/IterationCompletionCriteria.java
@@ -1,9 +1,6 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
-import java.util.List;
-
-import org.apache.commons.lang3.time.StopWatch;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class IterationCompletionCriteria implements CompletionCriteria {
 	
@@ -20,8 +17,8 @@ public class IterationCompletionCriteria implements CompletionCriteria {
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
-		return iter >= minIterations;
+	public boolean isSatisfied(InversionState state) {
+		return state.iterations >= minIterations;
 	}
 	
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/IterationsPerVariableCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/IterationsPerVariableCompletionCriteria.java
@@ -1,0 +1,35 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
+
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
+
+public class IterationsPerVariableCompletionCriteria implements CompletionCriteria {
+	
+	private double itersPerVariable;
+	private transient long offset = 0l;
+
+	public IterationsPerVariableCompletionCriteria(double itersPerVariable) {
+		this(itersPerVariable, 0l);
+	}
+
+	public IterationsPerVariableCompletionCriteria(double itersPerVariable, long offset) {
+		this.itersPerVariable = itersPerVariable;
+		this.offset = offset;
+	}
+
+	public double getItersPerVariable() {
+		return itersPerVariable;
+	}
+
+	@Override
+	public boolean isSatisfied(InversionState state) {
+		long iters = state.iterations - offset;
+		double itersPer = (double)iters/state.bestSolution.length;
+		return itersPer >= itersPerVariable;
+	}
+	
+	@Override
+	public String toString() {
+		return "IterationsPerVariableCompletionCriteria(itersPerVar: "+(float)itersPerVariable+")";
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/MisfitStdDevCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/MisfitStdDevCompletionCriteria.java
@@ -1,10 +1,8 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
-import java.util.List;
-
-import org.apache.commons.lang3.time.StopWatch;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.ConstraintWeightingType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class MisfitStdDevCompletionCriteria implements CompletionCriteria {
 	
@@ -23,13 +21,12 @@ public class MisfitStdDevCompletionCriteria implements CompletionCriteria {
 	private static boolean D = true;
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero,
-			double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
+	public boolean isSatisfied(InversionState state) {
 		if (D) System.out.println("Evaluating Misfit Std. Dev. criteria, target="
 			+(float)targetStdDev+", type="+weightingType);
 		boolean pass = true;
-		for (int c=0; c<constraintRanges.size(); c++) {
-			ConstraintRange range = constraintRanges.get(c);
+		for (int c=0; c<state.constraintRanges.size(); c++) {
+			ConstraintRange range = state.constraintRanges.get(c);
 			if (this.weightingType != null && range.weightingType != weightingType)
 				continue;
 			
@@ -41,12 +38,12 @@ public class MisfitStdDevCompletionCriteria implements CompletionCriteria {
 			// so if follows that:
 			// sd = sqrt((1/N)*E)
 			
-			double e = energy[c+4];
+			double e = state.energy[c+4];
 			if (range.weight != 1d)
 				// remove weighting
 				e /= range.weight*range.weight;
 			double stdDev = Math.sqrt(e/(range.endRow-range.startRow));
-			if (D) System.out.println("\t"+range.shortName+"\tE="+(float)energy[c+4]
+			if (D) System.out.println("\t"+range.shortName+"\tE="+(float)state.energy[c+4]
 					+"\tunWtE="+(float)e+"\tstdDev="+(float)stdDev);
 			if (stdDev > targetStdDev) {
 				if (!D)

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/TimeCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/TimeCompletionCriteria.java
@@ -1,9 +1,6 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion;
 
-import java.util.List;
-
-import org.apache.commons.lang3.time.StopWatch;
-import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class TimeCompletionCriteria implements CompletionCriteria {
 	
@@ -19,8 +16,8 @@ public class TimeCompletionCriteria implements CompletionCriteria {
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy, long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
-		return watch.getTime() >= millis;
+	public boolean isSatisfied(InversionState state) {
+		return state.elapsedTimeMillis >= millis;
 	}
 	
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/VariableSubTimeCompletionCriteria.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/completion/VariableSubTimeCompletionCriteria.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.apache.commons.lang3.time.StopWatch;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ConstraintRange;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.InversionState;
 
 public class VariableSubTimeCompletionCriteria implements VariableSubCompletionCriteria {
 	
@@ -19,9 +20,8 @@ public class VariableSubTimeCompletionCriteria implements VariableSubCompletionC
 	}
 
 	@Override
-	public boolean isSatisfied(StopWatch watch, long iter, double[] energy,
-			long numPerturbsKept, int numNonZero, double[] misfits, double[] misfits_ineq, List<ConstraintRange> constraintRanges) {
-		return watch.getTime() >= cur;
+	public boolean isSatisfied(InversionState state) {
+		return state.elapsedTimeMillis >= cur;
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/params/GenerationFunctionType.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/params/GenerationFunctionType.java
@@ -72,6 +72,12 @@ public enum GenerationFunctionType { // how rates are perturbed each SA algorith
 			double scale = Math.pow(10, r2);
 			return (r.nextDouble()-0.5)*scale;
 		}
+	},
+	FIXED_DEBUG {
+		@Override
+		public double getPerturbation(Random r, double temperature, int index, double[] variablePerturbationBasis) {
+			return 0.01;
+		}
 	};
 	
 	public boolean isVariable() {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitProgress.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitProgress.java
@@ -1,0 +1,205 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.util.modules.AverageableModule;
+import org.opensha.commons.util.modules.helpers.CSV_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats.MisfitStats;
+
+import com.google.common.base.Preconditions;
+
+public class InversionMisfitProgress implements CSV_BackedModule, AverageableModule<InversionMisfitProgress> {
+	
+	private List<Long> iterations;
+	private List<Long> times;
+	private List<InversionMisfitStats> stats;
+	
+	@SuppressWarnings("unused") // used for deserialization
+	private InversionMisfitProgress() {}
+	
+	public InversionMisfitProgress(CSVFile<String> csv) {
+		initFromCSV(csv);
+	}
+
+	public InversionMisfitProgress(List<Long> iterations, List<Long> times, List<InversionMisfitStats> stats) {
+		Preconditions.checkState(iterations.size() == times.size());
+		Preconditions.checkState(iterations.size() == stats.size());
+		this.iterations = iterations;
+		this.times = times;
+		this.stats = stats;
+	}
+	
+	public static final String MISFIT_PROGRESS_FILE_NAME = "inversion_misfit_progress.csv";
+
+	@Override
+	public String getFileName() {
+		return MISFIT_PROGRESS_FILE_NAME;
+	}
+
+	@Override
+	public String getName() {
+		return "Inversion Misfit Progress";
+	}
+
+	public List<Long> getIterations() {
+		return iterations;
+	}
+
+	public List<Long> getTimes() {
+		return times;
+	}
+
+	public List<InversionMisfitStats> getStats() {
+		return stats;
+	}
+
+	@Override
+	public CSVFile<?> getCSV() {
+		CSVFile<String> csv = new CSVFile<>(true);
+		List<String> header = new ArrayList<>();
+		header.add("Iteration");
+		header.add("Time (ms)");
+		header.addAll(InversionMisfitStats.csvHeader);
+		csv.addLine(header);
+		
+		for (int i=0; i<iterations.size(); i++) {
+			String iters = iterations.get(i)+"";
+			String time = times.get(i)+"";
+			for (MisfitStats stat : stats.get(i).getStats()) {
+				List<String> line = new ArrayList<>(header.size());
+				line.add(iters);
+				line.add(time);
+				line.addAll(stat.buildCSVLine());
+				csv.addLine(line);
+			}
+		}
+		return csv;
+	}
+
+	@Override
+	public void initFromCSV(CSVFile<String> csv) {
+		iterations = new ArrayList<>();
+		times = new ArrayList<>();
+		stats = new ArrayList<>();
+		
+		long curIteration = -1l;
+		long curTime = -1l;
+		List<MisfitStats> curStats = null;
+		for (int row=1; row<csv.getNumRows(); row++) {
+			long iteration = csv.getLong(row, 0);
+			long time = csv.getLong(row, 1);
+			List<String> misfitLine = csv.getLine(row);
+			misfitLine = misfitLine.subList(2, misfitLine.size());
+			MisfitStats stats = new MisfitStats(misfitLine);
+
+			Preconditions.checkState(iteration >= 0l);
+			Preconditions.checkState(iteration >= curIteration);
+			Preconditions.checkState(time >= curTime);
+			
+			if (iteration != curIteration) {
+				if (curStats != null) {
+					// finalize the previous one
+					Preconditions.checkState(curIteration >= 0l);
+					Preconditions.checkState(curTime >= 0l);
+					Preconditions.checkState(!curStats.isEmpty());
+					iterations.add(curIteration);
+					times.add(curTime);
+					this.stats.add(new InversionMisfitStats(curStats));
+				}
+				curStats = new ArrayList<>();
+				curIteration = iteration;
+				curTime = time;
+			}
+			Preconditions.checkState(time == curTime);
+			// additional constraint for the same iteration
+			curStats.add(stats);
+		}
+		// finalize the last one
+		Preconditions.checkState(curIteration >= 0l);
+		Preconditions.checkState(curTime >= 0l);
+		Preconditions.checkState(!curStats.isEmpty());
+		iterations.add(curIteration);
+		times.add(curTime);
+		this.stats.add(new InversionMisfitStats(curStats));
+	}
+
+	@Override
+	public AveragingAccumulator<InversionMisfitProgress> averagingAccumulator() {
+		return new AveragingAccumulator<InversionMisfitProgress>() {
+			
+			List<InversionMisfitProgress> progresses = new ArrayList<>();
+			List<Double> weights = new ArrayList<>();
+			
+			@Override
+			public void process(InversionMisfitProgress module, double relWeight) {
+				progresses.add(module);
+				weights.add(relWeight);
+			}
+			
+			@Override
+			public Class<InversionMisfitProgress> getType() {
+				return InversionMisfitProgress.class;
+			}
+			
+			@Override
+			public InversionMisfitProgress getAverage() {
+				int minNumSteps = Integer.MAX_VALUE;
+				int maxNumSteps = 0;
+				for (InversionMisfitProgress p : progresses) {
+					int steps = p.iterations.size();
+					minNumSteps = Integer.min(minNumSteps, steps);
+					maxNumSteps = Integer.max(maxNumSteps, steps);
+				}
+				Preconditions.checkState(minNumSteps > 0, "At least 1 InversionMisfitProgress instance has no steps");
+				if (minNumSteps < maxNumSteps)
+					System.err.println("WARNING: Not all InversionMisfitProgress instances have the same number of "
+							+ "steps, only averaging the first "+minNumSteps+" (max is "+maxNumSteps+")");
+				
+				List<Long> avgIters = new ArrayList<>(minNumSteps);
+				List<Long> avgTimes = new ArrayList<>(minNumSteps);
+				List<InversionMisfitStats> avgStats = new ArrayList<>(minNumSteps);
+				
+				for (int i=0; i<minNumSteps; i++) {
+					List<Long> iters = new ArrayList<>(progresses.size());
+					List<Long> times = new ArrayList<>(progresses.size());
+					AveragingAccumulator<InversionMisfitStats> statsAccumulator = null;
+					for (int p=0; p<progresses.size(); p++) {
+						InversionMisfitProgress progress = progresses.get(p);
+						double weight = weights.get(p);
+						iters.add(progress.iterations.get(i));
+						times.add(progress.times.get(i));
+						InversionMisfitStats stats = progress.stats.get(i);
+						if (statsAccumulator == null)
+							statsAccumulator = stats.averagingAccumulator();
+						statsAccumulator.process(stats, weight);
+					}
+					avgIters.add(longAvg(iters, weights));
+					avgTimes.add(longAvg(times, weights));
+					avgStats.add(statsAccumulator.getAverage());
+				}
+				return new InversionMisfitProgress(avgIters, avgTimes, avgStats);
+			}
+		};
+	}
+	
+	private static long longAvg(List<Long> vals, List<Double> weights) {
+		long val1 = vals.get(0);
+		double avgSum = 0d;
+		double weightSum = 0d;
+		boolean allSame = true;
+		for (int i=0; i<vals.size(); i++) {
+			long val = vals.get(i);
+			double weight = weights.get(i);
+			
+			allSame = allSame && val == val1;
+			avgSum += val*weight;
+			weightSum += weight;
+		}
+		if (allSame)
+			return val1;
+		return (long)(avgSum/weightSum + 0.5);
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitStats.java
@@ -153,7 +153,7 @@ public class InversionMisfitStats implements CSV_BackedModule, BranchAverageable
 			this.rmse = Math.sqrt(mse);
 		}
 		
-		private MisfitStats(List<String> csvLine) {
+		MisfitStats(List<String> csvLine) {
 			Preconditions.checkState(csvLine.size() == csvHeader.size() || csvLine.size() == csvHeader.size()-1);
 			int index = 0;
 			String name = csvLine.get(index++);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfits.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfits.java
@@ -152,7 +152,7 @@ public class InversionMisfits implements ArchivableModule, AverageableModule<Inv
 	private static void writeData(double[] misfits, double[] data,
 			String entryPrefix, String fileName, ZipOutputStream zout) throws IOException {
 		CSVFile<String> csv = new CSVFile<>(true);
-		Preconditions.checkState(misfits.length == data.length);
+		Preconditions.checkState(misfits.length == data.length, "%s != %s");
 		csv.addLine("Row", "Data", "Misfit");
 		for (int i=0; i<misfits.length; i++)
 			csv.addLine(i+"", data[i]+"", misfits[i]+"");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -463,6 +463,16 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 			writtenFiles.add(progressFile);
 		}
 		
+		InversionMisfitProgress misfitProgress = sol.getModule(InversionMisfitProgress.class);
+		
+		if (misfitProgress != null) {
+			String progressFile = getBranchFileName(branch, prefix,
+					InversionMisfitProgress.MISFIT_PROGRESS_FILE_NAME, true);
+			Preconditions.checkState(!writtenFiles.contains(progressFile));
+			CSV_BackedModule.writeToArchive(misfitProgress.getCSV(), zout, entryPrefix, progressFile);
+			writtenFiles.add(progressFile);
+		}
+		
 		// use rupture-sections file to figure out which things affect plausibility
 		List<? extends LogicTreeLevel<?>> rupSectLevels = getLevelsAffectingFile(
 				FaultSystemRupSet.RUP_SECTS_FILE_NAME, true);
@@ -618,6 +628,13 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 		if (progressFile != null && zip.getEntry(progressFile) != null) {
 			CSVFile<String> progressCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, progressFile);
 			AnnealingProgress progress = new AnnealingProgress(progressCSV);
+			sol.addModule(progress);
+		}
+		
+		String misfitProgressFile = getBranchFileName(branch, InversionMisfitProgress.MISFIT_PROGRESS_FILE_NAME, true);
+		if (misfitProgressFile != null && zip.getEntry(misfitProgressFile) != null) {
+			CSVFile<String> progressCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, misfitProgressFile);
+			InversionMisfitProgress progress = new InversionMisfitProgress(progressCSV);
 			sol.addModule(progress);
 		}
 		

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/FaultSectionConnectionsPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/FaultSectionConnectionsPlot.java
@@ -276,10 +276,10 @@ public class FaultSectionConnectionsPlot extends AbstractRupSetPlot {
 			
 			table.addLine("![Primary clusters]("+relPathToResources+"/"+primaryClusters.getName()+")",
 					"![Comparison clusters]("+relPathToResources+"/"+compClusters.getName()+")");
-			table.addLine(RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", "conn_clusters.geojson")
-					+" [Download GeoJSON](conn_clusters.geojson)",
-					RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", "conn_clusters_comp.geojson")
-					+" [Download GeoJSON](conn_clusters_comp.geojson)");
+			table.addLine(RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", relPathToResources+"/conn_clusters.geojson")
+					+" [Download GeoJSON]("+relPathToResources+"/conn_clusters.geojson)",
+					RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", relPathToResources+"/conn_clusters_comp.geojson")
+					+" [Download GeoJSON]("+relPathToResources+"/conn_clusters_comp.geojson)");
 			lines.addAll(table.build());
 		} else {
 			table = MarkdownUtils.tableBuilder();
@@ -288,8 +288,8 @@ public class FaultSectionConnectionsPlot extends AbstractRupSetPlot {
 					"Connected Section Clusters");
 			
 			table.addLine("![Primary clusters]("+relPathToResources+"/"+primaryClusters.getName()+")");
-			table.addLine(RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", "conn_clusters.geojson")
-					+" [Download GeoJSON](conn_clusters.geojson)");
+			table.addLine(RupSetMapMaker.getGeoJSONViewerRelativeLink("View GeoJSON", relPathToResources+"/conn_clusters.geojson")
+					+" [Download GeoJSON]("+relPathToResources+"/conn_clusters.geojson)");
 			lines.addAll(table.build());
 		}
 		return lines;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/InversionProgressPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/InversionProgressPlot.java
@@ -1,23 +1,43 @@
 package org.opensha.sha.earthquake.faultSysSolution.reports.plots;
 
+import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.jfree.chart.plot.DatasetRenderingOrder;
+import org.jfree.data.Range;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.gui.plot.HeadlessGraphPanel;
+import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
+import org.opensha.commons.gui.plot.PlotLineType;
+import org.opensha.commons.gui.plot.PlotSpec;
+import org.opensha.commons.gui.plot.PlotUtils;
+import org.opensha.commons.mapping.gmt.elements.GMT_CPT_Files;
 import org.opensha.commons.util.Interpolate;
 import org.opensha.commons.util.MarkdownUtils;
 import org.opensha.commons.util.MarkdownUtils.TableBuilder;
+import org.opensha.commons.util.cpt.CPT;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ThreadedSimulatedAnnealing;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.AnnealingProgress;
-import org.opensha.sha.earthquake.faultSysSolution.modules.InitialSolution;
-import org.opensha.sha.earthquake.faultSysSolution.modules.WaterLevelRates;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitProgress;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats.MisfitStats;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats.Quantity;
 import org.opensha.sha.earthquake.faultSysSolution.reports.AbstractSolutionPlot;
 import org.opensha.sha.earthquake.faultSysSolution.reports.ReportMetadata;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
 
 public class InversionProgressPlot extends AbstractSolutionPlot {
 
@@ -41,6 +61,7 @@ public class InversionProgressPlot extends AbstractSolutionPlot {
 		double mins = secs/60d;
 		double hours = mins/60d;
 		long perturbs = progress.getNumPerturbations(progress.size()-1);
+		long worseKept = progress.hasWorseKepts() ? progress.getNumWorseKept(progress.size()-1) : -1l;
 		long iters = progress.getIterations(progress.size()-1);
 		double totalEnergy = progress.getEnergies(progress.size()-1)[0];
 
@@ -54,7 +75,10 @@ public class InversionProgressPlot extends AbstractSolutionPlot {
 		if (compProgress != null)
 			table.addColumn("");
 		table.addColumn("**Iterations**").addColumn("**Time**").addColumn("**Iterations Per Sec.**")
-			.addColumn("**Perturbations**").addColumn("**Iterations Per Perturb.**").addColumn("**Total Energy**");
+			.addColumn("**Perturbations**");
+		if (worseKept >= 0l)
+			table.addColumn("**# Worse Pertubations Kept**");
+		table.addColumn("**Iterations Per Perturb.**").addColumn("**Total Energy**");
 		table.finalizeLine().initNewLine();
 		if (compProgress != null)
 			table.addColumn("Primary");
@@ -63,6 +87,8 @@ public class InversionProgressPlot extends AbstractSolutionPlot {
 		table.addColumn(ThreadedSimulatedAnnealing.timeStr(millis));
 		table.addColumn(countDF.format(ips));
 		table.addColumn(countDF.format(perturbs));
+		if (worseKept >= 0l)
+			table.addColumn(countDF.format(worseKept));
 		table.addColumn(ipp > 100d ? countDF.format((int)(ipp+0.5)) : twoDigits.format(ipp));
 		
 		table.addColumn((float)totalEnergy);
@@ -187,6 +213,142 @@ public class InversionProgressPlot extends AbstractSolutionPlot {
 		lines.add("");
 		
 		lines.add("![Perturbations]("+relPathToResources+"/"+prefix+"_perturb_vs_iters.png)");
+		
+		if (sol.hasModule(InversionMisfitProgress.class)) {
+			// also do misfit progress
+			
+			InversionMisfitProgress misfitProgress = sol.getModule(InversionMisfitProgress.class);
+			
+			List<Long> iterations = misfitProgress.getIterations();
+			List<Long> times = misfitProgress.getTimes();
+			List<InversionMisfitStats> statsList = misfitProgress.getStats();
+			
+			if (!iterations.isEmpty()) {
+				lines.add(getSubHeading()+" Constraint Misfit Progress");
+				lines.add(topLink); lines.add("");
+				
+				List<String> constraintNames = new ArrayList<>();
+				for (MisfitStats stats : statsList.get(0).getStats())
+					constraintNames.add(stats.range.name);
+				Preconditions.checkState(!constraintNames.isEmpty());
+				
+				Table<String, Quantity, ArbitrarilyDiscretizedFunc> constrValIterFuncs = HashBasedTable.create();
+				Map<String, ArbitrarilyDiscretizedFunc> constrWeightIterFuncs = new HashMap<>();
+				Map<Quantity, ArbitrarilyDiscretizedFunc> avgValIterFuncs = new HashMap<>();
+				
+				Quantity[] quantities = { Quantity.MAD, Quantity.STD_DEV };
+				
+				for (Quantity q : quantities)
+					avgValIterFuncs.put(q, new ArbitrarilyDiscretizedFunc("Average"));
+				
+				for (int i=0; i<iterations.size(); i++) {
+					long iter = iterations.get(i);
+					InversionMisfitStats stats = statsList.get(i);
+					
+					for (Quantity q : quantities) {
+						double avgVal = 0d;
+						
+						for (MisfitStats misfits : stats.getStats()) {
+							String name = misfits.range.name;
+							if (!constrValIterFuncs.contains(name, q))
+								constrValIterFuncs.put(name, q, new ArbitrarilyDiscretizedFunc(name));
+							
+							double val = misfits.get(q);
+							constrValIterFuncs.get(name, q).set((double)iter, val);
+							avgVal += val;
+							
+							if (q == quantities[0]) {
+								// track weight
+								if (!constrWeightIterFuncs.containsKey(name))
+									constrWeightIterFuncs.put(name, new ArbitrarilyDiscretizedFunc(name));
+								constrWeightIterFuncs.get(name).set((double)iter, misfits.range.weight);
+							}
+						}
+						
+						avgVal /= stats.getStats().size();
+						avgValIterFuncs.get(q).set((double)iter, avgVal);
+					}
+				}
+				
+				// same, but with a null at the end (that will be for weights)
+				Quantity[] plotQ = new Quantity[quantities.length+1];
+				for (int q=0; q<quantities.length; q++)
+					plotQ[q] = quantities[q];
+				
+				CPT colorCPT = GMT_CPT_Files.RAINBOW_UNIFORM.instance().rescale(0d, constraintNames.size()-1d);
+				
+				for (Quantity quantity : plotQ) {
+					Map<String, ArbitrarilyDiscretizedFunc> constrFuncs;
+					ArbitrarilyDiscretizedFunc avgFunc;
+					String myPrefix, yAxisLabel;
+					boolean yLog;
+					if (quantity == null) {
+						yAxisLabel = "Constraint Weight";
+						myPrefix = "misift_progress_weights";
+						constrFuncs = constrWeightIterFuncs;
+						avgFunc = null;
+						yLog = true;
+						
+						// see if we actually have variable weights
+						boolean variable = false;
+						for (ArbitrarilyDiscretizedFunc func : constrFuncs.values()) {
+							if ((float)func.getMinY() != (float)func.getMaxY()) {
+								variable = true;
+								break;
+							}
+						}
+						if (!variable)
+							continue;
+					} else {
+						yAxisLabel = "Misfit "+quantity;
+						myPrefix = "misift_progress_"+quantity.name();
+						constrFuncs = constrValIterFuncs.column(quantity);
+						avgFunc = avgValIterFuncs.get(quantity);
+						yLog = false;
+					}
+					
+					List<DiscretizedFunc> funcs = new ArrayList<>();
+					List<PlotCurveCharacterstics> chars = new ArrayList<>();
+					
+					if (avgFunc != null) {
+						funcs.add(avgFunc);
+						chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 4f, Color.BLACK));
+					}
+					
+					for (int i=0; i<constraintNames.size(); i++) {
+						String name = constraintNames.get(i);
+						funcs.add(constrFuncs.get(name));
+						chars.add(new PlotCurveCharacterstics(PlotLineType.SOLID, 3f, colorCPT.getColor((float)i)));
+					}
+					
+					PlotSpec spec = new PlotSpec(funcs, chars, "Misfit Progress", "Iterations", yAxisLabel);
+					spec.setLegendInset(true);
+					
+					Range xRange = new Range(0d, iterations.get(iterations.size()-1));
+					Range yRange = null;
+					if (yLog) {
+						double maxWeight = 0d;
+						double minWeight = Double.POSITIVE_INFINITY;
+						for (DiscretizedFunc func : funcs) {
+							maxWeight = Math.max(maxWeight, func.getMaxY());
+							minWeight = Math.min(minWeight, func.getMinY());
+						}
+						yRange = new Range(Math.pow(10, Math.floor(Math.log10(minWeight))),
+								Math.pow(10, Math.ceil(Math.log10(maxWeight))));
+					}
+					
+					HeadlessGraphPanel gp = PlotUtils.initHeadless();
+					
+					gp.setRenderingOrder(DatasetRenderingOrder.REVERSE);
+					gp.drawGraphPanel(spec, false, yLog, xRange, yRange);
+					
+					PlotUtils.writePlots(resourcesDir, myPrefix, gp, 1000, 700, true, false, false);
+					
+					lines.add("![misfit plot]("+relPathToResources+"/"+myPrefix+".png)");
+				}
+			}
+			
+		}
 		
 		return lines;
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SectBySectDetailPlots.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SectBySectDetailPlots.java
@@ -1940,8 +1940,6 @@ public class SectBySectDetailPlots extends AbstractRupSetPlot {
 		List<XY_DataSet> funcs = new ArrayList<>();
 		List<PlotCurveCharacterstics> chars = new ArrayList<>();
 		
-		FaultSystemRupSet rupSet = meta.primary.rupSet;
-		
 		boolean comp = meta.hasComparisonSol() && meta.comparison.rupSet.hasModule(AveSlipModule.class);
 		
 		double[] rupMoRates = SectBValuePlot.calcRupMomentRates(meta.primary.sol);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/DemoFileCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/DemoFileCreator.java
@@ -134,7 +134,7 @@ class DemoFileCreator {
 		ThreadedSimulatedAnnealing tsa = new ThreadedSimulatedAnnealing(
 				invGen.getA(), invGen.getD(), invGen.getInitialSolution(), threads, subCompletion);
 		tsa.setRandom(new Random(123456789l));
-		long iterations = tsa.iterate(completion);
+		long iterations = tsa.iterate(completion).iterations;
 		System.out.println("Completed "+iterations+" iterations");
 		double[] rates = invGen.adjustSolutionForWaterLevel(tsa.getBestSolution());
 		

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23InvConfigFactory.java
@@ -91,8 +91,10 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 	@Override
 	public FaultSystemRupSet buildRuptureSet(LogicTreeBranch<?> branch, int threads) {
 		// build empty-ish rup set without modules attached
-		FaultSystemRupSet rupSet = buildGenericRupSet(branch, threads);
-		
+		return buildRuptureSet(branch, buildGenericRupSet(branch, threads));
+	}
+
+	public FaultSystemRupSet buildRuptureSet(LogicTreeBranch<?> branch, FaultSystemRupSet rupSet) {
 		FaultModels fm = branch.getValue(FaultModels.class);
 		DeformationModels dm = branch.getValue(DeformationModels.class);
 		if (fm != null && dm != null) {

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23InvConfigFactory.java
@@ -13,6 +13,7 @@ import org.opensha.commons.logicTree.LogicTreeBranch;
 import org.opensha.commons.logicTree.LogicTreeNode;
 import org.opensha.commons.util.ExceptionUtils;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet.Builder;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.RuptureSets;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
@@ -27,6 +28,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.Pa
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.PaleoSlipInversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.ParkfieldInversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.IterationsPerVariableCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.TimeCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.GenerationFunctionType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.NonnegativityConstraintType;
@@ -40,6 +42,7 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.RegionsOfInterest;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionLogicTree.SolutionProcessor;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.JumpProbabilityCalc;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.SupraSeisBValInversionTargetMFDs;
@@ -95,16 +98,25 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 	}
 
 	public FaultSystemRupSet buildRuptureSet(LogicTreeBranch<?> branch, FaultSystemRupSet rupSet) {
-		FaultModels fm = branch.getValue(FaultModels.class);
-		DeformationModels dm = branch.getValue(DeformationModels.class);
-		if (fm != null && dm != null) {
-			// override slip rates to the correct deformation model
-			rupSet = FaultSystemRupSet.buildFromExisting(rupSet).replaceFaultSections(
-					RuptureSets.getU3SubSects(fm, dm)).build();
-		} else if (dm != null && fm == null) {
-			System.err.println("WARNING: can't override deformation model in rupture set because fault model is null");
-		}
+		// we don't trust any modules attached to this rupture set as it could have been used for another calculation
+		// that could have attached anything. Instead, lets only keep the ruptures themselves
 		
+		FaultModels fm = branch.requireValue(FaultModels.class);
+		DeformationModels dm = branch.requireValue(DeformationModels.class);
+		// override slip rates for the given deformation model
+		List<? extends FaultSection> subSects = RuptureSets.getU3SubSects(fm, dm);
+		
+		ClusterRuptures cRups = rupSet.requireModule(ClusterRuptures.class);
+		
+		PlausibilityConfiguration plausibility = rupSet.requireModule(PlausibilityConfiguration.class);
+		ScalingRelationships scale = branch.requireValue(ScalingRelationships.class);
+		
+		rupSet = ClusterRuptureBuilder.buildClusterRupSet(scale, subSects, plausibility, cRups.getAll());
+		
+		SlipAlongRuptureModels slipAlong = branch.requireValue(SlipAlongRuptureModels.class);
+		rupSet.addModule(slipAlong.getModel());
+		
+		// add other modules
 		return getSolutionLogicTreeProcessor().processRupSet(rupSet, branch);
 	}
 
@@ -255,7 +267,7 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 			}, PlausibilityConfiguration.class);
 			
 			// offer cluster ruptures
-			// should always be single stranged
+			// should always be single stranded
 			rupSet.offerAvailableModule(new Callable<ClusterRuptures>() {
 
 				@Override
@@ -298,7 +310,7 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 		
 		double slipWeight = 1d;
 		double paleoWeight = 5;
-		double parkWeight = 50;
+		double parkWeight = 10;
 		double mfdWeight = constrModel == SubSectConstraintModels.NUCL_MFD ? 1 : 10;
 		double nuclWeight = constrModel == SubSectConstraintModels.TOT_NUCL_RATE ? 0.5 : 0d;
 		double nuclMFDWeight = constrModel == SubSectConstraintModels.NUCL_MFD ? 0.5 : 0d;
@@ -333,6 +345,8 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 		
 		double bVal = branch.requireValue(SupraSeisBValues.class).bValue;
 		
+		GRParticRateEstimator rateEst = new GRParticRateEstimator(rupSet, bVal);
+		
 		SegmentationModels segModel = branch.getValue(SegmentationModels.class);
 		System.out.println("Segmentation model: "+segModel);
 		if (segModel != null && segModel != SegmentationModels.NONE) {
@@ -340,7 +354,6 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 			
 //			InitialModelParticipationRateEstimator rateEst = new InitialModelParticipationRateEstimator(
 //					rupSet, Inversions.getDefaultVariablePerturbationBasis(rupSet));
-			SectParticipationRateEstimator rateEst = new GRParticRateEstimator(rupSet, bVal);
 
 //			double weight = 0.5d;
 //			boolean ineq = false;
@@ -371,19 +384,17 @@ public class NSHM23InvConfigFactory implements InversionConfigurationFactory {
 		
 		int avgThreads = threads / 4;
 		
-		CompletionCriteria completion;
-		if (constrModel == SubSectConstraintModels.NUCL_MFD)
-			completion = TimeCompletionCriteria.getInHours(5l);
-		else
-			completion = TimeCompletionCriteria.getInHours(2l);
+		CompletionCriteria completion = new IterationsPerVariableCompletionCriteria(5000d);
 		
 		InversionConfiguration.Builder builder = InversionConfiguration.builder(constraints, completion)
 				.threads(threads)
-				.avgThreads(avgThreads, TimeCompletionCriteria.getInMinutes(5l))
+				.subCompletion(new IterationsPerVariableCompletionCriteria(1d))
+//				.avgThreads(avgThreads, new IterationsPerVariableCompletionCriteria(100d))
+				.avgThreads(avgThreads, new IterationsPerVariableCompletionCriteria(50d))
 				.perturbation(GenerationFunctionType.VARIABLE_EXPONENTIAL_SCALE)
 				.nonNegativity(NonnegativityConstraintType.TRY_ZERO_RATES_OFTEN)
 				.sampler(sampler)
-				.variablePertubationBasis(new GRParticRateEstimator(rupSet, bVal).estimateRuptureRates());
+				.variablePertubationBasis(rateEst.estimateRuptureRates());
 		
 		if (parkWeight > 0d)
 			builder.initialSolution(constrBuilder.getParkfieldInitial(true));

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23LogicTreeBranch.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23LogicTreeBranch.java
@@ -40,7 +40,7 @@ public class NSHM23LogicTreeBranch extends LogicTreeBranch<LogicTreeNode> {
 	}
 	
 	@SuppressWarnings("unused") // used for deserialization
-	private NSHM23LogicTreeBranch() {
+	public NSHM23LogicTreeBranch() {
 		super(levels);
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
@@ -124,7 +124,7 @@ public class DraftModelConstraintBuilder {
 		magDepRelStdDev(M->0.1*Math.pow(10, supraBVal*0.5*(M-6)))
 				.slipRates().weight(1d)
 				.paleoRates().weight(5d).paleoSlips().weight(5d)
-				.parkfield().weight(50d);
+				.parkfield().weight(10d);
 		if (subSectConstrModel == SubSectConstraintModels.TOT_NUCL_RATE) {
 			supraBValMFDs().weight(10).sectSupraRates().weight(0.5);
 		} else if (subSectConstrModel == SubSectConstraintModels.NUCL_MFD) {

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
@@ -41,6 +41,7 @@ import org.opensha.sha.earthquake.faultSysSolution.reports.plots.SectBValuePlot;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.FaultSubsectionCluster;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
+import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.SubSectConstraintModels;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.SupraSeisBValInversionTargetMFDs;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.SupraSeisBValInversionTargetMFDs.Builder;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.SupraSeisBValInversionTargetMFDs.SubSeisMoRateReduction;
@@ -96,7 +97,11 @@ public class DraftModelConstraintBuilder {
 	}
 	
 	public DraftModelConstraintBuilder defaultConstraints() {
-		return defaultDataConstraints().defaultMetaConstraints();
+		return defaultConstraints(SubSectConstraintModels.TOT_NUCL_RATE);
+	}
+	
+	public DraftModelConstraintBuilder defaultConstraints(SubSectConstraintModels subSectConstrModel) {
+		return defaultDataConstraints(subSectConstrModel).defaultMetaConstraints();
 	}
 	
 	public DraftModelConstraintBuilder except(Class<? extends InversionConstraint> clazz) {
@@ -112,12 +117,23 @@ public class DraftModelConstraintBuilder {
 	}
 	
 	public DraftModelConstraintBuilder defaultDataConstraints() {
-		return magDepRelStdDev(M->0.1*Math.pow(10, supraBVal*0.5*(M-6)))
+		return defaultDataConstraints(SubSectConstraintModels.TOT_NUCL_RATE);
+	}
+	
+	public DraftModelConstraintBuilder defaultDataConstraints(SubSectConstraintModels subSectConstrModel) {
+		magDepRelStdDev(M->0.1*Math.pow(10, supraBVal*0.5*(M-6)))
 				.slipRates().weight(1d)
 				.paleoRates().weight(5d).paleoSlips().weight(5d)
-				.parkfield().weight(100d)
-				.supraBValMFDs().weight(10)
-				.sectSupraRates().weight(0.5);
+				.parkfield().weight(50d);
+		if (subSectConstrModel == SubSectConstraintModels.TOT_NUCL_RATE) {
+			supraBValMFDs().weight(10).sectSupraRates().weight(0.5);
+		} else if (subSectConstrModel == SubSectConstraintModels.NUCL_MFD) {
+			supraBValMFDs().weight(1).sectSupraNuclMFDs().weight(0.5);
+		} else if (subSectConstrModel == null || subSectConstrModel == SubSectConstraintModels.NONE) {
+			supraBValMFDs().weight(1);
+		}
+		
+		return this;
 	}
 	
 	public DraftModelConstraintBuilder slipRates() {

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/estimators/DraftModelConstraintBuilder.java
@@ -753,5 +753,21 @@ public class DraftModelConstraintBuilder {
 		}
 		return new IntegerPDF_FunctionSampler(weights);
 	}
+	
+	public double[] getParkfieldInitial(boolean ensureNotSkipped) {
+		List<Integer> parkRups = new ArrayList<>(UCERF3InversionInputGenerator.findParkfieldRups(rupSet));
+		double[] initial = new double[rupSet.getNumRuptures()];
+		if (ensureNotSkipped) {
+			HashSet<Integer> skips = new HashSet<Integer>(getRupIndexesBelowMinMag());
+			for (int r=parkRups.size(); --r>=0;)
+				if (skips.contains(parkRups.get(r)))
+					parkRups.remove(r);
+			Preconditions.checkState(!skips.isEmpty(), "All parkfield rups are skipped!");
+		}
+		double rateEach = parkfieldRate.bestEstimate/(double)parkRups.size();
+		for (int rup : parkRups)
+			initial[rup] = rateEach;
+		return initial;
+	}
 
 }


### PR DESCRIPTION
cc @chrisbc @voj

This pull request greatly improves efficiency of the simulated annealing algorithm by a factor of ~6-40x. The actual improvements depends on problem size, with the greatest benefit for larger problems (more constraint rows). Before, inversion speed scaled approximately inverse-linearly with row count, but now the dependence on row count is minimal (performance is similar for large and small problems).

Speedup examples:
* Large model with a full nucleation MFD constraint for each subsection
  * 48147 rows
  * before: ~8k iterations/sec
  * after: ~325k iterations/sec
  * speedup: ~40x
* Smaller model with a single nucleation rate constraint for each subsection
  * 5542 rows
  * before: ~60k iterations/sec
  * after: ~370k iterations/sec
  * speedup: ~6x

I think that I have now (really this time) squeezed just about every ounce of possible performance out of the algorithm. Details on the changes are below.

## Removed all Arrays.copyOf(...) and System.arraycopy(...) invocations from the iteration loop

This was the primary bottleneck for large problems. Every iteration had 1 System.arraycopy(...) on misfit vectors (2 if there are inequality constraints). Additional array copies were possible in certain worse case scenarios as well, e.g., randomly keeping non-ideal perturbations. Now, I keep track of misfits for the best, current kept model, and current perturbed model (that we may or may not keep depending on energy and temperature) separately. Instead of doing full array copies, I copy (or roll back) only rows that were modified in those misfit arrays, as needed.

I also removed an array copy on the solution on every kept worse perturbation.

These had an enormous impact on older compute nodes at CARC that presumably don't have as much memory bandwidth.

## Moved conditional statements out of core loops

I also moved some if statements out of the core energy calculation loops. This leads to slightly more duplicated code, but the duplicated code is simple and side by side.

## Minor performance improvements to sum of squares calculations

I now use `Math.fma(a, b, c)` to do sum of squares calculations, which both reduces floating point error and can be more efficient (can be a single floating point operation).

I also now 'unroll' the sum of squares loop which helps the JVM to vectorize it, leading to ~15% speedup in my tests. See [here](https://stackoverflow.com/a/51429748) and [here](https://en.wikipedia.org/wiki/Loop_unrolling) for more information.

## Now calculate energy change in each iteration, rather than recalculating full energy

This is the big one for small problems that were already pretty efficient.

After those previous optimizations are applied, the bulk of the remaining time is spent on energy calculation (summing the square of all misfits), which scales with row count. We need not recalculate the sum of squares for every row in the misfit array, however, as most are unchanged in any iteration. Instead, now when calculating misfits I keep track of energy change:

```
deltaE += new_misfit*new_misfit - old_misfit*old_misfit
```

Then I add that energy difference to the previously computed energy. Due to floating point precision issues, this new energy calculation method will differ slightly from the old version where we summed all rows, but I think it is actually likely more accurate. Before, if energy is large (as is the case early on), small individual constraint misfits could be ignored. For example, if energy is 1e8 and you try to add a misfit of size 1e-9, that added misfit is ignored to double precision:

```
jshell> 1e8+1e-9
$3 ==> 1.0E8
```

So, it should be more accurate to sum up the smaller energy changes, then add that smaller number to the large number (prior energy).

I recalculate the energy in full every 100k iterations, or at the end of each single thread loop, to reduce any slow accumulation of floating point errors by summing many differences. This leads to fractional errors (relative to the full energy calculation) on the order of 1e-14.

## Other minor changes

These improvements require knowing what rows in the inputs each column (rupture) affects. We were already using this information previously in the misfit calculation step if the input matrix was column compressed, but now we need it more places. I now use a new `ColumnOrganizedAnnealingData` instance that manages this information and is created by (or passed in to) the constructors of the `SimulatedAnnealing` implementations. If an input A matrix is not already column compressed, it will be here.

The `SimulatedAnnealing` interface (and thus the threaded and serial implementations) now return a new immutable `InversionState` object with more details than just the total iteration count. That object is also now used in the `CompletionCriteria` interface. This was done to make tracking inversions easier, and also to facilitate adding additional information that may be needed by any `CompletionCriteria` implementations without having to further modify the method signature (just add it to the state object instead).

New `IterationsPerVariableCompletionCriteria` where the number of iterations is dependent on the number of variables we're solving for (rupture count). For example, if you use this as a sub-completion criteria with a value of '1', then across-thread synchronization will haven every numRuptures iterations (meaning that each rupture has been randomly selected once on average). Or if you set it very large, you could use it as a full completion criteria to, for example, end an inversion after each rupture has been selected an average of 1000 times. I'm planning on using this rather than time steps in the future as it should adapt better to varying problem sizes (small or large rupture sets) and won't behave differently for slower running models (e.g., with more constraint rows).

The number of worse perturbations randomly kept is now tracked by the algorithm, stored in the AnnealingProgress module, and plotted as a function of iteration count.

My dynamically-reweighted inversion implementation is now in here and working, see `org.opensha.sha.earthquake.faultSysSolution.inversion.sa.ReweightEvenFitSimulatedAnnealing`. It will also track constraint misfit progress (beyond energy) with the new `InversionMisfitProgress` module and plots.

Fixed an unrelated issue with `ModuleContainer` where adding an available module didn't evict any matching already loaded modules. This wasn't necessarily a bug, but was counter intuitive and led to bugs in user code. Now, if you add an available module, any already loaded modules that match the given type will be evicted.