### PR TITLE
Ability to run inversions for individual clusters of connected faults within a fault system

### DIFF
--- a/src/main/java/org/opensha/commons/gui/plot/PlotSpec.java
+++ b/src/main/java/org/opensha/commons/gui/plot/PlotSpec.java
@@ -25,6 +25,7 @@ import org.jfree.chart.ui.RectangleEdge;
 import org.jfree.data.Range;
 import org.opensha.commons.data.function.DiscretizedFunc;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 /**
@@ -258,6 +259,33 @@ public class PlotSpec implements Serializable {
 		if (insetLegend)
 			this.legend = true;
 		this.insetLegend = insetLegend;
+	}
+	
+	/**
+	 * Creates an inset legend with the given anchor and otherwise default settings (0.975 relative x/y, single column,
+	 * max 35% width).
+	 * 
+	 * @param anchor
+	 */
+	public void setLegendInset(RectangleAnchor anchor) {
+		Preconditions.checkNotNull(anchor);
+		this.legend = true;
+		this.insetLegend = true;
+		this.insetLegendLocation = anchor;
+		if (anchor == RectangleAnchor.TOP || anchor == RectangleAnchor.TOP_LEFT || anchor == RectangleAnchor.TOP_RIGHT) {
+			insetLegendRelY = 0.975;
+		} else if (anchor == RectangleAnchor.BOTTOM || anchor == RectangleAnchor.BOTTOM_LEFT || anchor == RectangleAnchor.BOTTOM_RIGHT) {
+			insetLegendRelY = 0.025;
+		} else {
+			insetLegendRelY = 0.5;
+		}
+		if (anchor == RectangleAnchor.LEFT || anchor == RectangleAnchor.TOP_LEFT || anchor == RectangleAnchor.BOTTOM_LEFT) {
+			insetLegendRelX = 0.055;
+		} else if (anchor == RectangleAnchor.RIGHT || anchor == RectangleAnchor.TOP_RIGHT || anchor == RectangleAnchor.BOTTOM_RIGHT) {
+			insetLegendRelX = 0.975;
+		} else {
+			insetLegendRelX = 0.5;
+		}
 	}
 	
 	/**

--- a/src/main/java/org/opensha/commons/util/modules/ModuleContainer.java
+++ b/src/main/java/org/opensha/commons/util/modules/ModuleContainer.java
@@ -443,7 +443,7 @@ public class ModuleContainer<E extends OpenSHA_Module> {
 		E module = null;
 		Stopwatch watch = Stopwatch.createStarted();
 		try {
-			debug("Lazily loading available module...");
+			debug("Lazily loading available module from "+call.getClass()+"...");
 			module = call.call();
 			double secs = watch.elapsed(TimeUnit.MILLISECONDS)/1000d;
 			debug("Took "+secsDF.format(secs)+" s to load "+(module == null ? "null" : module.getName()));

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,9 +43,11 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
 import org.opensha.sha.earthquake.faultSysSolution.modules.GridSourceProvider;
 import org.opensha.sha.earthquake.faultSysSolution.modules.InfoModule;
 import org.opensha.sha.earthquake.faultSysSolution.modules.ModSectMinMags;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RuptureSubSetMappings;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SectAreas;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SplittableRuptureSubSetModule;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.GeoJSONFaultReader;
 import org.opensha.sha.faultSurface.CompoundSurface;
@@ -55,7 +58,9 @@ import org.opensha.sha.faultSurface.RuptureSurface;
 import org.opensha.sha.gui.infoTools.CalcProgressBar;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
@@ -512,6 +517,15 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 		
 		private short[] vals;
 		
+		private ShortListWrapper(List<Integer> ints) {
+			vals = new short[ints.size()];
+			for (int i=0; i<vals.length; i++) {
+				int val = ints.get(i);
+				Preconditions.checkState(val < Short.MAX_VALUE);
+				vals[i] = (short)val;
+			}
+		}
+		
 		public ShortListWrapper(short[] vals) {
 			this.vals = vals;
 		}
@@ -556,6 +570,12 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 	private static class IntListWrapper extends AbstractList<Integer> {
 		
 		private int[] vals;
+		
+		private IntListWrapper(List<Integer> ints) {
+			vals = new int[ints.size()];
+			for (int i=0; i<vals.length; i++)
+				vals[i] = ints.get(i);
+		}
 		
 		public IntListWrapper(int[] vals) {
 			this.vals = vals;
@@ -1271,6 +1291,101 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 		}
 		
 		return true;
+	}
+	
+	/**
+	 * Builds a rupture subset for only the given section IDs. Fault section instances will be duplicated and assigned
+	 * new section IDs in the returned rupture set, and only ruptures involving those sections will be retained. If any
+	 * ruptures utilize both retained and non-retained section IDs, an {@link IllegalStateException} will be thrown.
+	 * <br>
+	 * All modules that implement {@link SplittableRuptureSubSetModule} will be copied over to the returned rupture set.
+	 * <br>
+	 * Mappings between original and new section/rupture IDs can be retrieved via the {@link RuptureSubSetMappings} module
+	 * that will be attached to the rupture subset.
+	 * 
+	 * @param retainedSectIDs
+	 * @return rupture subset containing only the given sections and their corresponding ruptures
+	 * @throws IllegalStateException if there are ruptures that utilize both retained and non-retained sections
+	 */
+	public FaultSystemRupSet getForSectionSubSet(Collection<Integer> retainedSectIDs) throws IllegalStateException {
+		List<FaultSection> remappedSects = new ArrayList<>();
+		int sectIndex = 0;
+		BiMap<Integer, Integer> sectIDs_newToOld = HashBiMap.create(retainedSectIDs.size());
+		for (int origID=0; origID<this.faultSectionData.size(); origID++) {
+			if (retainedSectIDs.contains(origID)) {
+				FaultSection remappedSect = this.faultSectionData.get(origID).clone();
+				remappedSect.setSectionId(sectIndex);
+				remappedSects.add(remappedSect);
+				sectIDs_newToOld.put(sectIndex, origID);
+				sectIndex++;
+			}
+		}
+		
+		System.out.println("Building rupture sub-set, retaining "+sectIDs_newToOld.size()+"/"+getNumSections()+" sections");
+		
+		int rupIndex = 0;
+		BiMap<Integer, Integer> rupIDs_newToOld = HashBiMap.create(retainedSectIDs.size());
+		for (int origID=0; origID<this.getNumRuptures(); origID++) {
+			boolean allRetained = true;
+			boolean anyRetained = false;
+			for (int s : this.sectionForRups.get(origID)) {
+				boolean sectRetained = retainedSectIDs.contains(s);
+				allRetained = allRetained && sectRetained;
+				anyRetained = anyRetained || sectRetained;
+			}
+			Preconditions.checkState(anyRetained == allRetained,
+					"Rupture %s involves sections that are retained and excluded in the rupture subset, can only build "
+					+ "subsets for independent clusters of sections.", origID);
+			if (anyRetained)
+				rupIDs_newToOld.put(rupIndex++, origID);
+		}
+		System.out.println("Retaining "+rupIDs_newToOld.size()+"/"+getNumRuptures()+" ruptures");
+		
+		boolean shortSafe = sectIDs_newToOld.size() < Short.MAX_VALUE;
+		
+		double[] modMags = new double[rupIndex];
+		double[] modRakes = new double[rupIndex];
+		double[] modRupAreas = new double[rupIndex];
+		double[] modRupLengths = rupLengths == null ? null : new double[rupIndex];
+		List<List<Integer>> modSectionForRups = new ArrayList<>();
+		BiMap<Integer, Integer> sectIDs_oldToNew = sectIDs_newToOld.inverse();
+		for (rupIndex=0; rupIndex<rupIDs_newToOld.size(); rupIndex++) {
+			int origID = rupIDs_newToOld.get(rupIndex);
+			modMags[rupIndex] = mags[origID];
+			modRakes[rupIndex] = rakes[origID];
+			modRupAreas[rupIndex] = rupAreas[origID];
+			if (modRupLengths != null)
+				modRupLengths[rupIndex] = rupLengths[origID];
+			List<Integer> sectForRup = new ArrayList<>();
+			for (int origSectIndex : sectionForRups.get(origID)) {
+				Integer newSectID = sectIDs_oldToNew.get(origSectIndex);
+				Preconditions.checkNotNull(newSectID,
+						"Rupture (newID=%s, oldID=%s) uses origSectID=%s which is not retained",
+						rupIndex, origID, origID);
+				sectForRup.add(newSectID);
+			}
+			if (shortSafe)
+				modSectionForRups.add(new ShortListWrapper(sectForRup));
+			else
+				modSectionForRups.add(new IntListWrapper(sectForRup));
+		}
+		
+		FaultSystemRupSet modRupSet = new FaultSystemRupSet(remappedSects, modSectionForRups,
+				modMags, modRakes, modRupAreas, modRupLengths);
+		
+		// add mappings module
+		RuptureSubSetMappings mappings = new RuptureSubSetMappings(sectIDs_newToOld, rupIDs_newToOld);
+		modRupSet.addModule(mappings);
+		
+		// now copy over any modules we can
+		for (OpenSHA_Module module : getModulesAssignableTo(SplittableRuptureSubSetModule.class, true)) {
+			OpenSHA_Module modModule = ((SplittableRuptureSubSetModule<?>)module).getForRuptureSubSet(
+					modRupSet, mappings);
+			if (modModule != null)
+				modRupSet.addModule(modModule);
+		}
+		
+		return modRupSet;
 	}
 	
 	/*

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -1294,7 +1294,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 	}
 	
 	/**
-	 * Builds a rupture subset for only the given section IDs. Fault section instances will be duplicated and assigned
+	 * Builds a rupture subset using only the given section IDs. Fault section instances will be duplicated and assigned
 	 * new section IDs in the returned rupture set, and only ruptures involving those sections will be retained. If any
 	 * ruptures utilize both retained and non-retained section IDs, an {@link IllegalStateException} will be thrown.
 	 * <br>

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/RuptureSets.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/RuptureSets.java
@@ -264,6 +264,10 @@ public class RuptureSets {
 			this.maxJumpDist = maxJumpDist;
 		}
 		
+		public void setMinSectsPerParent(int minSectsPerParent) {
+			this.minSectsPerParent = minSectsPerParent;
+		}
+		
 	}
 	
 	public static class CoulombRupSetConfig extends RupSetConfig {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionConfigurationFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionConfigurationFactory.java
@@ -1,0 +1,22 @@
+package org.opensha.sha.earthquake.faultSysSolution.inversion;
+
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.ConnectivityCluster;
+
+/**
+ * Interface for a factory that can build a separate {@link InversionConfiguration} for each {@link ConnectivityCluster},
+ * which will be solved individually and then combined into a single solution.
+ * 
+ * @author kevin
+ *
+ */
+public interface ClusterSpecificInversionConfigurationFactory extends InversionConfigurationFactory {
+	
+	/**
+	 * @return true if clusters should be solved for individually, otherwise will be treated as a regular
+	 * {@link InversionConfigurationFactory}. Default implementation returns true.
+	 */
+	public default boolean isSolveClustersIndividually() {
+		return true;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
@@ -600,8 +600,8 @@ public class Inversions {
 			
 			List<FaultSystemSolution> solutions = new ArrayList<>(clusters.size());
 			
-			File tmpDir = new File("/tmp/inv_debug");
-			Preconditions.checkState(tmpDir.exists() || tmpDir.mkdir());
+//			File tmpDir = new File("/tmp/inv_debug");
+//			Preconditions.checkState(tmpDir.exists() || tmpDir.mkdir());
 			for (ConnectivityCluster cluster : sorted) {
 				System.out.println("Handling cluster: "+cluster);
 				System.out.println("Building subset rupture set for "+cluster);
@@ -613,11 +613,11 @@ public class Inversions {
 					config = InversionConfiguration.builder(config).forCommandLine(cmd).build();
 				solutions.add(run(clusterRupSet, config));
 				
-				String name = "sol_"+(solutions.size()-1)+"_"+cluster.getNumSections()+"sects_"+cluster.getNumRuptures()+"rups";
-				if (cluster.getParentSectIDs().size() == 1)
-					name += "_"+clusterRupSet.getFaultSectionData(0).getParentSectionName().replaceAll("\\W+", "_");
-				File tmpFile = new File(tmpDir, name+".zip");
-				solutions.get(solutions.size()-1).write(tmpFile);
+//				String name = "sol_"+(solutions.size()-1)+"_"+cluster.getNumSections()+"sects_"+cluster.getNumRuptures()+"rups";
+//				if (cluster.getParentSectIDs().size() == 1)
+//					name += "_"+clusterRupSet.getFaultSectionData(0).getParentSectionName().replaceAll("\\W+", "_");
+//				File tmpFile = new File(tmpDir, name+".zip");
+//				solutions.get(solutions.size()-1).write(tmpFile);
 			}
 			
 			System.out.println("Finished "+solutions.size()+" cluster-specific inversions, combining");

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/UncertainDataConstraint.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/constraints/impl/UncertainDataConstraint.java
@@ -95,6 +95,10 @@ public class UncertainDataConstraint implements Named {
 			this.sectionName = sectionName;
 			this.dataLocation = dataLocation;
 		}
+		
+		public SectMappedUncertainDataConstraint forRemappedSectionIndex(int newSectIndex) {
+			return new SectMappedUncertainDataConstraint(name, newSectIndex, sectionName, dataLocation, bestEstimate, uncertainties);
+		}
 	}
 	
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/mpj/MPJ_LogicTreeInversionRunner.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/mpj/MPJ_LogicTreeInversionRunner.java
@@ -334,18 +334,10 @@ public class MPJ_LogicTreeInversionRunner extends MPJTaskCalculator {
 			
 			memoryDebug("Beginning config for "+index);
 			
-			FaultSystemRupSet rupSet;
-			try {
-				rupSet = factory.buildRuptureSet(branch, annealingThreads);
-			} catch (IOException e) {
-				throw ExceptionUtils.asRuntimeException(e);
-			}
-			rupSet.addModule(branch);
-			
 			FaultSystemSolution sol;
 			
 			try {
-				sol = Inversions.run(rupSet, factory, branch, annealingThreads, cmd);
+				sol = Inversions.run(factory, branch, annealingThreads, cmd);
 				sol.write(solFile);
 			} catch (IOException e) {
 				throw ExceptionUtils.asRuntimeException(e);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/mpj/MPJ_LogicTreeInversionRunner.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/mpj/MPJ_LogicTreeInversionRunner.java
@@ -342,26 +342,10 @@ public class MPJ_LogicTreeInversionRunner extends MPJTaskCalculator {
 			}
 			rupSet.addModule(branch);
 			
-			InversionConfiguration config;
-			try {
-				config = factory.buildInversionConfig(rupSet, branch, annealingThreads);
-			} catch (IOException e) {
-				throw ExceptionUtils.asRuntimeException(e);
-			}
-			rupSet.addModule(branch);
-			// apply any command line overrides
-			config = InversionConfiguration.builder(config).forCommandLine(cmd).build();
-			
-			memoryDebug("Running inversion for task "+index+" with "+config.getConstraints().size()+" constraints");
-			FaultSystemSolution sol = Inversions.run(rupSet, config);
-			
-			// attach any relevant modules before writing out
-			SolutionProcessor processor = factory.getSolutionLogicTreeProcessor();
-			
-			if (processor != null)
-				processor.processSolution(sol, branch);
+			FaultSystemSolution sol;
 			
 			try {
+				sol = Inversions.run(rupSet, factory, branch, annealingThreads, cmd);
 				sol.write(solFile);
 			} catch (IOException e) {
 				throw ExceptionUtils.asRuntimeException(e);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/sa/ReweightEvenFitSimulatedAnnealing.java
@@ -42,6 +42,7 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfits;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SectSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.NSHM23_InvConfigFactory;
+import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.NSHM23_LogicTreeBranch;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.NSHM23_U3_HybridLogicTreeBranch;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.RupturePlausibilityModels;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.SegmentationModels;
@@ -742,14 +743,18 @@ public class ReweightEvenFitSimulatedAnnealing extends ThreadedSimulatedAnnealin
 
 		String dirName = new SimpleDateFormat("yyyy_MM_dd").format(new Date());
 
-		U3InversionConfigFactory factory = new U3InversionConfigFactory.OriginalCalcParams();
-		dirName += "-u3_orig_params";
-		
-		LogicTreeBranch<U3LogicTreeBranchNode<?>> branch = U3LogicTreeBranch.DEFAULT;
+//		U3InversionConfigFactory factory = new U3InversionConfigFactory.OriginalCalcParams();
+//		dirName += "-u3_orig_params";
+//		
+//		LogicTreeBranch<U3LogicTreeBranchNode<?>> branch = U3LogicTreeBranch.DEFAULT;
 
 //		NSHM23_InvConfigFactory factory = new NSHM23_InvConfigFactory();
-//		
+//		dirName += "-nshm23";
+		NSHM23_InvConfigFactory factory = new NSHM23_InvConfigFactory.ClusterSpecific();
+		dirName += "-nshm23-cluster_specific";
+		
 //		LogicTreeBranch<LogicTreeNode> branch = NSHM18_LogicTreeBranch.DEFAULT;
+		LogicTreeBranch<LogicTreeNode> branch = NSHM23_U3_HybridLogicTreeBranch.DEFAULT;
 //		
 ////		LogicTreeBranch<LogicTreeNode> branch = new NSHM23_U3_HybridLogicTreeBranch();
 ////		branch.setValue(FaultModels.FM3_1);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AveSlipModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/AveSlipModule.java
@@ -17,7 +17,8 @@ import com.google.common.base.Preconditions;
 
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
 
-public abstract class AveSlipModule implements SubModule<FaultSystemRupSet>, BranchAverageableModule<AveSlipModule> {
+public abstract class AveSlipModule implements SubModule<FaultSystemRupSet>, BranchAverageableModule<AveSlipModule>,
+SplittableRuptureSubSetModule<AveSlipModule> {
 	
 	FaultSystemRupSet rupSet;
 
@@ -149,6 +150,11 @@ public abstract class AveSlipModule implements SubModule<FaultSystemRupSet>, Bra
 			};
 		}
 
+		@Override
+		public ModelBased getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			return new ModelBased(rupSubSet, scale);
+		}
+
 	}
 
 	public static class Precomputed extends AveSlipModule implements CSV_BackedModule {
@@ -265,6 +271,16 @@ public abstract class AveSlipModule implements SubModule<FaultSystemRupSet>, Bra
 		@Override
 		public String getName() {
 			return "Precomputed Average Slips";
+		}
+
+		@Override
+		public Precomputed getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			double[] filteredAveSlips = new double[rupSubSet.getNumSections()];
+			for (int s=0; s<rupSubSet.getNumSections(); s++) {
+				int origID = mappings.getOrigSectID(s);
+				filteredAveSlips[s] = aveSlips[origID];
+			}
+			return new Precomputed(rupSubSet, filteredAveSlips);
 		}
 
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ClusterRuptures.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ClusterRuptures.java
@@ -33,7 +33,8 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 public abstract class ClusterRuptures implements SubModule<FaultSystemRupSet>, Iterable<ClusterRupture>,
-BranchAverageableModule<ClusterRuptures>, AverageableModule.ConstantAverageable<ClusterRuptures> {
+BranchAverageableModule<ClusterRuptures>, AverageableModule.ConstantAverageable<ClusterRuptures>,
+SplittableRuptureSubSetModule<ClusterRuptures> {
 	
 	protected FaultSystemRupSet rupSet;
 
@@ -260,6 +261,18 @@ BranchAverageableModule<ClusterRuptures>, AverageableModule.ConstantAverageable<
 				Preconditions.checkState(rupSet.isEquivalentTo(parent));
 			this.rupSet = parent;
 		}
+
+		@Override
+		public AveragingAccumulator<ClusterRuptures> averagingAccumulator() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public SingleStranded getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			// don't keep cache, new ruptures will have new IDs and FaultSection indexes
+			return new SingleStranded(rupSubSet, null);
+		}
 		
 	}
 	
@@ -324,6 +337,24 @@ BranchAverageableModule<ClusterRuptures>, AverageableModule.ConstantAverageable<
 			if (this.clusterRuptures != null)
 				Preconditions.checkState(rupSet.isEquivalentTo(parent));
 			this.rupSet = parent;
+		}
+
+		@Override
+		public AveragingAccumulator<ClusterRuptures> averagingAccumulator() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public ClusterRuptures getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			throw new UnsupportedOperationException("Not yet supported");
+//			List<ClusterRupture> subSet = new ArrayList<>();
+//			for (int r=0; r<mappings.getNumRetainedRuptures(); r++) {
+//				ClusterRupture origRup = clusterRuptures.get(mappings.getOrigRupID(r));
+//				
+//				
+//			}
+//			return subSet;
 		}
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ConnectivityClusters.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ConnectivityClusters.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 
 import org.opensha.commons.util.modules.SubModule;
@@ -16,7 +17,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 
 public class ConnectivityClusters implements SubModule<FaultSystemRupSet>,
-JSON_TypeAdapterBackedModule<List<ConnectivityCluster>> {
+JSON_TypeAdapterBackedModule<List<ConnectivityCluster>>, Iterable<ConnectivityCluster> {
 	
 	private FaultSystemRupSet rupSet;
 	private List<ConnectivityCluster> clusters;
@@ -95,6 +96,11 @@ JSON_TypeAdapterBackedModule<List<ConnectivityCluster>> {
 	@Override
 	public void registerTypeAdapters(GsonBuilder builder) {
 		// do nothing, default serialization will work
+	}
+
+	@Override
+	public Iterator<ConnectivityCluster> iterator() {
+		return clusters.iterator();
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModSectMinMags.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModSectMinMags.java
@@ -13,7 +13,8 @@ import org.opensha.sha.faultSurface.FaultSection;
 
 import com.google.common.base.Preconditions;
 
-public abstract class ModSectMinMags implements SubModule<FaultSystemRupSet>, BranchAverageableModule<ModSectMinMags> {
+public abstract class ModSectMinMags implements SubModule<FaultSystemRupSet>, BranchAverageableModule<ModSectMinMags>,
+SplittableRuptureSubSetModule<ModSectMinMags> {
 	
 	FaultSystemRupSet rupSet;
 
@@ -227,6 +228,14 @@ public abstract class ModSectMinMags implements SubModule<FaultSystemRupSet>, Br
 					return ModSectMinMags.class;
 				}
 			};
+		}
+
+		@Override
+		public ModSectMinMags getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			double[] remapped = new double[mappings.getNumRetainedSects()];
+			for (int s=0; s<remapped.length; s++)
+				remapped[s] = sectMinMags[mappings.getOrigSectID(s)];
+			return new Precomputed(rupSubSet, remapped);
 		}
 
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModelRegion.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ModelRegion.java
@@ -1,0 +1,72 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.lang.reflect.Type;
+
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.geo.json.Feature;
+import org.opensha.commons.util.modules.AverageableModule;
+import org.opensha.commons.util.modules.helpers.JSON_TypeAdapterBackedModule;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.GsonBuilder;
+
+public class ModelRegion implements JSON_TypeAdapterBackedModule<Feature>,
+AverageableModule.ConstantAverageable<ModelRegion>, BranchAverageableModule<ModelRegion>  {
+	
+	private Region region;
+	
+	@SuppressWarnings("unused") // for serialization
+	private ModelRegion() {}
+	
+	public ModelRegion(Region region) {
+		Preconditions.checkNotNull(region);
+		this.region = region;
+	}
+
+	@Override
+	public String getFileName() {
+		return "model_region.json";
+	}
+
+	@Override
+	public String getName() {
+		return "Model Region";
+	}
+
+	@Override
+	public Type getType() {
+		return Feature.class;
+	}
+
+	@Override
+	public Feature get() {
+		return region.toFeature();
+	}
+	
+	public Region getRegion() {
+		return region;
+	}
+
+	@Override
+	public void set(Feature value) {
+		this.region = Region.fromFeature(value);
+	}
+	
+	public void set(Region region) {
+		this.region = region;
+	}
+
+	@Override
+	public void registerTypeAdapters(GsonBuilder builder) {}
+
+	@Override
+	public Class<ModelRegion> getAveragingType() {
+		return ModelRegion.class;
+	}
+
+	@Override
+	public boolean isIdentical(ModelRegion module) {
+		return module == this || module.region.equalsRegion(region);
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RuptureSubSetMappings.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RuptureSubSetMappings.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.opensha.commons.util.modules.helpers.JSON_BackedModule;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
@@ -12,6 +13,14 @@ import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
+/**
+ * This class gives mappings between original and subset rupture and section IDs. This is created by
+ * {@link FaultSystemRupSet#getForSectionSubSet(java.util.Collection)}, and used by {@link SplittableRuptureSubSetModule}
+ * instances to build module subsets.
+ * 
+ * @author kevin
+ *
+ */
 public class RuptureSubSetMappings implements JSON_BackedModule {
 
 	private BiMap<Integer, Integer> sectIDs_newToOld;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RuptureSubSetMappings.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/RuptureSubSetMappings.java
@@ -1,0 +1,185 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.opensha.commons.util.modules.helpers.JSON_BackedModule;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.gson.Gson;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+public class RuptureSubSetMappings implements JSON_BackedModule {
+
+	private BiMap<Integer, Integer> sectIDs_newToOld;
+	private BiMap<Integer, Integer> sectIDs_oldToNew;
+	private BiMap<Integer, Integer> rupIDs_newToOld;
+	private BiMap<Integer, Integer> rupIDs_oldToNew;
+	
+	@SuppressWarnings("unused") // deserialization
+	private RuptureSubSetMappings() {}
+
+	public RuptureSubSetMappings(BiMap<Integer, Integer> sectIDs_newToOld,
+			BiMap<Integer, Integer> rupIDs_newToOld) {
+		this.sectIDs_newToOld = sectIDs_newToOld;
+		this.sectIDs_oldToNew = sectIDs_newToOld.inverse();
+		this.rupIDs_newToOld = rupIDs_newToOld;
+		this.rupIDs_oldToNew = rupIDs_newToOld.inverse();
+	}
+	
+	/**
+	 *  @return the number of retained section IDs
+	 */
+	public int getNumRetainedSects() {
+		return sectIDs_newToOld.size();
+	}
+	
+	/**
+	 * @return the set of original section IDs that have been retained
+	 */
+	public Set<Integer> getRetainedOrigSectIDs() {
+		return sectIDs_newToOld.values();
+	}
+	
+	/**
+	 * @param origSectID
+	 * @return true if the given section was retained in this subset
+	 */
+	public boolean isSectRetained(int origSectID) {
+		return sectIDs_newToOld.containsValue(origSectID);
+	}
+	
+	/**
+	 * @param origSectID
+	 * @return the new ID in this subset for the given original section ID
+	 */
+	public int getNewSectID(int origSectID) {
+		return sectIDs_oldToNew.get(origSectID);
+	}
+	
+	/**
+	 * @param newSectID
+	 * @return the original ID of this new subset section ID
+	 */
+	public int getOrigSectID(int newSectID) {
+		return sectIDs_newToOld.get(newSectID);
+	}
+	
+	/**
+	 *  @return the number of retained rupture IDs
+	 */
+	public int getNumRetainedRuptures() {
+		return rupIDs_newToOld.size();
+	}
+	
+	/**
+	 * @return the set of original rupture IDs that have been retained
+	 */
+	public Set<Integer> getRetainedOrigRupIDs() {
+		return rupIDs_newToOld.values();
+	}
+	
+	/**
+	 * @param origRupID
+	 * @return true if the given section was retained in this subset
+	 */
+	public boolean isRupRetained(int origRupID) {
+		return rupIDs_newToOld.containsValue(origRupID);
+	}
+	
+	/**
+	 * @param origRupID
+	 * @return the new ID in this subset for the given original rupture ID
+	 */
+	public int getNewRupID(int origRupID) {
+		return rupIDs_oldToNew.get(origRupID);
+	}
+	
+	/**
+	 * @param newRupID
+	 * @return the original ID of this new subset rupture ID
+	 */
+	public int getOrigRupID(int newRupID) {
+		return rupIDs_newToOld.get(newRupID);
+	}
+
+	@Override
+	public String getName() {
+		return "Rupture Subset Mappings";
+	}
+
+	@Override
+	public String getFileName() {
+		return "rupture_sub_set_mappings.json";
+	}
+
+	@Override
+	public void writeToJSON(JsonWriter out, Gson gson) throws IOException {
+		out.beginObject();
+		
+		out.name("sectIDs_newToOld");
+		writeBiMapJSON(out, sectIDs_newToOld);
+		
+		out.name("rupIDs_newToOld");
+		writeBiMapJSON(out, rupIDs_newToOld);
+		
+		out.endObject();
+	}
+	
+	private static void writeBiMapJSON(JsonWriter out, BiMap<Integer, Integer> map) throws IOException {
+		out.beginArray();
+		
+		for (Integer key : map.keySet()) {
+			out.beginArray();
+			out.value(key.intValue());
+			out.value(map.get(key).intValue());
+			out.endArray();
+		}
+		
+		out.endArray();
+	}
+	
+	private static BiMap<Integer, Integer> readBiMapJSON(JsonReader in) throws IOException {
+		BiMap<Integer, Integer> map = HashBiMap.create();
+		in.beginArray();
+		
+		while (in.hasNext()) {
+			in.beginArray();
+			int key = in.nextInt();
+			int val = in.nextInt();
+			map.put(key, val);
+			in.endArray();
+		}
+		
+		in.endArray();
+		return map;
+	}
+
+	@Override
+	public void initFromJSON(JsonReader in, Gson gson) throws IOException {
+		in.beginObject();
+		
+		while (in.hasNext()) {
+			switch (in.nextName()) {
+			case "sectIDs_newToOld":
+				sectIDs_newToOld = readBiMapJSON(in);
+				break;
+			case "rupIDs_newToOld":
+				rupIDs_newToOld = readBiMapJSON(in);
+				break;
+
+			default:
+				in.skipValue();
+				break;
+			}
+		}
+		Preconditions.checkNotNull(sectIDs_newToOld);
+		Preconditions.checkNotNull(rupIDs_newToOld);
+		
+		in.endObject();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SectAreas.java
@@ -8,7 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
 import com.google.common.base.Preconditions;
 
-public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
+public abstract class SectAreas implements SubModule<FaultSystemRupSet>, SplittableRuptureSubSetModule<SectAreas> {
 	
 	protected FaultSystemRupSet parent;
 
@@ -68,9 +68,8 @@ public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
 		}
 
 		@Override
-		public SubModule<FaultSystemRupSet> copy(FaultSystemRupSet newParent) throws IllegalStateException {
+		public Default copy(FaultSystemRupSet newParent) throws IllegalStateException {
 			Preconditions.checkNotNull(newParent);
-			Preconditions.checkState(parent == null || newParent.getNumSections() == parent.getNumSections());
 			return new Default(newParent);
 		}
 
@@ -87,6 +86,11 @@ public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
 				}
 			}
 			return data[sectIndex];
+		}
+
+		@Override
+		public SectAreas getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			return copy(rupSubSet);
 		}
 		
 	}
@@ -173,6 +177,14 @@ public abstract class SectAreas implements SubModule<FaultSystemRupSet> {
 					return false;
 			}
 			return true;
+		}
+
+		@Override
+		public Precomputed getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+			double[] filtered = new double[rupSubSet.getNumSections()];
+			for (int s=0; s<rupSubSet.getNumSections(); s++)
+				filtered[s] = sectAreas[mappings.getOrigSectID(s)];
+			return new Precomputed(rupSubSet, filtered);
 		}
 
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SlipAlongRuptureModel.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SlipAlongRuptureModel.java
@@ -18,7 +18,8 @@ import com.google.common.base.Preconditions;
 
 import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
 
-public abstract class SlipAlongRuptureModel implements OpenSHA_Module, ConstantAverageable<SlipAlongRuptureModel> {
+public abstract class SlipAlongRuptureModel implements OpenSHA_Module, ConstantAverageable<SlipAlongRuptureModel>,
+SplittableRuptureSubSetModule<SlipAlongRuptureModel> {
 
 	public static SlipAlongRuptureModel forModel(SlipAlongRuptureModels slipAlong) {
 		return slipAlong.getModel();
@@ -341,6 +342,11 @@ public abstract class SlipAlongRuptureModel implements OpenSHA_Module, ConstantA
 	@Override
 	public boolean isIdentical(SlipAlongRuptureModel module) {
 		return this.getClass().equals(module.getClass());
+	}
+
+	@Override
+	public SlipAlongRuptureModel getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings) {
+		return this;
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SplittableRuptureSubSetModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SplittableRuptureSubSetModule.java
@@ -4,6 +4,13 @@ import org.opensha.commons.util.modules.ModuleHelper;
 import org.opensha.commons.util.modules.OpenSHA_Module;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
+/**
+ * Interface for a module that can be split into a subset of a {@link FaultSystemRupSet}. This is primarily used by
+ * {@link FaultSystemRupSet#getForSectionSubSet(java.util.Collection)}.
+ * @author kevin
+ *
+ * @param <E>
+ */
 @ModuleHelper
 public interface SplittableRuptureSubSetModule<E extends OpenSHA_Module> extends OpenSHA_Module {
 	
@@ -11,7 +18,7 @@ public interface SplittableRuptureSubSetModule<E extends OpenSHA_Module> extends
 	 * Returns a view of this module that is specific to the given subset of a {@link FaultSystemRupSet}.
 	 * 
 	 * @param rupSubSet the subset {@link FaultSystemRupSet} containing a subset of the original sections and/or ruptures
-	 * @param mappings TODO
+	 * @param mappings gives mappings between original and new section and rupture IDs
 	 * @return module for the given {@link FaultSystemRupSet} subset
 	 */
 	public E getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SplittableRuptureSubSetModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SplittableRuptureSubSetModule.java
@@ -1,0 +1,19 @@
+package org.opensha.sha.earthquake.faultSysSolution.modules;
+
+import org.opensha.commons.util.modules.ModuleHelper;
+import org.opensha.commons.util.modules.OpenSHA_Module;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+
+@ModuleHelper
+public interface SplittableRuptureSubSetModule<E extends OpenSHA_Module> extends OpenSHA_Module {
+	
+	/**
+	 * Returns a view of this module that is specific to the given subset of a {@link FaultSystemRupSet}.
+	 * 
+	 * @param rupSubSet the subset {@link FaultSystemRupSet} containing a subset of the original sections and/or ruptures
+	 * @param mappings TODO
+	 * @return module for the given {@link FaultSystemRupSet} subset
+	 */
+	public E getForRuptureSubSet(FaultSystemRupSet rupSubSet, RuptureSubSetMappings mappings);
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/ReportMetadata.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/ReportMetadata.java
@@ -8,6 +8,7 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.modules.FaultGridAssociations;
 import org.opensha.sha.earthquake.faultSysSolution.modules.GridSourceProvider;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ModelRegion;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.Jump;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.RupSetMapMaker;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.UniqueRupture;
@@ -68,6 +69,8 @@ public class ReportMetadata {
 	}
 	
 	private static Region detectRegion(FaultSystemRupSet rupSet, FaultSystemSolution sol) {
+		if (rupSet.hasModule(ModelRegion.class))
+			return rupSet.requireModule(ModelRegion.class).getRegion();
 		if (ReportPageGen.getUCERF3FM(rupSet) != null)
 			return new CaliforniaRegions.RELM_TESTING();
 		if (rupSet.hasModule(FaultGridAssociations.class))

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SolMFDPlot.java
@@ -46,7 +46,7 @@ public class SolMFDPlot extends AbstractRupSetPlot {
 		return "Solution MFDs";
 	}
 	
-	private static final Color SUPRA_SEIS_TARGET_COLOR = Color.CYAN.darker();
+	public static final Color SUPRA_SEIS_TARGET_COLOR = Color.CYAN.darker();
 
 	@Override
 	public List<String> plot(FaultSystemRupSet rupSet, FaultSystemSolution sol, ReportMetadata meta,

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ConnectivityCluster.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/ConnectivityCluster.java
@@ -55,6 +55,22 @@ public class ConnectivityCluster implements Comparable<ConnectivityCluster> {
 	public int getNumRuptures() {
 		return numRuptures;
 	}
+	
+	/**
+	 * @param sect
+	 * @return true if the given section is part of this cluster, false otherwise
+	 */
+	public boolean containsSect(FaultSection sect) {
+		return containsSect(sect.getSectionId());
+	}
+	
+	/**
+	 * @param sectID
+	 * @return true if the given section ID is part of this cluster, false otherwise
+	 */
+	public boolean containsSect(int sectID) {
+		return sectIDs.contains(sectID);
+	}
 
 	/**
 	 * @return unmodifiable view of the sections IDs associated with this cluster
@@ -138,6 +154,11 @@ public class ConnectivityCluster implements Comparable<ConnectivityCluster> {
 		return sectCountComparator.compare(this, o);
 	}
 	
+	@Override
+	public String toString() {
+		return "ConnectivityCluster["+numSections+" sects, "+numRuptures+" rups]";
+	}
+
 	public static final Comparator<ConnectivityCluster> sectCountComparator = new Comparator<ConnectivityCluster>() {
 		
 		@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SolHazardMapCalc.java
@@ -478,9 +478,9 @@ public class SolHazardMapCalc {
 			if (yDiff > 10)
 				yDiff /= 30d;
 			else if (yDiff > 5d)
-				yDiff /= 15d;
+				yDiff /= 20d;
 			else
-				yDiff /= 10d;
+				yDiff /= 15d;
 			double y = latRange.getUpperBound() - 0.5*yDiff;
 			for (String label : labels) {
 				double x = lonRange.getUpperBound();

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
@@ -251,8 +251,7 @@ public class NSHM23_ConstraintBuilder {
 		if (adjustForIncompatibleData) {
 			UncertaintyBoundType dataWithinType = UncertaintyBoundType.ONE_SIGMA;
 			List<SectNucleationMFD_Estimator> dataConstraints = new ArrayList<>();
-			dataConstraints.add(new APrioriSectNuclEstimator(rupSet,
-					UCERF3InversionInputGenerator.findParkfieldRups(rupSet), parkfieldRate));
+			dataConstraints.add(new APrioriSectNuclEstimator(rupSet, findParkfieldRups(), parkfieldRate));
 			if (rupSet.hasModule(PaleoseismicConstraintData.class)) {
 				PaleoseismicConstraintData paleoData = rupSet.requireModule(PaleoseismicConstraintData.class);
 				if (paleoData.getPaleoSlipConstraints() != null) {
@@ -325,14 +324,24 @@ public class NSHM23_ConstraintBuilder {
 		return this;
 	}
 	
+	public List<Integer> findParkfieldRups() {
+		// TODO hack
+		return UCERF3InversionInputGenerator.findParkfieldRups(rupSet);
+	}
+	
+	public boolean rupSetHasParkfield() {
+		List<Integer> parkfieldRups = findParkfieldRups();
+		return !parkfieldRups.isEmpty();
+	}
+	
 	public NSHM23_ConstraintBuilder parkfield() {
 		double parkfieldMeanRate = 1.0/25.0; // Bakun et al. (2005)
 		System.err.println("WARNING: temporary relative standard deviation of "
 				+(float)DEFAULT_REL_STD_DEV+" set for parkfield constraint"); // TODO
 		double parkfieldStdDev = DEFAULT_REL_STD_DEV*parkfieldMeanRate;
 		
-		// Find Parkfield M~6 ruptures
-		List<Integer> parkfieldRups = UCERF3InversionInputGenerator.findParkfieldRups(rupSet);
+		// Find Parkfield M~6 ruptures TODO HACK
+		List<Integer> parkfieldRups = findParkfieldRups();
 		constraints.add(new ParkfieldInversionConstraint(1d, parkfieldMeanRate, parkfieldRups,
 				ConstraintWeightingType.NORMALIZED_BY_UNCERTAINTY, parkfieldStdDev));
 		return this;
@@ -835,7 +844,7 @@ public class NSHM23_ConstraintBuilder {
 	}
 	
 	public double[] getParkfieldInitial(boolean ensureNotSkipped) {
-		List<Integer> parkRups = new ArrayList<>(UCERF3InversionInputGenerator.findParkfieldRups(rupSet));
+		List<Integer> parkRups = new ArrayList<>(findParkfieldRups());
 		double[] initial = new double[rupSet.getNumRuptures()];
 		if (ensureNotSkipped) {
 			HashSet<Integer> skips = new HashSet<Integer>(getRupIndexesBelowMinMag());

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
@@ -90,7 +90,7 @@ public class NSHM23_ConstraintBuilder {
 	
 	private SubSeisMoRateReduction subSeisMoRateReduction = SupraSeisBValInversionTargetMFDs.SUB_SEIS_MO_RATE_REDUCTION_DEFAULT;
 	
-	private static final double DEFAULT_REL_STD_DEV = 0.1;
+	public static double DEFAULT_REL_STD_DEV = 0.1;
 	
 	private DoubleUnaryOperator magDepRelStdDev = M->DEFAULT_REL_STD_DEV;
 	
@@ -142,7 +142,7 @@ public class NSHM23_ConstraintBuilder {
 	}
 	
 	public NSHM23_ConstraintBuilder defaultDataConstraints(SubSectConstraintModels subSectConstrModel) {
-		magDepRelStdDev(M->0.1*Math.pow(10, supraBVal*0.5*(M-6)))
+		magDepRelStdDev(M->DEFAULT_REL_STD_DEV*Math.pow(10, supraBVal*0.5*(M-6)))
 				.slipRates().weight(1d)
 				.paleoRates().weight(5d).paleoSlips().weight(5d)
 				.parkfield().weight(10d);

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
@@ -80,7 +80,8 @@ public class NSHM23_ConstraintBuilder {
 	private double supraBVal;
 	private boolean applyDefModelUncertaintiesToNucl;
 	private boolean addSectCountUncertaintiesToMFD;
-	private boolean adjustForIncompatibleData;
+	public static boolean ADJ_FOR_INCOMPATIBLE_DATA_DEFAULT = true;
+	private boolean adjustForIncompatibleData = ADJ_FOR_INCOMPATIBLE_DATA_DEFAULT;
 	
 	public static boolean ADJ_FOR_ACTUAL_RUP_SLIPS_DEFAULT = true;
 	public static boolean ADJ_FOR_SLIP_ALONG_DEFAULT = false;
@@ -98,7 +99,7 @@ public class NSHM23_ConstraintBuilder {
 	
 	public NSHM23_ConstraintBuilder(FaultSystemRupSet rupSet, double supraSeisB) {
 		this(rupSet, supraSeisB, SupraSeisBValInversionTargetMFDs.APPLY_DEF_MODEL_UNCERTAINTIES_DEFAULT,
-				SupraSeisBValInversionTargetMFDs.ADD_SECT_COUNT_UNCERTAINTIES_DEFAULT, false);
+				SupraSeisBValInversionTargetMFDs.ADD_SECT_COUNT_UNCERTAINTIES_DEFAULT, ADJ_FOR_INCOMPATIBLE_DATA_DEFAULT);
 	}
 	
 	public NSHM23_ConstraintBuilder(FaultSystemRupSet rupSet, double supraBVal,

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
@@ -13,6 +13,8 @@ import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.data.IntegerSampler;
 import org.opensha.commons.data.IntegerSampler.ExclusionIntegerSampler;
 import org.opensha.commons.data.function.IntegerPDF_FunctionSampler;
+import org.opensha.commons.geo.json.Feature;
+import org.opensha.commons.geo.json.FeatureProperties;
 import org.opensha.commons.logicTree.LogicTreeBranch;
 import org.opensha.commons.logicTree.LogicTreeLevel;
 import org.opensha.commons.util.ExceptionUtils;
@@ -22,6 +24,7 @@ import org.opensha.sha.earthquake.faultSysSolution.RupSetDeformationModel;
 import org.opensha.sha.earthquake.faultSysSolution.RupSetFaultModel;
 import org.opensha.sha.earthquake.faultSysSolution.RupSetScalingRelationship;
 import org.opensha.sha.earthquake.faultSysSolution.RuptureSets.RupSetConfig;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.ClusterSpecificInversionConfigurationFactory;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfigurationFactory;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.ConstraintWeightingType;
@@ -32,6 +35,7 @@ import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.Pa
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.PaleoSlipInversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.impl.ParkfieldInversionConstraint;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.CompletionCriteria;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.IterationCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.completion.IterationsPerVariableCompletionCriteria;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.GenerationFunctionType;
 import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.params.NonnegativityConstraintType;
@@ -46,6 +50,7 @@ import org.opensha.sha.earthquake.faultSysSolution.modules.SlipAlongRuptureModel
 import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionSlipRates;
 import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats.MisfitStats;
 import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionLogicTree.SolutionProcessor;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRupture;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.ClusterRuptureBuilder;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.PlausibilityConfiguration;
 import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.JumpProbabilityCalc;
@@ -64,6 +69,7 @@ import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.estimators.G
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.estimators.SegmentationImpliedSectNuclMFD_Estimator;
 import org.opensha.sha.earthquake.rupForecastImpl.nshm23.targetMFDs.estimators.SegmentationImpliedSectNuclMFD_Estimator.MultiBinDistributionMethod;
 import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.faultSurface.GeoJSONFaultSection;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashBasedTable;
@@ -390,10 +396,11 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 		
 		SubSectConstraintModels constrModel = branch.requireValue(SubSectConstraintModels.class);
 		RupSetFaultModel fm = branch.requireValue(RupSetFaultModel.class);
+		boolean hasPaleoData = rupSet.hasModule(PaleoseismicConstraintData.class);
 		
 		double slipWeight = 1d;
-		double paleoWeight = fm instanceof FaultModels ? 5 : 0; // TODO
-		double parkWeight = fm instanceof FaultModels ? 10 : 0; // TODO
+		double paleoWeight = fm instanceof FaultModels && hasPaleoData ? 5 : 0; // TODO
+		double parkWeight = fm instanceof FaultModels && constrBuilder.rupSetHasParkfield() ? 10 : 0; // TODO
 		double mfdWeight = constrModel == SubSectConstraintModels.NUCL_MFD ? 1 : 10;
 		double nuclWeight = constrModel == SubSectConstraintModels.TOT_NUCL_RATE ? 0.5 : 0d;
 		double nuclMFDWeight = constrModel == SubSectConstraintModels.NUCL_MFD ? 0.5 : 0d;
@@ -403,6 +410,21 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 		System.out.println("Segmentation model: "+segModel);
 		MaxJumpDistModels distModel = branch.getValue(MaxJumpDistModels.class);
 		System.out.println("Max distance model: "+distModel);
+		// make sure we actually have jumps
+		if (segModel != null || distModel != null) {
+			boolean jumpFound = false;
+			for (ClusterRupture cRup : rupSet.requireModule(ClusterRuptures.class)) {
+				if (cRup.getTotalNumJumps() > 0) {
+					jumpFound = true;
+					break;
+				}
+			}
+			if (!jumpFound) {
+				System.out.println("Rupture set has no jumps, disabling segmentation");
+				segModel = null;
+				distModel = null;
+			}
+		}
 		JumpProbabilityCalc targetSegModel = segModel == null ? null : segModel.getModel(rupSet);
 		if (distModel != null) {
 			if (targetSegModel == null)
@@ -489,7 +511,13 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 		
 		int avgThreads = threads / 4;
 		
-		CompletionCriteria completion = new IterationsPerVariableCompletionCriteria(5000d);
+//		CompletionCriteria completion = new IterationsPerVariableCompletionCriteria(5000d);
+		// the greater of 2,000 iterations per rupture and 500,000 iterations per section
+//		long rupIters = rupSet.getNumRuptures()*2000l;
+//		long sectIters = rupSet.getNumSections()*500000l;
+		long rupIters = rupSet.getNumRuptures()*1000l; // TODO temp short
+		long sectIters = rupSet.getNumSections()*100000l;
+		CompletionCriteria completion = new IterationCompletionCriteria(Long.max(rupIters, sectIters));
 		
 		InversionConfiguration.Builder builder = InversionConfiguration.builder(constraints, completion)
 				.threads(threads)
@@ -611,6 +639,66 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 			config = InversionConfiguration.builder(config).reweight(null).build();
 			
 			return config;
+		}
+		
+	}
+	
+	public static class ClusterSpecific extends NSHM23_InvConfigFactory implements ClusterSpecificInversionConfigurationFactory {
+		
+	}
+	
+	/**
+	 * Extend down-dip width of all faults
+	 * 
+	 * @author kevin
+	 *
+	 */
+	private static class AbstractScaleLowerDepth extends NSHM23_InvConfigFactory {
+		
+		private double scalar;
+
+		private AbstractScaleLowerDepth(double scalar) {
+			this.scalar = scalar;
+		}
+
+		@Override
+		public FaultSystemRupSet buildRuptureSet(LogicTreeBranch<?> branch, int threads) throws IOException {
+			FaultSystemRupSet rupSet = super.buildRuptureSet(branch, threads);
+			
+			List<FaultSection> modSects = new ArrayList<>();
+			for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+				GeoJSONFaultSection geoSect;
+				if (sect instanceof GeoJSONFaultSection)
+					geoSect = (GeoJSONFaultSection)sect;
+				else
+					geoSect = new GeoJSONFaultSection(sect);
+				Feature feature = geoSect.toFeature();
+				FeatureProperties props = feature.properties;
+				double curLowDepth = props.getDouble(GeoJSONFaultSection.LOW_DEPTH, Double.NaN);
+				Preconditions.checkState(curLowDepth > 0);
+				props.set(GeoJSONFaultSection.LOW_DEPTH, curLowDepth*scalar);
+				FaultSection modSect = GeoJSONFaultSection.fromFeature(feature);
+				modSects.add(modSect);
+			}
+			
+			ClusterRuptures cRups = rupSet.requireModule(ClusterRuptures.class);
+			PlausibilityConfiguration plausibility = rupSet.getModule(PlausibilityConfiguration.class);
+			RupSetScalingRelationship scale = branch.requireValue(RupSetScalingRelationship.class);
+
+			rupSet = ClusterRuptureBuilder.buildClusterRupSet(scale, modSects, plausibility, cRups.getAll());
+			
+			// attach modules
+			getSolutionLogicTreeProcessor().processRupSet(rupSet, branch);
+			
+			return rupSet;
+		}
+		
+	}
+	
+	public static class ScaleLowerDepth1p3 extends AbstractScaleLowerDepth {
+		
+		public ScaleLowerDepth1p3() {
+			super(1.3);
 		}
 		
 	}

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
@@ -530,9 +530,9 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 		int avgThreads = threads / 4;
 		
 //		CompletionCriteria completion = new IterationsPerVariableCompletionCriteria(5000d);
-		// the greater of 2,000 iterations per rupture and 500,000 iterations per section
+		// the greater of 2,000 iterations per rupture and 200,000 iterations per section
 		long rupIters = rupSet.getNumRuptures()*2000l;
-		long sectIters = rupSet.getNumSections()*500000l;
+		long sectIters = rupSet.getNumSections()*200000l;
 //		long rupIters = rupSet.getNumRuptures()*1000l;
 //		long sectIters = rupSet.getNumSections()*100000l;
 		CompletionCriteria completion = new IterationCompletionCriteria(Long.max(rupIters, sectIters));
@@ -671,6 +671,13 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 	
 	public static class ClusterSpecific extends NSHM23_InvConfigFactory implements ClusterSpecificInversionConfigurationFactory {
 		
+	}
+	
+	public static class DefaultUncert0p05 extends NSHM23_InvConfigFactory {
+		
+		public DefaultUncert0p05() {
+			NSHM23_ConstraintBuilder.DEFAULT_REL_STD_DEV = 0.05;
+		}
 	}
 	
 	/**

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
@@ -513,10 +513,10 @@ public class NSHM23_InvConfigFactory implements InversionConfigurationFactory {
 		
 //		CompletionCriteria completion = new IterationsPerVariableCompletionCriteria(5000d);
 		// the greater of 2,000 iterations per rupture and 500,000 iterations per section
-//		long rupIters = rupSet.getNumRuptures()*2000l;
-//		long sectIters = rupSet.getNumSections()*500000l;
-		long rupIters = rupSet.getNumRuptures()*1000l; // TODO temp short
-		long sectIters = rupSet.getNumSections()*100000l;
+		long rupIters = rupSet.getNumRuptures()*2000l;
+		long sectIters = rupSet.getNumSections()*500000l;
+//		long rupIters = rupSet.getNumRuptures()*1000l;
+//		long sectIters = rupSet.getNumSections()*100000l;
 		CompletionCriteria completion = new IterationCompletionCriteria(Long.max(rupIters, sectIters));
 		
 		InversionConfiguration.Builder builder = InversionConfiguration.builder(constraints, completion)

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/SegmentationMFD_Adjustment.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/SegmentationMFD_Adjustment.java
@@ -25,13 +25,13 @@ import com.google.common.base.Preconditions;
 @DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
 @Affects(FaultSystemSolution.RATES_FILE_NAME)
 public enum SegmentationMFD_Adjustment implements LogicTreeNode {
-	JUMP_PROB_THRESHOLD_AVG("Jump Prob Threshold Averaging", "JumpProb", 1d) {
+	JUMP_PROB_THRESHOLD_AVG("Threshold Averaging", "ThreshAvg", 1d) {
 		@Override
 		public SectNucleationMFD_Estimator getAdjustment(JumpProbabilityCalc segModel) {
 			return new ImprobModelThresholdAveragingSectNuclMFD_Estimator.WorstJumpProb(segModel);
 		}
 	},
-	JUMP_PROB_THRESHOLD_AVG_MATCH_STRICT("Strict-Seg Equiv Fractional Jump Prob", "StrictEquivJumpProb", 1d) {
+	JUMP_PROB_THRESHOLD_AVG_MATCH_STRICT("Strict-Seg Equiv Threshold Averaging", "StrictEquivThreshAvg", 1d) {
 		@Override
 		public SectNucleationMFD_Estimator getAdjustment(JumpProbabilityCalc segModel) {
 			Preconditions.checkState(segModel instanceof DistDependentJumpProbabilityCalc,
@@ -43,7 +43,7 @@ public enum SegmentationMFD_Adjustment implements LogicTreeNode {
 			return new ImprobModelThresholdAveragingSectNuclMFD_Estimator.WorstJumpProb(segModel, probs);
 		}
 	},
-	JUMP_PROB_THRESHOLD_AVG_ABOVE_1KM("Fractional Jump Prob >1km", "JumpProbGt1km", 1d) {
+	JUMP_PROB_THRESHOLD_AVG_ABOVE_1KM("Threshold Averaging >1km", "JumpProbGt1km", 1d) {
 		@Override
 		public SectNucleationMFD_Estimator getAdjustment(JumpProbabilityCalc segModel) {
 			Preconditions.checkState(segModel instanceof DistDependentJumpProbabilityCalc,

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/SupraSeisBValInversionTargetMFDs.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/SupraSeisBValInversionTargetMFDs.java
@@ -371,8 +371,9 @@ public class SupraSeisBValInversionTargetMFDs extends InversionTargetMFDs.Precom
 		private SupraSeisBValInversionTargetMFDs build(boolean slipOnly) {
 			EvenlyDiscretizedFunc refMFD = buildRefXValues(rupSet);
 			int NUM_MAG = refMFD.size();
-			System.out.println("SupraSeisBValInversionTargetMFDs total MFD range: ["
-					+(float)MIN_MAG+","+(float)refMFD.getMaxX()+"] for maxMag="+rupSet.getMaxMag());
+			System.out.println("Building SupraSeisBValInversionTargetMFDs with b="+supraSeisBValue
+					+", slipOnly="+slipOnly+", total MFD range: ["+(float)MIN_MAG+","+(float)refMFD.getMaxX()
+					+"] for maxMag="+rupSet.getMaxMag());
 			
 			ModSectMinMags minMags = rupSet.getModule(ModSectMinMags.class);
 			
@@ -650,6 +651,8 @@ public class SupraSeisBValInversionTargetMFDs extends InversionTargetMFDs.Precom
 			}
 			
 			System.out.println("Fraction supra-seismogenic stats: "+fractSuprasTrack);
+			System.out.println("Fault moments: total="+(float)StatUtils.sum(targetMoRates)
+				+"\tsupra="+(float)StatUtils.sum(targetSupraMoRates));
 			
 			if (subSeisMoRateReduction == SubSeisMoRateReduction.SYSTEM_AVG_IMPLIED_FROM_SUPRA_B) {
 				// need to re-balance to use average supra-seis fract
@@ -684,7 +687,7 @@ public class SupraSeisBValInversionTargetMFDs extends InversionTargetMFDs.Precom
 			}
 			if (slipOnly)
 				// shortcut for if we only need slip rates
-				return new SupraSeisBValInversionTargetMFDs(rupSet, supraSeisBValue, totalTargetMFD, null,
+				return new SupraSeisBValInversionTargetMFDs(rupSet, supraSeisBValue, null, null,
 						null, null, null, null, sectSlipRates, sectRupUtilizations);
 			
 			ExecutorService exec = null;

--- a/src/main/java/org/opensha/sha/magdist/IncrementalMagFreqDist.java
+++ b/src/main/java/org/opensha/sha/magdist/IncrementalMagFreqDist.java
@@ -39,6 +39,7 @@ implements IncrementalMagFreqDistAPI,java.io.Serializable {
 
 	protected String defaultInfo;
 	protected String defaultName;
+	private boolean nameOverride = false;
 	
 	protected Region region;
 
@@ -52,7 +53,8 @@ implements IncrementalMagFreqDistAPI,java.io.Serializable {
 	public IncrementalMagFreqDist (IncrementalMagFreqDist other) {
 		super(other.minX, other.maxX, other.size());
 		region = other.region;
-		setName(other.getName());
+		if (other.nameOverride)
+			setName(other.getName());
 		setInfo(other.getInfo());
 		setTolerance(other.getTolerance());
 		for (int i=0; i<other.size(); i++)
@@ -404,11 +406,17 @@ implements IncrementalMagFreqDistAPI,java.io.Serializable {
 	 * @return String
 	 */
 	public String getName(){
-		if(name !=null && !(name.trim().equals("")))
+		if(name !=null && !(name.trim().equals("")) || nameOverride)
 			return super.getName();
 		return getDefaultName();
 	}
 
+
+	@Override
+	public void setName(String name) {
+		this.nameOverride = true;
+		super.setName(name);
+	}
 
 	/**
 	 * Returns the info of the distribution that user has set from outside,

--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/modules/StandardFaultSysModulesTest.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/modules/StandardFaultSysModulesTest.java
@@ -48,6 +48,8 @@ import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
 import org.opensha.sha.magdist.IncrementalMagFreqDist;
 
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.io.Files;
 
 import scratch.UCERF3.enumTreeBranches.ScalingRelationships;
@@ -320,6 +322,23 @@ public class StandardFaultSysModulesTest {
 		ConnectivityClusters module = ConnectivityClusters.build(demoRupSet);
 		
 		testModuleSerialization(demoRupSet.getArchive(), demoRupSet, module, ConnectivityClusters.class);
+	}
+	
+	@Test
+	public void testRupSubSet() throws IOException {
+		BiMap<Integer, Integer> sectIDs_newToOld = HashBiMap.create();
+		int newSectID = 0;
+		for (int origSectID=0; origSectID<500; origSectID++)
+			if (Math.random() < 0.1)
+				sectIDs_newToOld.put(origSectID, newSectID++);
+		BiMap<Integer, Integer> rupIDs_newToOld = HashBiMap.create();
+		int newRupID = 0;
+		for (int origRupID=0; origRupID<1000; origRupID++)
+			if (Math.random() < 0.05)
+				rupIDs_newToOld.put(origRupID, newRupID++);
+		RuptureSubSetMappings module = new RuptureSubSetMappings(sectIDs_newToOld, rupIDs_newToOld);
+		
+		testModuleSerialization(demoRupSet.getArchive(), demoRupSet, module, RuptureSubSetMappings.class);
 	}
 	
 	private static double[] randArray(int len) {


### PR DESCRIPTION
This PR adds the capability to run individual inversions for isolated faults and smaller interconnected fault systems, that then get merged together into a final FaultSystemSolution. This is done via the following changes:

## FaultSystemRupSet.getForSectionSubSet

New `FaultSystemRupSet.getForSectionSubSet(Collection<Integer> retainedSectIDs)` method:

Builds a rupture subset using only the given section IDs. Fault section instances will be duplicated and assigned new section IDs in the returned rupture set, and only ruptures involving those sections will be retained. If any ruptures utilize both retained and non-retained section IDs, an `IllegalStateException` will be thrown.

All modules that implement `SplittableRuptureSubSetModule` will be copied over to the returned rupture set.

Mappings between original and new section/rupture IDs can be retrieved via the `RuptureSubSetMappings` module that will be attached to the rupture subset.

## New factory interface: ClusterSpecificInversionConfigurationFactory

Interface specifying that this factory supports cluster-specific inversions.

## Inversions.run(...) methods support cluster-specific calculations

`Inversions.run(InversionConfigurationFactory factory, LogicTreeBranch<?> branch, int threads)` handles the cluster-specific splitting and merging, if the the supplied factory is an instance of `ClusterSpecificInversionConfigurationFactory` and `isSolveClustersIndividually() == true`. The rupture set is split up into individual rupture sets for each isolated `ConnectivityCluster` and then solved individually (the largest cluster is always solved first).

Note the smart `CompletionCriteria` should be used, such as fixed number of iterations per rupture and/or section, as you don't want to spend the same amount of time annealing a single fault inversion as you would a complex many-fault inversion.

Then, after all are solved, rupture rates are merged back into a single composite solution for the original (full) rupture set.

## New module interface: SplittableRuptureSubSetModule

Interface for modules that can be split into subsets, used by `FaultSystemRupSet.getForSectionSubSet(...)`.