### PR TITLE
GridSourceProvider method refactoring

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/GridSourceProvider.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/GridSourceProvider.java
@@ -16,11 +16,20 @@ import scratch.UCERF3.griddedSeismicity.AbstractGridSourceProvider;
 import scratch.UCERF3.griddedSeismicity.UCERF3_GridSourceGenerator;
 
 /**
- * Interface implemented by providers of gridded (sometimes referred to as
- * 'other') seismicity sources.
+ * Interface implemented by providers of gridded (sometimes referred to as 'other') seismicity sources. Each
+ * {@link GridSourceProvider} supplies a {@link GriddedRegion}, accessible via {@link #getGriddedRegion()}. Then, at
+ * each location in the {@link GriddedRegion}, a magnitude-frequency distribution (MFD) is supplied via
+ * {@link #getMFD(int)}. That MFD may be comprised of multiple components that are also available individually:
+ * sub-seismogenic ruptures associated with a modeled faults (see {@link #getMFD_SubSeisOnFault(int)}), and/or ruptures
+ * that are unassociated with any modeled fault (see {@link #getMFD_Unassociated(int)}).
+ * <p>
+ * Focal mechanisms at each grid location are available via the {@link #getFracStrikeSlip(int)},
+ * {@link #getFracReverse(int)}, and {@link #getFracNormal(int)} methods. {@link ProbEqkSource} implementations for are
+ * available via the {@link #getSource(int, double, boolean, BackgroundRupType)} method, and also via related methods
+ * for sub-seismogenic and/or unassociated sources only.
  * 
  * @author Peter Powers
- * @version $Id:$
+ * @see AbstractGridSourceProvider
  */
 public interface GridSourceProvider extends BranchAverageableModule<GridSourceProvider> {
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/GridSourceProvider.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/GridSourceProvider.java
@@ -31,112 +31,117 @@ public interface GridSourceProvider extends BranchAverageableModule<GridSourcePr
 	public int size();
 
 	/**
-	 * Return the source at {@code index}.
-	 * @param index of source to retrieve
+	 * Return the source at {@code gridIndex}.
+	 * 
+	 * @param gridIndex of source to retrieve
 	 * @param duration of forecast
 	 * @param filterAftershocks
-	 * @param crosshair sources if true,
+	 * @param bgRupType type of source to build
 	 * @return the source at {@code index}
 	 */
-	public ProbEqkSource getSource(int index, double duration,
+	public ProbEqkSource getSource(int gridIndex, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType);
 	
 
 	/**
-	 * Return the source at {@code index}, where only the subseismo component is included
-	 * (no truly off fault component).  This returns null if there is no subseismo component
-	 * for the grid node
+	 * Return the source at {@code gridIndex}, where only the on-fault sub-seismogenic component is included
+	 * (no seismicity that is unassociated with modeled faults).  This returns null if there is no on-fault
+	 * sub-seismogenic component for the grid location
+	 * 
 	 * @param index of source to retrieve
 	 * @param duration of forecast
 	 * @param filterAftershocks
-	 * @param crosshair sources if true,
+	 * @param bgRupType type of source to build
 	 * @return the source at {@code index}
 	 */
-	public ProbEqkSource getSourceSubseismoOnly(int index, double duration,
+	public ProbEqkSource getSourceSubSeisOnFault(int gridIndex, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType);
 
 	/**
-	 * Return the source at {@code index}, where only the truly off fault component is included
-	 * (no subseismo component).  This returns null if there is no truly off fault component
-	 * for the grid node
-	 * @param index of source to retrieve
+	 * Return the source at {@code gridIndex}, where only the component that is unassociated with modeled faults
+	 * included (no on-fault sub-seismogenic component). This returns null if there is no unassociated component
+	 * for the grid location
+	 * 
+	 * @param gridIndex of source to retrieve
 	 * @param duration of forecast
 	 * @param filterAftershocks
-	 * @param crosshair sources if true,
+	 * @param bgRupType type of source to build
 	 * @return the source at {@code index}
 	 */
-	public ProbEqkSource getSourceTrulyOffOnly(int index, double duration,
+	public ProbEqkSource getSourceUnassociated(int gridIndex, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType);
 
 	/**
-	 * Returns the unassociated MFD of a grid node.
-	 * @param idx node index
+	 * Returns the unassociated MFD of a grid location, if any exists, null otherwise.
+	 * @param gridIndex grid index
 	 * @return the MFD
 	 */
-	public IncrementalMagFreqDist getNodeUnassociatedMFD(int idx);
+	public IncrementalMagFreqDist getMFD_Unassociated(int gridIndex);
 	
 	/**
-	 * Returns the sub-seismogenic MFD associated with a grid node, if any
-	 * exists.
-	 * @param idx node index
+	 * Returns the on-fault sub-seismogenic MFD associated with a grid location, if any
+	 * exists, null otherwise
+	 * @param gridIndex grid index
 	 * @return the MFD
 	 */
-	public IncrementalMagFreqDist getNodeSubSeisMFD(int idx);
+	public IncrementalMagFreqDist getMFD_SubSeisOnFault(int gridIndex);
 	
 	/**
-	 * Returns the MFD associated with a grid node trimmed to the supplied 
+	 * Returns the MFD associated with a grid location trimmed to the supplied 
 	 * minimum magnitude and the maximum non-zero magnitude.
 	 * 
-	 * @param idx node index
-	 * @param minMag minimum magniitude to trim MFD to
+	 * @param gridIndex grid index
+	 * @param minMag minimum magnitude to trim MFD to
 	 * @return the trimmed MFD
 	 */
-	public IncrementalMagFreqDist getNodeMFD(int idx, double minMag);
+	public IncrementalMagFreqDist getMFD(int gridIndex, double minMag);
 	
 	/**
-	 * Returns the MFD associated with a grid node. This is the sum of any
-	 * unassociated and sub-seismogenic MFDs for the node.
-	 * @param idx node index
+	 * Returns the MFD associated with a grid location. This is the sum of any
+	 * unassociated and sub-seismogenic MFDs for the location.
+	 * 
+	 * @param gridIndex grid index
 	 * @return the MFD
-	 * @see UCERF3_GridSourceGenerator#getNodeUnassociatedMFD(int)
-	 * @see UCERF3_GridSourceGenerator#getNodeSubSeisMFD(int)
+	 * @see UCERF3_GridSourceGenerator#getMFD_Unassociated(int)
+	 * @see UCERF3_GridSourceGenerator#getMFD_SubSeisOnFault(int)
 	 */
-	public IncrementalMagFreqDist getNodeMFD(int idx);
+	public IncrementalMagFreqDist getMFD(int gridIndex);
 	
 	/**
 	 * Returns the gridded region associated with these grid sources.
+	 * 
 	 * @return the gridded region
 	 */
 	public GriddedRegion getGriddedRegion();
 	
 	/**
-	 * Returns the fraction of focal mechanisms at this node that are strike slip
-	 * @param idx
+	 * Returns the fraction of focal mechanisms at this grid index that are strike slip
+	 * @param gridIndex
 	 * @return
 	 */
-	public abstract double getFracStrikeSlip(int idx);
+	public abstract double getFracStrikeSlip(int gridIndex);
 
 	/**
-	 * Returns the fraction of focal mechanisms at this node that are reverse
-	 * @param idx
+	 * Returns the fraction of focal mechanisms at this grid index that are reverse
+	 * @param gridIndex
 	 * @return
 	 */
-	public abstract double getFracReverse(int idx);
+	public abstract double getFracReverse(int gridIndex);
 
 	/**
-	 * Returns the fraction of focal mechanisms at this node that are normal
-	 * @param idx
+	 * Returns the fraction of focal mechanisms at this grid index that are normal
+	 * @param gridIndex
 	 * @return
 	 */
-	public abstract double getFracNormal(int idx);
+	public abstract double getFracNormal(int gridIndex);
 	
 	/**
 	 * Scales all MFDs by the given values, and throws an exception if the array size is not equal to the
-	 * number of nodes in the gridded region
+	 * number of locations in the gridded region
 	 * 
 	 * @param valuesArray
 	 */
-	public void scaleAllNodeMFDs(double[] valuesArray);
+	public void scaleAllMFDs(double[] valuesArray);
 
 	@Override
 	default AveragingAccumulator<GridSourceProvider> averagingAccumulator() {
@@ -144,8 +149,8 @@ public interface GridSourceProvider extends BranchAverageableModule<GridSourcePr
 			
 			private GridSourceProvider refGridProv = null;
 			private GriddedRegion gridReg = null;
-			private Map<Integer, IncrementalMagFreqDist> nodeSubSeisMFDs = null;
-			private Map<Integer, IncrementalMagFreqDist> nodeUnassociatedMFDs = null;
+			private Map<Integer, IncrementalMagFreqDist> subSeisMFDs = null;
+			private Map<Integer, IncrementalMagFreqDist> unassociatedMFDs = null;
 			
 			private double totWeight = 0;
 			
@@ -161,8 +166,8 @@ public interface GridSourceProvider extends BranchAverageableModule<GridSourcePr
 				if (refGridProv == null) {
 					refGridProv = module;
 					gridReg = module.getGriddedRegion();
-					nodeSubSeisMFDs = new HashMap<>();
-					nodeUnassociatedMFDs = new HashMap<>();
+					subSeisMFDs = new HashMap<>();
+					unassociatedMFDs = new HashMap<>();
 					
 					fractSS = new double[refGridProv.size()];
 					fractR = new double[fractSS.length];
@@ -172,8 +177,8 @@ public interface GridSourceProvider extends BranchAverageableModule<GridSourcePr
 				}
 				totWeight += relWeight;
 				for (int i=0; i<gridReg.getNodeCount(); i++) {
-					addWeighted(nodeSubSeisMFDs, i, module.getNodeSubSeisMFD(i), relWeight);
-					addWeighted(nodeUnassociatedMFDs, i, module.getNodeUnassociatedMFD(i), relWeight);
+					addWeighted(subSeisMFDs, i, module.getMFD_SubSeisOnFault(i), relWeight);
+					addWeighted(unassociatedMFDs, i, module.getMFD_Unassociated(i), relWeight);
 					fractSS[i] += module.getFracStrikeSlip(i)*relWeight;
 					fractR[i] += module.getFracReverse(i)*relWeight;
 					fractN[i] += module.getFracNormal(i)*relWeight;
@@ -184,19 +189,19 @@ public interface GridSourceProvider extends BranchAverageableModule<GridSourcePr
 			public GridSourceProvider getAverage() {
 				double scale = 1d/totWeight;
 				for (int i=0; i<fractSS.length; i++) {
-					IncrementalMagFreqDist subSeisMFD = nodeSubSeisMFDs.get(i);
+					IncrementalMagFreqDist subSeisMFD = subSeisMFDs.get(i);
 					if (subSeisMFD != null)
 						subSeisMFD.scale(scale);
-					IncrementalMagFreqDist nodeUnassociatedMFD = nodeUnassociatedMFDs.get(i);
-					if (nodeUnassociatedMFD != null)
-						nodeUnassociatedMFD.scale(scale);
+					IncrementalMagFreqDist unassociatedMFD = unassociatedMFDs.get(i);
+					if (unassociatedMFD != null)
+						unassociatedMFD.scale(scale);
 					fractSS[i] *= scale;
 					fractR[i] *= scale;
 					fractN[i] *= scale;
 				}
 				
 				return new AbstractGridSourceProvider.Precomputed(refGridProv.getGriddedRegion(),
-						nodeSubSeisMFDs, nodeUnassociatedMFDs, fractSS, fractN, fractR);
+						subSeisMFDs, unassociatedMFDs, fractSS, fractN, fractR);
 			}
 		};
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
@@ -319,7 +319,7 @@ public class SolMFDPlot extends AbstractRupSetPlot {
 			GriddedRegion gridReg = prov.getGriddedRegion();
 			boolean regionTest = region != null && region != gridReg && !region.getBorder().equals(gridReg.getBorder());
 			for (int i=0; i<gridReg.getNodeCount(); i++) {
-				IncrementalMagFreqDist nodeMFD = prov.getNodeMFD(i);
+				IncrementalMagFreqDist nodeMFD = prov.getMFD(i);
 				if (nodeMFD == null)
 					continue;
 				if (regionTest && !region.contains(gridReg.getLocation(i)))

--- a/src/main/java/scratch/UCERF3/analysis/CompoundFSSPlots.java
+++ b/src/main/java/scratch/UCERF3/analysis/CompoundFSSPlots.java
@@ -6198,8 +6198,8 @@ public abstract class CompoundFSSPlots implements Serializable {
 				region = gridSources.getGriddedRegion();
 			
 			for (int i=0; i<region.getNumLocations(); i++) {
-				nodeSubSeisMFDs.put(i, gridSources.getNodeSubSeisMFD(i));
-				nodeUnassociatedMFDs.put(i, gridSources.getNodeUnassociatedMFD(i));
+				nodeSubSeisMFDs.put(i, gridSources.getMFD_SubSeisOnFault(i));
+				nodeUnassociatedMFDs.put(i, gridSources.getMFD_Unassociated(i));
 			}
 			List<? extends IncrementalMagFreqDist> subSeisMFDs = sol.getFinalSubSeismoOnFaultMFD_List();
 			

--- a/src/main/java/scratch/UCERF3/analysis/FaultSysSolutionERF_Calc.java
+++ b/src/main/java/scratch/UCERF3/analysis/FaultSysSolutionERF_Calc.java
@@ -5384,7 +5384,7 @@ public class FaultSysSolutionERF_Calc {
 		GridSourceProvider gridSrcProvider = erf.getGridSourceProvider();
 		SummedMagFreqDist mfd1 = new SummedMagFreqDist(2.05,8.95,70);
 		for(int i=0;i<gridSrcProvider.getGriddedRegion().getNumLocations(); i++) {
-			IncrementalMagFreqDist mfd = gridSrcProvider.getNodeSubSeisMFD(i);
+			IncrementalMagFreqDist mfd = gridSrcProvider.getMFD_SubSeisOnFault(i);
 			if(mfd != null)
 				mfd1.addIncrementalMagFreqDist(mfd);
 //			else {

--- a/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_PrimaryEventSampler.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_PrimaryEventSampler.java
@@ -1069,8 +1069,8 @@ double maxCharFactor = maxRate/cubeRateBeyondDistThresh;
 		
 		int num0=0,num1=0,num2=0;
 		for(int i=0;i<numGridLocs; i++) {
-			IncrementalMagFreqDist subSeisMFD = gridSrcProvider.getNodeSubSeisMFD(i);
-			IncrementalMagFreqDist trulyOffMFD = gridSrcProvider.getNodeUnassociatedMFD(i);
+			IncrementalMagFreqDist subSeisMFD = gridSrcProvider.getMFD_SubSeisOnFault(i);
+			IncrementalMagFreqDist trulyOffMFD = gridSrcProvider.getMFD_Unassociated(i);
 			double frac = faultPolyMgr.getNodeFraction(i);
 			if(subSeisMFD == null && trulyOffMFD != null) {
 				gridSeisStatus[i] = 0;	// no cubes are inside; all are truly off
@@ -4271,7 +4271,7 @@ double maxCharFactor = maxRate/cubeRateBeyondDistThresh;
 					// check whether hypLoc is now out of region, and return false if so
 					if(testIndex == -1)
 						return false;
-					IncrementalMagFreqDist mfd = fssERF.getSolution().getGridSourceProvider().getNodeMFD(testIndex);
+					IncrementalMagFreqDist mfd = fssERF.getSolution().getGridSourceProvider().getMFD(testIndex);
 //					if(mfd==null) {
 //						throw new RuntimeException("testIndex="+testIndex+"\thypLoc= "+hypLoc+"\tgridLoc= "+tempERF.getSolution().getGridSourceProvider().getGriddedRegion().getLocation(testIndex));
 //					}

--- a/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_Simulator.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_Simulator.java
@@ -1159,12 +1159,12 @@ public class ETAS_Simulator {
 	public static void correctGriddedSeismicityRatesInERF(FaultSystemSolution sol, boolean plotRateRatio,
 			double[] gridSeisCorrValsArray) {
 		GridSourceProvider gridSources = sol.getGridSourceProvider();
-		gridSources.scaleAllNodeMFDs(gridSeisCorrValsArray);
+		gridSources.scaleAllMFDs(gridSeisCorrValsArray);
 		
 		double totalRate=0;
 		double[] nodeRateArray = new double[gridSources.size()];
 		for(int i=0;i<nodeRateArray.length;i++) {
-			nodeRateArray[i] = gridSources.getNodeMFD(i).getCumRate(2.55);
+			nodeRateArray[i] = gridSources.getMFD(i).getCumRate(2.55);
 			totalRate+=nodeRateArray[i];
 		}
 				

--- a/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_Utils.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_Utils.java
@@ -2548,7 +2548,7 @@ System.out.println(sectID+"\t"+primaryFromSupraArray[sectID]+"\t"+resultArray[se
 		SummedMagFreqDist trulyOffMFD = new SummedMagFreqDist(2.55, 8.45, 60);
 		GridSourceProvider gridProvider = erf.getGridSourceProvider();
 		for(int n=0;n<gridProvider.getGriddedRegion().getNodeCount();n++) {
-			ProbEqkSource src = erf.getGridSourceProvider().getSourceTrulyOffOnly(n, 1.0, false, BackgroundRupType.POINT);
+			ProbEqkSource src = erf.getGridSourceProvider().getSourceUnassociated(n, 1.0, false, BackgroundRupType.POINT);
 			if(src != null) {
 				for(ProbEqkRupture rup : src) {
 					trulyOffMFD.add(rup.getMag(), rup.getMeanAnnualRate(1.0));

--- a/src/main/java/scratch/UCERF3/erf/ETAS/HaywiredSRL_PaperCalc.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/HaywiredSRL_PaperCalc.java
@@ -130,7 +130,7 @@ public class HaywiredSRL_PaperCalc {
 		System.out.println("Calculating gridded");
 		for (int lowResIndex=0; lowResIndex<gridProv.size(); lowResIndex++) {
 			List<Integer> indexes = lowToHighResIndexMap.get(lowResIndex);
-			IncrementalMagFreqDist mfd = gridProv.getNodeMFD(lowResIndex);
+			IncrementalMagFreqDist mfd = gridProv.getMFD(lowResIndex);
 			double rateAbove = 0d;
 			for (Point2D pt : mfd)
 				if (pt.getX() >= minMag)

--- a/src/main/java/scratch/UCERF3/erf/ETAS/analysis/ETAS_GriddedNucleationPlot.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/analysis/ETAS_GriddedNucleationPlot.java
@@ -180,7 +180,7 @@ public class ETAS_GriddedNucleationPlot extends ETAS_AbstractPlot {
 					if (mags[i] >= modalMag && mags[i] >= 5d) {
 						fssXYZs[i] = new GriddedGeoDataSet(gridReg, false);
 						for (int j=0; j<gridProv.size(); j++) {
-							IncrementalMagFreqDist mfd = gridProv.getNodeMFD(j);
+							IncrementalMagFreqDist mfd = gridProv.getMFD(j);
 							for (int k=0; k<mfd.size(); k++)
 								if (mfd.getX(k) >= mags[i])
 									fssXYZs[i].set(j, fssXYZs[i].get(j)+mfd.getY(k));

--- a/src/main/java/scratch/UCERF3/erf/ETAS/analysis/ETAS_MFD_Plot.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/analysis/ETAS_MFD_Plot.java
@@ -414,7 +414,7 @@ public class ETAS_MFD_Plot extends ETAS_AbstractPlot {
 		if (gridProv != null) {
 			double minMag = 5d;
 			for (int i=0; i<gridProv.size(); i++) {
-				IncrementalMagFreqDist nodeMFD = gridProv.getNodeMFD(i);
+				IncrementalMagFreqDist nodeMFD = gridProv.getMFD(i);
 				for (int j=0; j<nodeMFD.size(); j++) {
 					double x = nodeMFD.getX(j);
 					if (x >= minMag)

--- a/src/main/java/scratch/UCERF3/erf/FaultSystemSolutionERF.java
+++ b/src/main/java/scratch/UCERF3/erf/FaultSystemSolutionERF.java
@@ -775,7 +775,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 			if (gridSources == null)
 				return null;
 			else
-				return gridSources.getSourceSubseismoOnly(iSource, timeSpan.getDuration(),
+				return gridSources.getSourceSubSeisOnFault(iSource, timeSpan.getDuration(),
 						applyAftershockFilter, bgRupType);
 		} else if(bgInclude.equals(EXCLUDE)) {
 			return null;
@@ -785,7 +785,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 			if (gridSources == null)
 				return null;
 			else
-				return gridSources.getSourceSubseismoOnly(iSource - numNonZeroFaultSystemSources, timeSpan.getDuration(),
+				return gridSources.getSourceSubSeisOnFault(iSource - numNonZeroFaultSystemSources, timeSpan.getDuration(),
 						applyAftershockFilter, bgRupType);
 		}
 	}
@@ -805,7 +805,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 			if (gridSources == null)
 				return null;
 			else
-				return gridSources.getSourceTrulyOffOnly(iSource, timeSpan.getDuration(),
+				return gridSources.getSourceUnassociated(iSource, timeSpan.getDuration(),
 						applyAftershockFilter, bgRupType);
 		} else if(bgInclude.equals(EXCLUDE)) {
 			return null;
@@ -815,7 +815,7 @@ public class FaultSystemSolutionERF extends AbstractNthRupERF {
 			if (gridSources == null)
 				return null;
 			else
-				return gridSources.getSourceTrulyOffOnly(iSource - numNonZeroFaultSystemSources, timeSpan.getDuration(),
+				return gridSources.getSourceUnassociated(iSource - numNonZeroFaultSystemSources, timeSpan.getDuration(),
 						applyAftershockFilter, bgRupType);
 		}
 	}

--- a/src/main/java/scratch/UCERF3/erf/mean/TrueMeanBuilder.java
+++ b/src/main/java/scratch/UCERF3/erf/mean/TrueMeanBuilder.java
@@ -750,8 +750,8 @@ public class TrueMeanBuilder {
 				Preconditions.checkState(region.equals(prov.getGriddedRegion()));
 			}
 			for (int index=0; index<region.getNodeCount(); index++) {
-				addToMFD(nodeSubSeisMFDs, index, prov.getNodeSubSeisMFD(index), weight);
-				addToMFD(nodeUnassociatedMFDs, index, prov.getNodeUnassociatedMFD(index), weight);
+				addToMFD(nodeSubSeisMFDs, index, prov.getMFD_SubSeisOnFault(index), weight);
+				addToMFD(nodeUnassociatedMFDs, index, prov.getMFD_Unassociated(index), weight);
 			}
 		}
 		

--- a/src/main/java/scratch/UCERF3/griddedSeismicity/AbstractGridSourceProvider.java
+++ b/src/main/java/scratch/UCERF3/griddedSeismicity/AbstractGridSourceProvider.java
@@ -71,7 +71,7 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 	public ProbEqkSource getSource(int idx, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType) {
 		Location loc = getGriddedRegion().locationForIndex(idx);
-		IncrementalMagFreqDist mfd = getNodeMFD(idx, SOURCE_MIN_MAG_CUTOFF);
+		IncrementalMagFreqDist mfd = getMFD(idx, SOURCE_MIN_MAG_CUTOFF);
 		if (filterAftershocks) scaleMFD(mfd);
 		
 		double fracStrikeSlip = getFracStrikeSlip(idx);
@@ -103,10 +103,10 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 	
 	
 	
-	public ProbEqkSource getSourceSubseismoOnly(int idx, double duration,
+	public ProbEqkSource getSourceSubSeisOnFault(int idx, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType) {
 		Location loc = getGriddedRegion().locationForIndex(idx);
-		IncrementalMagFreqDist origMFD = getNodeSubSeisMFD(idx);
+		IncrementalMagFreqDist origMFD = getMFD_SubSeisOnFault(idx);
 		if(origMFD == null)
 			return null;
 		IncrementalMagFreqDist mfd = trimMFD(origMFD, SOURCE_MIN_MAG_CUTOFF);
@@ -138,10 +138,10 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 		
 	}
 
-	public ProbEqkSource getSourceTrulyOffOnly(int idx, double duration,
+	public ProbEqkSource getSourceUnassociated(int idx, double duration,
 			boolean filterAftershocks, BackgroundRupType bgRupType) {
 		Location loc = getGriddedRegion().locationForIndex(idx);
-		IncrementalMagFreqDist origMFD = getNodeUnassociatedMFD(idx);
+		IncrementalMagFreqDist origMFD = getMFD_Unassociated(idx);
 		if(origMFD == null)
 			return null;
 		IncrementalMagFreqDist mfd = trimMFD(origMFD, SOURCE_MIN_MAG_CUTOFF);
@@ -181,19 +181,19 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 
 
 	@Override
-	public IncrementalMagFreqDist getNodeMFD(int idx, double minMag) {
-		return trimMFD(getNodeMFD(idx), minMag);
+	public IncrementalMagFreqDist getMFD(int idx, double minMag) {
+		return trimMFD(getMFD(idx), minMag);
 		
-		// NOTE trimMFD clones the MFD returned by getNodeMFD so its safe for
+		// NOTE trimMFD clones the MFD returned by getMFD so its safe for
 		// subsequent modification; if this changes, then we need to review if
 		// MFD is safe from alteration.
 	}
 	
 	@Override
-	public IncrementalMagFreqDist getNodeMFD(int idx) {
+	public IncrementalMagFreqDist getMFD(int idx) {
 		
-		IncrementalMagFreqDist nodeIndMFD = getNodeUnassociatedMFD(idx);
-		IncrementalMagFreqDist nodeSubMFD = getNodeSubSeisMFD(idx);
+		IncrementalMagFreqDist nodeIndMFD = getMFD_Unassociated(idx);
+		IncrementalMagFreqDist nodeSubMFD = getMFD_SubSeisOnFault(idx);
 		if (nodeIndMFD == null) return nodeSubMFD;
 		if (nodeSubMFD == null) return nodeIndMFD;
 		
@@ -293,15 +293,15 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 	}
 	
 	@Override
-	public void scaleAllNodeMFDs(double[] valuesArray) {
+	public void scaleAllMFDs(double[] valuesArray) {
 		if(valuesArray.length != getGriddedRegion().getNodeCount())
 			throw new RuntimeException("Error: valuesArray must have same length as getGriddedRegion().getNodeCount()");
 		for(int i=0;i<valuesArray.length;i++) {
 			if(valuesArray[i] != 1.0) {
-				IncrementalMagFreqDist mfd = getNodeUnassociatedMFD(i);
+				IncrementalMagFreqDist mfd = getMFD_Unassociated(i);
 				if(mfd != null)
 					mfd.scale(valuesArray[i]);;
-				mfd = getNodeSubSeisMFD(i);				
+				mfd = getMFD_SubSeisOnFault(i);				
 				if(mfd != null)
 					mfd.scale(valuesArray[i]);;
 			}
@@ -356,10 +356,10 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 			fracNormal = new double[nodeCount];
 			fracReverse = new double[nodeCount];
 			for (int i=0; i<nodeCount; i++) {
-				IncrementalMagFreqDist subSeis = prov.getNodeSubSeisMFD(i);
+				IncrementalMagFreqDist subSeis = prov.getMFD_SubSeisOnFault(i);
 				if (subSeis != null)
 					subSeisBuilder.put(i, subSeis);
-				IncrementalMagFreqDist unassociated = prov.getNodeUnassociatedMFD(i);
+				IncrementalMagFreqDist unassociated = prov.getMFD_Unassociated(i);
 				if (unassociated != null)
 					unassociatedBuilder.put(i, unassociated);
 				fracStrikeSlip[i] = prov.getFracStrikeSlip(i);
@@ -375,12 +375,12 @@ public abstract class AbstractGridSourceProvider implements GridSourceProvider, 
 		}
 
 		@Override
-		public final IncrementalMagFreqDist getNodeUnassociatedMFD(int idx) {
+		public final IncrementalMagFreqDist getMFD_Unassociated(int idx) {
 			return nodeUnassociatedMFDs.get(idx);
 		}
 
 		@Override
-		public final IncrementalMagFreqDist getNodeSubSeisMFD(int idx) {
+		public final IncrementalMagFreqDist getMFD_SubSeisOnFault(int idx) {
 			return nodeSubSeisMFDs.get(idx);
 		}
 

--- a/src/main/java/scratch/UCERF3/griddedSeismicity/GridSourceFileReader.java
+++ b/src/main/java/scratch/UCERF3/griddedSeismicity/GridSourceFileReader.java
@@ -58,12 +58,12 @@ public class GridSourceFileReader extends AbstractGridSourceProvider implements 
 	}
 	
 	@Override
-	public IncrementalMagFreqDist getNodeUnassociatedMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_Unassociated(int idx) {
 		return nodeUnassociatedMFDs.get(idx);
 	}
 
 	@Override
-	public IncrementalMagFreqDist getNodeSubSeisMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_SubSeisOnFault(int idx) {
 		return nodeSubSeisMFDs.get(idx);
 	}
 
@@ -140,11 +140,11 @@ public class GridSourceFileReader extends AbstractGridSourceProvider implements 
 			File binFile, File regXMLFile, GridSourceProvider gridProv, double minMag) throws IOException {
 		DiscretizedFunc refFunc = null;
 		for (int i=0; i<gridProv.size(); i++) {
-			if (gridProv.getNodeUnassociatedMFD(i) != null) {
-				refFunc = gridProv.getNodeUnassociatedMFD(i);
+			if (gridProv.getMFD_Unassociated(i) != null) {
+				refFunc = gridProv.getMFD_Unassociated(i);
 				break;
-			} else if (gridProv.getNodeSubSeisMFD(i) != null) {
-				refFunc = gridProv.getNodeSubSeisMFD(i);
+			} else if (gridProv.getMFD_SubSeisOnFault(i) != null) {
+				refFunc = gridProv.getMFD_SubSeisOnFault(i);
 				break;
 			}
 		}
@@ -155,7 +155,7 @@ public class GridSourceFileReader extends AbstractGridSourceProvider implements 
 		arrays.add(funcToArray(true, refFunc, minMag));
 		
 		for (int i=0; i<gridProv.size(); i++) {
-			DiscretizedFunc unMFD = gridProv.getNodeUnassociatedMFD(i);
+			DiscretizedFunc unMFD = gridProv.getMFD_Unassociated(i);
 			if (unMFD != null && unMFD.getMaxY()>0) {
 				Preconditions.checkState(unMFD.getMinX() == refFunc.getMinX()
 						&& unMFD.getMaxX() == refFunc.getMaxX());
@@ -163,7 +163,7 @@ public class GridSourceFileReader extends AbstractGridSourceProvider implements 
 			} else {
 				arrays.add(new double[0]);
 			}
-			DiscretizedFunc subSeisMFD = gridProv.getNodeSubSeisMFD(i);
+			DiscretizedFunc subSeisMFD = gridProv.getMFD_SubSeisOnFault(i);
 			if (subSeisMFD != null && subSeisMFD.getMaxY()>0) {
 				Preconditions.checkState(subSeisMFD.getMinX() == refFunc.getMinX()
 						&& subSeisMFD.getMaxX() == refFunc.getMaxX());
@@ -248,8 +248,8 @@ public class GridSourceFileReader extends AbstractGridSourceProvider implements 
 			Map<Integer, IncrementalMagFreqDist> nodeUnassociatedMFDs = Maps.newHashMap();
 			
 			for (int i=0; i<region.getNumLocations(); i++) {
-				nodeSubSeisMFDs.put(i, gridProv.getNodeSubSeisMFD(i));
-				nodeUnassociatedMFDs.put(i, gridProv.getNodeUnassociatedMFD(i));
+				nodeSubSeisMFDs.put(i, gridProv.getMFD_SubSeisOnFault(i));
+				nodeUnassociatedMFDs.put(i, gridProv.getMFD_Unassociated(i));
 			}
 			
 			fileBased = new GridSourceFileReader(region, nodeSubSeisMFDs, nodeUnassociatedMFDs);

--- a/src/main/java/scratch/UCERF3/griddedSeismicity/UCERF3_GridSourceGenerator.java
+++ b/src/main/java/scratch/UCERF3/griddedSeismicity/UCERF3_GridSourceGenerator.java
@@ -217,12 +217,12 @@ public class UCERF3_GridSourceGenerator extends AbstractGridSourceProvider {
 	}
 
 	@Override
-	public IncrementalMagFreqDist getNodeSubSeisMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_SubSeisOnFault(int idx) {
 		return nodeSubSeisMFDs.get(idx);
 	}
 
 	@Override
-	public IncrementalMagFreqDist getNodeUnassociatedMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_Unassociated(int idx) {
 		IncrementalMagFreqDist mfd = realOffFaultMFD.deepClone();
 		mfd.scale(revisedSpatialPDF[idx]);
 		return mfd;

--- a/src/main/java/scratch/UCERF3/griddedSeismicity/UCERF3_NoFaultsGridSourceGenerator.java
+++ b/src/main/java/scratch/UCERF3/griddedSeismicity/UCERF3_NoFaultsGridSourceGenerator.java
@@ -87,12 +87,12 @@ public class UCERF3_NoFaultsGridSourceGenerator extends AbstractGridSourceProvid
 	}
 
 	@Override
-	public IncrementalMagFreqDist getNodeSubSeisMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_SubSeisOnFault(int idx) {
 		return null;
 	}
 
 	@Override
-	public IncrementalMagFreqDist getNodeUnassociatedMFD(int idx) {
+	public IncrementalMagFreqDist getMFD_Unassociated(int idx) {
 		IncrementalMagFreqDist mfd = realOffFaultMFD.deepClone();
 		if(srcSpatialPDF !=null)
 			mfd.scale(srcSpatialPDF[idx]);

--- a/src/main/java/scratch/kevin/ucerf3/etas/CacheFileGen.java
+++ b/src/main/java/scratch/kevin/ucerf3/etas/CacheFileGen.java
@@ -149,8 +149,8 @@ public class CacheFileGen {
 		FaultGridAssociations faultPolyMgr = FaultPolyMgr.create(subSects, U3InversionTargetMFDs.FAULT_BUFFER);
 		for (int index=0; index<region.getNodeCount(); index++) {
 			Location loc = region.getLocation(index);
-			IncrementalMagFreqDist subSeisMFD = origGridProv.getNodeSubSeisMFD(index);
-			IncrementalMagFreqDist offMFD = origGridProv.getNodeUnassociatedMFD(index);
+			IncrementalMagFreqDist subSeisMFD = origGridProv.getMFD_SubSeisOnFault(index);
+			IncrementalMagFreqDist offMFD = origGridProv.getMFD_Unassociated(index);
 			Preconditions.checkState(subSeisMFD != null || offMFD != null);
 			IncrementalMagFreqDist zeroMFD; // give things outside a very, very tiny G-R MFD, otherwise bad things happen
 			if (subSeisMFD != null)


### PR DESCRIPTION
This implements refactoring of `GridSourceProvider` method names as requested by @field-usgs, and documentation improvements. Here is a summary of the changes:

* `getSourceSubseismoOnly(...)` ->  `getSourceSubSeisOnFault(...)`
* `getSourceTrulyOffOnly(...)` -> `getSourceUnassociated(...)`
* `getNodeUnassociatedMFD(int)` -> `getMFD_Unassociated(int)`
* `getNodeSubSeisMFD(int)` -> `getMFD_SubSeisOnFault(int)`
* `getNodeMFD(int)` -> `getMFD(int)`
* `scaleAllNodeMFDs(double[])` -> `scaleAllMFDs(double[])`

Ned, I went with the "unassociated" nomenclature (as opposed to "truly off") as it's consistent with the file formats, and also tried to improve documentation to make the definitions more clear. Want to take a look before I merge the changes in?

I think we'll want to either heavily refactor or replace `AbstractGridSourceProvider` at some point as it is hardcoded to certain depths and `ProbEqkSource` implementations, but I don't yet have a clear view of what changes will be required so I'm punting for now.

FYI @voj @chrisbc