### PR TITLE
NSHM23: Support for classic segmentation model, & analytical solution for isolated faults

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionConfigurationFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionConfigurationFactory.java
@@ -1,6 +1,7 @@
 package org.opensha.sha.earthquake.faultSysSolution.inversion;
 
 import org.opensha.commons.logicTree.LogicTreeBranch;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
 
 /**
  * Interface for a factory that can build a separate {@link InversionConfiguration} for each {@link ConnectivityCluster},
@@ -20,7 +21,7 @@ public interface ClusterSpecificInversionConfigurationFactory extends InversionC
 	}
 
 	@Override
-	public default InversionSolver getSolver(LogicTreeBranch<?> branch) {
+	public default InversionSolver getSolver(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
 		if (isSolveClustersIndividually())
 			return new ClusterSpecificInversionSolver();
 		return new InversionSolver.Default();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionSolver.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/ClusterSpecificInversionSolver.java
@@ -55,6 +55,7 @@ public class ClusterSpecificInversionSolver extends InversionSolver.Default {
 			rupSet.addModule(clusterModule);
 			clusters = clusterModule.get();
 		}
+		Preconditions.checkState(!clusters.isEmpty(), "No clusters found?");
 		// sort by number of ruptures, decreasing
 		clusters = new ArrayList<>(clusters);
 		Collections.sort(clusters, ConnectivityCluster.rupCountComparator);
@@ -157,6 +158,9 @@ public class ClusterSpecificInversionSolver extends InversionSolver.Default {
 
 			return sol;
 		} else {
+			ConnectivityCluster cluster = clusters.get(0);
+			if (!shouldInvert(cluster))
+				return null;
 			System.out.println("Only 1 connectivity cluster, will run regular inversion");
 			InversionConfiguration config = factory.buildInversionConfig(rupSet, branch, threads);
 			if (branch != rupSet.getModule(LogicTreeBranch.class))

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfigurationFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionConfigurationFactory.java
@@ -88,7 +88,7 @@ public interface InversionConfigurationFactory {
 	 * @param branch
 	 * @return
 	 */
-	public default InversionSolver getSolver(LogicTreeBranch<?> branch) {
+	public default InversionSolver getSolver(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
 		return new InversionSolver.Default();
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionSolver.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionSolver.java
@@ -51,7 +51,7 @@ public interface InversionSolver {
 				// apply any command line overrides
 				config = InversionConfiguration.builder(config).forCommandLine(cmd).build();
 			
-			FaultSystemSolution sol = Inversions.run(rupSet, config);
+			FaultSystemSolution sol = run(rupSet, config, null);
 			
 			// attach any relevant modules before writing out
 			SolutionProcessor processor = factory.getSolutionLogicTreeProcessor();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionSolver.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/InversionSolver.java
@@ -26,7 +26,6 @@ public interface InversionSolver {
 	public default FaultSystemSolution run(InversionConfigurationFactory factory, LogicTreeBranch<?> branch, int threads,
 			CommandLine cmd) throws IOException {
 		FaultSystemRupSet rupSet = factory.buildRuptureSet(branch, threads);
-		rupSet.addModule(branch);
 		
 		return run(rupSet, factory, branch, threads, cmd);
 	}
@@ -46,7 +45,8 @@ public interface InversionSolver {
 		public FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfigurationFactory factory,
 				LogicTreeBranch<?> branch, int threads, CommandLine cmd) throws IOException {
 			InversionConfiguration config = factory.buildInversionConfig(rupSet, branch, threads);
-			rupSet.addModule(branch);
+			if (branch != rupSet.getModule(LogicTreeBranch.class))
+				rupSet.addModule(branch);
 			if (cmd != null)
 				// apply any command line overrides
 				config = InversionConfiguration.builder(config).forCommandLine(cmd).build();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/inversion/Inversions.java
@@ -563,17 +563,18 @@ public class Inversions {
 	
 	public static FaultSystemSolution run(InversionConfigurationFactory factory, LogicTreeBranch<?> branch, int threads)
 			throws IOException {
-		return factory.getSolver(branch).run(factory, branch, threads);
+		return run(factory, branch, threads, null);
 	}
 	
 	public static FaultSystemSolution run(InversionConfigurationFactory factory, LogicTreeBranch<?> branch, int threads,
 			CommandLine cmd) throws IOException {
-		return factory.getSolver(branch).run(factory, branch, threads, cmd);
+		FaultSystemRupSet rupSet = factory.buildRuptureSet(branch, threads);;
+		return run(rupSet, factory, branch, threads, cmd);
 	}
 	
 	public static FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfigurationFactory factory,
 			LogicTreeBranch<?> branch, int threads, CommandLine cmd) throws IOException {
-		return factory.getSolver(branch).run(rupSet, factory, branch, threads, cmd);
+		return factory.getSolver(rupSet, branch).run(rupSet, factory, branch, threads, cmd);
 	}
 	
 	public static FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfiguration config) {

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ConnectivityClusters.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ConnectivityClusters.java
@@ -266,7 +266,6 @@ BranchAverageableModule<ConnectivityClusters>, AverageableModule.ConstantAverage
 
 		@Override
 		public AveragingAccumulator<ConnectivityClusterSolutionMisfits> averagingAccumulator() {
-			// TODO Auto-generated method stub
 			return new AveragingAccumulator<>() {
 				
 				private List<AveragingAccumulator<InversionMisfitStats>> statsAccumulators;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitProgress.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/InversionMisfitProgress.java
@@ -252,7 +252,7 @@ public class InversionMisfitProgress implements CSV_BackedModule, BranchAveragea
 						targetVals.add(doubleAvg(targetVals, weights));
 					avgStats.add(statsAccumulator.getAverage());
 				}
-				return new InversionMisfitProgress(avgIters, avgTimes, avgStats);
+				return new InversionMisfitProgress(avgIters, avgTimes, avgStats, targetQuantity, avgTargetVals);
 			}
 		};
 	}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/JumpProbabilityCalc.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/JumpProbabilityCalc.java
@@ -160,6 +160,56 @@ public interface JumpProbabilityCalc extends RuptureProbabilityCalc {
 		
 	}
 	
+	public class NoJumps implements BinaryJumpProbabilityCalc {
+
+		@Override
+		public boolean isDirectional(boolean splayed) {
+			return false;
+		}
+
+		@Override
+		public String getName() {
+			return "No Jumps";
+		}
+
+		@Override
+		public boolean isJumpAllowed(ClusterRupture fullRupture, Jump jump, boolean verbose) {
+			return false;
+		}
+		
+	}
+	
+	public class LogicalAnd implements BinaryJumpProbabilityCalc {
+		
+		private BinaryJumpProbabilityCalc[] calcs;
+
+		public LogicalAnd(BinaryJumpProbabilityCalc... calcs) {
+			Preconditions.checkState(calcs.length > 1);
+			this.calcs = calcs;
+		}
+
+		@Override
+		public String getName() {
+			return "Logical AND of "+calcs.length+" models";
+		}
+
+		@Override
+		public boolean isDirectional(boolean splayed) {
+			for (RuptureProbabilityCalc calc : calcs)
+				if (calc.isDirectional(splayed))
+					return true;
+			return false;
+		}
+
+		@Override
+		public boolean isJumpAllowed(ClusterRupture fullRupture, Jump jump, boolean verbose) {
+			for (BinaryJumpProbabilityCalc calc : calcs)
+				if (!calc.isJumpAllowed(fullRupture, jump, verbose))
+					return false;
+			return true;
+		}
+	}
+	
 	public class HardcodedJumpProb implements JumpProbabilityCalc {
 		
 		private String name;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/RuptureProbabilityCalc.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/RuptureProbabilityCalc.java
@@ -43,6 +43,37 @@ public interface RuptureProbabilityCalc extends Named {
 		}
 	}
 	
+	public class LogicalAnd implements BinaryRuptureProbabilityCalc {
+		
+		private BinaryRuptureProbabilityCalc[] calcs;
+
+		public LogicalAnd(BinaryRuptureProbabilityCalc... calcs) {
+			Preconditions.checkState(calcs.length > 1);
+			this.calcs = calcs;
+		}
+
+		@Override
+		public String getName() {
+			return "Logical AND of "+calcs.length+" models";
+		}
+
+		@Override
+		public boolean isDirectional(boolean splayed) {
+			for (RuptureProbabilityCalc calc : calcs)
+				if (calc.isDirectional(splayed))
+					return true;
+			return false;
+		}
+
+		@Override
+		public boolean isRupAllowed(ClusterRupture fullRupture, boolean verbose) {
+			for (BinaryRuptureProbabilityCalc calc : calcs)
+				if (!calc.isRupAllowed(fullRupture, verbose))
+					return false;
+			return true;
+		}
+	}
+	
 	public class MultiProduct implements RuptureProbabilityCalc {
 		
 		private RuptureProbabilityCalc[] calcs;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
@@ -1629,20 +1629,25 @@ public class SegmentationCalculator {
 					if (segClass != null && segClass.isEnum() && SegmentationModelBranchNode.class.isAssignableFrom(segClass)) {
 						for (SegmentationModelBranchNode option : segClass.getEnumConstants()) {
 							if (option.getNodeWeight(branch) > 0d || option == segChoice) {
-								JumpProbabilityCalc model = option.getModel(sol.getRupSet(), branch);
-								if (!(model instanceof DistDependentJumpProbabilityCalc)) {
-									// try generic
-									model = option.getModel(null, branch);
-								}
-								if (model instanceof DistDependentJumpProbabilityCalc) {
-									DistDependentJumpProbabilityCalc distModel = (DistDependentJumpProbabilityCalc)model;
-									if (option == segChoice) {
-										chosenSegModel = distModel;
-										chosenName = option.getShortName();
-									} else {
-										comparisons.add(distModel);
-										compNames.add(option.getShortName());
+								try {
+									JumpProbabilityCalc model = option.getModel(sol.getRupSet(), branch);
+									if (!(model instanceof DistDependentJumpProbabilityCalc)) {
+										// try generic
+										model = option.getModel(null, branch);
 									}
+									if (model instanceof DistDependentJumpProbabilityCalc) {
+										DistDependentJumpProbabilityCalc distModel = (DistDependentJumpProbabilityCalc)model;
+										if (option == segChoice) {
+											chosenSegModel = distModel;
+											chosenName = option.getShortName();
+										} else {
+											comparisons.add(distModel);
+											compNames.add(option.getShortName());
+										}
+									}
+								} catch (Exception e) {
+									// error building segmentation model, possibly with our generic (no rupture set)
+									// method call, skip
 								}
 							}
 						}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/BranchAverageSolutionCreator.java
@@ -247,9 +247,10 @@ public class BranchAverageSolutionCreator {
 			try {
 				accumulator.processContainer(container, weight);
 			} catch (Exception e) {
-				e.printStackTrace();
-				System.err.println("Error processing accumulator, will no longer average "
-						+accumulator.getType().getName()+". Failed on branch: "+branch);
+//				e.printStackTrace();
+				System.err.println("Error processing accumulator, will no longer average "+accumulator.getType().getName()
+						+".\n\tFailed on branch: "+branch
+						+"\n\tError message: "+e.getMessage());
 				System.err.flush();
 				accumulators.remove(i);
 				if (accumulatingSlipRates && SolutionSlipRates.class.isAssignableFrom(accumulator.getType()))

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
@@ -666,7 +666,10 @@ public class NSHM23_ConstraintBuilder {
 		Preconditions.checkState(!paleos.isEmpty());
 		for (SectMappedUncertainDataConstraint paleo : paleos)
 			paleoParentIDs.add(rupSet.getFaultSectionData(paleo.sectionIndex).getParentSectionId());
-		constraints.add(new LaplacianSmoothingInversionConstraint(rupSet, 1000, paleoParentIDs));
+		LaplacianSmoothingInversionConstraint constraint = new LaplacianSmoothingInversionConstraint(rupSet, 1000, paleoParentIDs);
+		if (constraint.getNumRows() > 0)
+			// make sure it actually has rows, can not if only 2-section parents
+			constraints.add(constraint);
 		return this;
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_ConstraintBuilder.java
@@ -293,7 +293,7 @@ public class NSHM23_ConstraintBuilder {
 			}
 		}
 		if (rupExclusionModel != null)
-			builder.forBinaryRupProbModel(rupExclusionModel);
+			builder.forBinaryRupProbModel(rupExclusionModel, false);
 		if (adjustForActualRupSlips)
 			builder.adjustTargetsForData(new ScalingRelSlipRateMFD_Estimator(adjustForSlipAlong));
 		if (adjustForIncompatibleData) {
@@ -394,7 +394,11 @@ public class NSHM23_ConstraintBuilder {
 	}
 	
 	public boolean rupSetHasCreepingSection() {
-		return FaultSectionUtils.findParentSectionID(rupSet.getFaultSectionDataList(), "San", "Andreas", "Creeping") >= 0;
+		return findCreepingSection(rupSet) >= 0;
+	}
+	
+	public static int findCreepingSection(FaultSystemRupSet rupSet) {
+		return FaultSectionUtils.findParentSectionID(rupSet.getFaultSectionDataList(), "San", "Andreas", "Creeping");
 	}
 	
 	public static boolean isRupThroughCreeping(int creepingParentID, ClusterRupture rup) {

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23_SegmentationModels.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23_SegmentationModels.java
@@ -32,7 +32,18 @@ import com.google.common.base.Preconditions;
 @DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
 @DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
 @Affects(FaultSystemSolution.RATES_FILE_NAME)
-public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
+public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode, RupsThroughCreepingSectBranchNode {
+	NONE("None", "None", 1.0d) {
+		@Override
+		public JumpProbabilityCalc getModel(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
+			return null;
+		}
+
+		@Override
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			return false;
+		}
+	},
 	LOW("Low Segmentation", "LowSeg",
 			1d, // weight
 			4d, // R0
@@ -42,11 +53,16 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 			// if we don't have a creeping section branch explicitly on the logic tree, include it here
 			double creepingProb = 1d;
 			if (APPLY_TO_CREEPING_SECT && !branch.hasValue(RupsThroughCreepingSect.class))
-				// Creeping P=1 unless wide branches, then 0.75
-				creepingProb = WIDE_BRANCHES ? 0.75 : 1d;
+				// Creeping P=0.75
+				creepingProb = 0.75;
 			// Wasatch P=1 unless wide branches, then 0.75
-			double wasatchProb = WIDE_BRANCHES ? 0.75 : 1d;
+			double wasatchProb = 0.75;
 			return buildModel(rupSet, shawR0, shawShift, wasatchProb, creepingProb, Double.NaN);
+		}
+
+		@Override
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			return false;
 		}
 	},
 	MID("Middle Segmentation", "MidSeg",
@@ -64,6 +80,11 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 			double wasatchProb = 0.5;
 			return buildModel(rupSet, shawR0, shawShift, wasatchProb, creepingProb, Double.NaN);
 		}
+
+		@Override
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			return false;
+		}
 	},
 	HIGH("High Segmentation", "HighSeg",
 			1d, // weight
@@ -75,30 +96,47 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 			// externally at the rupture exclusion model stage
 			double creepingProb = 1d;
 			if (APPLY_TO_CREEPING_SECT && !branch.hasValue(RupsThroughCreepingSect.class))
-				// Creeping P=0.5 unless wide branches, then 0.25
-				creepingProb = WIDE_BRANCHES ? 0.25 : 0.5d;
-			// Wasatch P=0 unless wide branches, then 0.25
-			double wasatchProb = WIDE_BRANCHES ? 0.25 : 0d;
+				// Creeping P=0.25
+				creepingProb = 0.25;
+			// Wasatch P=0.25
+			double wasatchProb = 0.25;
 			return buildModel(rupSet, shawR0, shawShift, wasatchProb, creepingProb, Double.NaN);
 		}
-	},
-	NONE("None", "None", 0.0d) {
+
 		@Override
-		public JumpProbabilityCalc getModel(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
-			return null;
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			return false;
 		}
 	},
-	TWO_KM("2km Hard Cutoff", "Max2km", 0.0d) {
+	CLASSIC("Classic ('A' faults)", "Classic", 1d) {
 		@Override
-		public JumpProbabilityCalc getModel(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
-			// Still restrict creeping section, but the bulk of the through-creeping-section will be handled
-			// externally at the rupture exclusion model stage
-			double creepingProb = 1d;
-			if (APPLY_TO_CREEPING_SECT && !branch.hasValue(RupsThroughCreepingSect.class))
-				creepingProb = 0.25;
-			// Wasatch P=0
-			double wasatchProb = 0d;
-			return buildModel(rupSet, Double.NaN, Double.NaN, wasatchProb, creepingProb, 2d);
+		public BinaryJumpProbabilityCalc getModel(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
+			// jumps within named faults only
+			List<BinaryJumpProbabilityCalc> models = new ArrayList<>();
+			if (rupSet.hasModule(NamedFaults.class))
+				models.add(new NamedFaultSegmentationModel(rupSet.requireModule(NamedFaults.class)));
+			else
+				models.add(new JumpProbabilityCalc.NoJumps());
+			
+			// creeping section. this limints not just through, but anything corupturing with the creeping section
+			int creepingParentID = FaultSectionUtils.findParentSectionID(rupSet.getFaultSectionDataList(), "San", "Andreas", "Creeping");
+			if (creepingParentID >= 0)
+				models.add(new CreepingSectionBinaryJumpExcludeModel(creepingParentID));
+			
+			// wasatch
+			BinaryJumpProbabilityCalc wasatch = NSHM23_WasatchSegmentationData.buildFullExclusion(rupSet.getFaultSectionDataList(), null);
+			if (wasatch != null)
+				models.add(wasatch);
+			
+			Preconditions.checkState(!models.isEmpty());
+			if (models.size() == 1)
+				return models.get(0);
+			return new JumpProbabilityCalc.LogicalAnd(models.toArray(new BinaryJumpProbabilityCalc[0]));
+		}
+
+		@Override
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			return true;
 		}
 	},
 	AVERAGE("NSHM23 Average Segmentation", "AvgSeg", 0.0d) {
@@ -154,11 +192,24 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 				
 			};
 		}
+
+		@Override
+		public boolean isExcludeRupturesThroughCreepingSect() {
+			double weightInclude = 0d;
+			double weightExclude = 0d;
+			for (NSHM23_SegmentationModels segModel : values()) {
+				if (segModel != this && segModel.weight > 0d) {
+					if (segModel.isExcludeRupturesThroughCreepingSect())
+						weightExclude += segModel.weight;
+					else
+						weightInclude += segModel.weight;
+				}
+			}
+			return weightExclude > weightInclude;
+		}
 	};
 	
 	public static boolean APPLY_TO_CREEPING_SECT = true;
-	
-	public static boolean WIDE_BRANCHES = false;
 	
 	private String name;
 	private String shortName;
@@ -198,8 +249,13 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 		if (rupSet != null) {
 			if (creepingProb < 1d) {
 				int creepingParentID = FaultSectionUtils.findParentSectionID(rupSet.getFaultSectionDataList(), "San", "Andreas", "Creeping");
-				if (creepingParentID >= 0)
-					model = new JumpProbabilityCalc.Minimum(model, new CreepingSectionJumpSegModel(creepingParentID, creepingProb));
+				if (creepingParentID >= 0) {
+					CreepingSectionJumpSegModel creepModel = new CreepingSectionJumpSegModel(creepingParentID, creepingProb);
+					if (model == null)
+						model = creepModel;
+					else
+						model = new JumpProbabilityCalc.Minimum(model, creepModel);
+				}
 			}
 			// Wasatch model
 			JumpProbabilityCalc wasatch = NSHM23_WasatchSegmentationData.build(
@@ -270,6 +326,33 @@ public enum NSHM23_SegmentationModels implements SegmentationModelBranchNode {
 			if (jump.fromCluster.parentSectionID == creepingParentID || jump.toCluster.parentSectionID == creepingParentID)
 				return prob;
 			return 1;
+		}
+		
+	}
+	
+	public static class CreepingSectionBinaryJumpExcludeModel implements BinaryJumpProbabilityCalc {
+		
+		private int creepingParentID;
+
+		public CreepingSectionBinaryJumpExcludeModel(int creepingParentID) {
+			this.creepingParentID = creepingParentID;
+		}
+
+		@Override
+		public boolean isDirectional(boolean splayed) {
+			return false;
+		}
+
+		@Override
+		public String getName() {
+			return "Exclude Creeping Section Jumps";
+		}
+
+		@Override
+		public boolean isJumpAllowed(ClusterRupture fullRupture, Jump jump, boolean verbose) {
+			if (jump.fromCluster.parentSectionID == creepingParentID || jump.toCluster.parentSectionID == creepingParentID)
+				return false;
+			return true;
 		}
 		
 	}

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/RupsThroughCreepingSect.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/RupsThroughCreepingSect.java
@@ -12,8 +12,7 @@ import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 @DoesNotAffect(FaultSystemRupSet.RUP_SECTS_FILE_NAME)
 @DoesNotAffect(FaultSystemRupSet.RUP_PROPS_FILE_NAME)
 @Affects(FaultSystemSolution.RATES_FILE_NAME)
-public enum RupsThroughCreepingSect implements LogicTreeNode {
-	
+public enum RupsThroughCreepingSect implements RupsThroughCreepingSectBranchNode {
 	INCLUDE(true, 0.5d),
 	EXCLUDE(false, 0.5d);
 	
@@ -44,12 +43,9 @@ public enum RupsThroughCreepingSect implements LogicTreeNode {
 	public String getFilePrefix() {
 		return getShortName()+"ThruCreep";
 	}
-	
-	public boolean isInclude() {
-		return include;
-	}
-	
-	public boolean isExclude() {
+
+	@Override
+	public boolean isExcludeRupturesThroughCreepingSect() {
 		return !include;
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/RupsThroughCreepingSectBranchNode.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/RupsThroughCreepingSectBranchNode.java
@@ -1,0 +1,13 @@
+package org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree;
+
+import org.opensha.commons.logicTree.LogicTreeNode;
+
+public interface RupsThroughCreepingSectBranchNode extends LogicTreeNode {
+	
+	public default boolean isIncludeRupturesThroughCreepingSect() {
+		return !isExcludeRupturesThroughCreepingSect();
+	}
+	
+	public boolean isExcludeRupturesThroughCreepingSect();
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/SupraSeisBValInversionTargetMFDs.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/targetMFDs/SupraSeisBValInversionTargetMFDs.java
@@ -351,6 +351,10 @@ public class SupraSeisBValInversionTargetMFDs extends InversionTargetMFDs.Precom
 		}
 		
 		public Builder forBinaryRupProbModel(BinaryRuptureProbabilityCalc binaryRupProb) {
+			return forBinaryRupProbModel(binaryRupProb, true);
+		}
+		
+		public Builder forBinaryRupProbModel(BinaryRuptureProbabilityCalc binaryRupProb, boolean replaceExisting) {
 			BitSet rupSubSet = new BitSet(rupSet.getNumRuptures());
 			ClusterRuptures cRups = rupSet.requireModule(ClusterRuptures.class);
 			System.out.println("Processing "+rupSet.getNumRuptures()+" ruptures for binary rupture probability calculation");
@@ -359,17 +363,33 @@ public class SupraSeisBValInversionTargetMFDs extends InversionTargetMFDs.Precom
 				if (binaryRupProb.isRupAllowed(rup, false))
 					rupSubSet.set(r);
 			}
-			return forRupSubSet(rupSubSet);
+			return forRupSubSet(rupSubSet, replaceExisting);
 		}
 		
 		/**
-		 * It non-null, specifies a subset of ruptures that we are allowed to use when determining MFD targets
+		 * It non-null, specifies a subset of ruptures that we are allowed to use when determining MFD targets. Will
+		 * replace any existing rupture subset.
 		 * 
 		 * @param rupSubSet
 		 * @return
 		 */
 		public Builder forRupSubSet(BitSet rupSubSet) {
-			this.rupSubSet = rupSubSet;
+			return forRupSubSet(rupSubSet, true);
+		}
+		
+		/**
+		 * It non-null, specifies a subset of ruptures that we are allowed to use when determining MFD targets.
+		 * 
+		 * @param rupSubSet
+		 * @param replaceExisting if true and a previous rupture subset has been set, then only ruptures common to both
+		 * will be retained, unless the given subset is null in which case everything will be cleared
+		 * @return
+		 */
+		public Builder forRupSubSet(BitSet rupSubSet, boolean replaceExisting) {
+			if (!replaceExisting && rupSubSet != null && this.rupSubSet != null)
+				this.rupSubSet.and(rupSubSet);
+			else
+				this.rupSubSet = rupSubSet;
 			return this;
 		}
 		

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/AnalyticalSingleFaultInversionSolver.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/AnalyticalSingleFaultInversionSolver.java
@@ -1,0 +1,172 @@
+package org.opensha.sha.earthquake.rupForecastImpl.nshm23.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionInputGenerator;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionSolver;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.constraints.InversionConstraint;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.sa.SerialSimulatedAnnealing;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InfoModule;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfits;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionTargetMFDs;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ModSectMinMags;
+import org.opensha.sha.faultSurface.FaultSection;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+
+import com.google.common.base.Preconditions;
+
+public class AnalyticalSingleFaultInversionSolver extends InversionSolver.Default {
+	
+	private double bVal;
+
+	public AnalyticalSingleFaultInversionSolver(double bVal) {
+		this.bVal = bVal;
+	}
+	
+	public static boolean isSingleFault(FaultSystemRupSet rupSet) {
+		Integer parentID = null;
+		for (FaultSection sect : rupSet.getFaultSectionDataList()) {
+			int myParentID = sect.getParentSectionId();
+			if (parentID == null)
+				parentID = myParentID;
+			else if (myParentID != parentID)
+				return false;
+		}
+		return true;
+	}
+
+	@Override
+	public FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfiguration config, String info) {
+		// make sure that it's actually a single fault
+		Preconditions.checkState(isSingleFault(rupSet), "Analytical solution only works for a single-fault "
+				+ "rupture set, encountered multiple parents");
+		
+		ModSectMinMags minMags = rupSet.getModule(ModSectMinMags.class);
+		
+		InversionTargetMFDs targets = rupSet.requireModule(InversionTargetMFDs.class);
+		
+		List<? extends IncrementalMagFreqDist> supraNuclMFDs = targets.getOnFaultSupraSeisNucleationMFDs();
+		Preconditions.checkNotNull(supraNuclMFDs,
+				"Must have section supra-seis nucleation MFDs to solve classic model analytically");
+		
+		double[] rates = new double[rupSet.getNumRuptures()];
+		for (int s=0; s<rupSet.getNumSections(); s++) {
+			// solve it in the world of each subsection
+			IncrementalMagFreqDist sectMFD = supraNuclMFDs.get(s);
+			Preconditions.checkNotNull(sectMFD,
+					"Must have section supra-seis nucleation MFDs to solve classic model analytically");
+			if (sectMFD.calcSumOfY_Vals() == 0d)
+				continue;
+			
+			// TODO support (and adjust for) waterlevel
+			
+			List<List<Integer>> rupsInBins = new ArrayList<>(sectMFD.size());
+			for (int i=0; i<sectMFD.size(); i++)
+				rupsInBins.add(null);
+			
+			// identify ruptures above section minimum magnitude, and figure out how many occupy each input MFD bin
+			for (int rupIndex : rupSet.getRupturesForSection(s)) {
+				double mag = rupSet.getMagForRup(rupIndex);
+				if (minMags != null && minMags.isBelowSectMinMag(s, mag, sectMFD))
+					continue;
+				int magIndex = sectMFD.getClosestXIndex(mag);
+				List<Integer> binRups = rupsInBins.get(magIndex);
+				if (binRups == null) {
+					binRups = new ArrayList<>();
+					rupsInBins.set(magIndex, binRups);
+				}
+				binRups.add(rupIndex);
+			}
+			
+			// now figure out rupture rates to satisfy this nucleation MFD
+			for (int i=0; i<sectMFD.size(); i++) {
+				List<Integer> rups = rupsInBins.get(i);
+				double binRate = sectMFD.getY(i);
+				if (rups == null || binRate == 0d)
+					continue;
+				
+				if (this.bVal == 0d || allMagsSame(rupSet, rups)) {
+					// simple case
+					double rateEach = binRate / rups.size();
+					
+					for (int rupIndex : rups)
+						rates[rupIndex] += rateEach;
+				} else {
+					// complicated, need to spread it across ruptures of different magnitudes
+					// do so according to the target b-value
+					
+					double binCenter = sectMFD.getX(i);
+					double centerGR = calcGR(bVal, binCenter);
+					double[] weights = new double[rups.size()];
+					double sumWeight = 0d;
+					for (int r=0; r<weights.length; r++) {
+						double mag = rupSet.getMagForRup(rups.get(r));
+						double myGR = calcGR(bVal, mag);
+						double weight = myGR/centerGR;
+						sumWeight += weight;
+						weights[r] = weight;
+					}
+					for (int r=0; r<weights.length; r++)
+						rates[rups.get(r)] += binRate*weights[r]/sumWeight;
+				}
+			}
+		}
+		
+		FaultSystemSolution sol = new FaultSystemSolution(rupSet, rates);
+		
+		// TODO: water level?
+		
+		if (config != null) {
+			sol.addModule(config);
+			List<InversionConstraint> constraints = config.getConstraints();
+			if (constraints != null && !constraints.isEmpty()) {
+				InversionInputGenerator inputGen = new InversionInputGenerator(rupSet, config);
+				inputGen.generateInputs(false);
+				double[] data_eq = inputGen.getD();
+				double[] misfits_eq = new double[data_eq.length];
+				SerialSimulatedAnnealing.calculateMisfit(inputGen.getA(), data_eq, rates, misfits_eq);
+				
+				double[] data_ineq = null;
+				double[] misfits_ineq = null;
+				if (inputGen.getA_ineq() != null) {
+					data_ineq = inputGen.getD_ineq();
+					misfits_ineq = new double[data_eq.length];
+					SerialSimulatedAnnealing.calculateMisfit(inputGen.getA_ineq(), data_ineq, rates, misfits_ineq);
+				}
+				
+				InversionMisfits misfits = new InversionMisfits(inputGen.getConstraintRowRanges(), misfits_eq, data_eq,
+						misfits_ineq, data_ineq);
+				sol.addModule(misfits);
+				sol.addModule(misfits.getMisfitStats());
+			}
+		}
+		
+		if (info != null)
+			sol.addModule(new InfoModule(info));
+		
+		return sol;
+	}
+	
+	private static boolean allMagsSame(FaultSystemRupSet rupSet, List<Integer> binRups) {
+		if (binRups.size() == 1)
+			return true;
+		Double mag = null;
+		for (int rupIndex : binRups) {
+			double myMag = rupSet.getMagForRup(rupIndex);
+			if (mag == null)
+				mag = myMag;
+			else if (mag != myMag)
+				return false;
+		}
+		return true;
+	}
+	
+	private static double calcGR(double bVal, double mag) {
+		return Math.pow(10, -bVal*mag);
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/ClassicModelInversionSolver.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/ClassicModelInversionSolver.java
@@ -1,0 +1,154 @@
+package org.opensha.sha.earthquake.rupForecastImpl.nshm23.util;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.cli.CommandLine;
+import org.opensha.commons.logicTree.LogicTreeBranch;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemRupSet;
+import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.ClusterSpecificInversionSolver;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfiguration;
+import org.opensha.sha.earthquake.faultSysSolution.inversion.InversionConfigurationFactory;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ClusterRuptures;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ConnectivityClusters;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InitialSolution;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitProgress;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfitStats;
+import org.opensha.sha.earthquake.faultSysSolution.modules.InversionMisfits;
+import org.opensha.sha.earthquake.faultSysSolution.modules.RuptureSubSetMappings;
+import org.opensha.sha.earthquake.faultSysSolution.modules.WaterLevelRates;
+import org.opensha.sha.earthquake.faultSysSolution.modules.ConnectivityClusters.ConnectivityClusterSolutionMisfits;
+import org.opensha.sha.earthquake.faultSysSolution.modules.SolutionLogicTree.SolutionProcessor;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.plausibility.impl.prob.RuptureProbabilityCalc.BinaryRuptureProbabilityCalc;
+import org.opensha.sha.earthquake.faultSysSolution.ruptures.util.ConnectivityCluster;
+import org.opensha.sha.earthquake.rupForecastImpl.nshm23.NSHM23_InvConfigFactory;
+import org.opensha.sha.earthquake.rupForecastImpl.nshm23.logicTree.SupraSeisBValues;
+
+/**
+ * 
+ * @author kevin
+ *
+ */
+public class ClassicModelInversionSolver extends ClusterSpecificInversionSolver {
+	
+	private AnalyticalSingleFaultInversionSolver analytical;
+	private BinaryRuptureProbabilityCalc rupProbCalc;
+	
+	public ClassicModelInversionSolver(FaultSystemRupSet rupSet, LogicTreeBranch<?> branch) {
+		analytical = new AnalyticalSingleFaultInversionSolver(branch.requireValue(SupraSeisBValues.class).bValue);
+		rupProbCalc = NSHM23_InvConfigFactory.getExclusionModel(rupSet, branch, rupSet.requireModule(ClusterRuptures.class));
+	}
+
+	@Override
+	protected BinaryRuptureProbabilityCalc getRuptureExclusionModel(FaultSystemRupSet rupSet,
+			LogicTreeBranch<?> branch) {
+		return rupProbCalc;
+	}
+
+	@Override
+	protected boolean shouldInvert(ConnectivityCluster cluster) {
+		// only run inversions when multiple parent sections are involved
+		return cluster.getParentSectIDs().size() > 1;
+	}
+
+	@Override
+	public FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfigurationFactory factory,
+			LogicTreeBranch<?> branch, int threads, CommandLine cmd) throws IOException {
+		// first do inversion-based solutions
+		FaultSystemSolution inversionSol = super.run(rupSet, factory, branch, threads, cmd);
+		if (inversionSol == null) {
+			// simplest case, all analytical
+			return analytical.run(rupSet, factory, branch, threads, cmd);
+		}
+		ConnectivityClusters clusters = rupSet.requireModule(ConnectivityClusters.class);
+		// now add in analytical
+		HashSet<Integer> analyticalSects = new HashSet<>();
+		for (ConnectivityCluster cluster : clusters)
+			if (!shouldInvert(cluster))
+				analyticalSects.addAll(cluster.getSectIDs());
+		System.out.println("Calculating analytical solution for "+analyticalSects.size()+"/"+rupSet.getNumSections()+" sections");
+		if (analyticalSects.isEmpty()) {
+			return inversionSol;
+		} else {
+			// build rupture set only with analytical sections
+			FaultSystemRupSet analyticalRupSet = rupSet.getForSectionSubSet(analyticalSects, rupProbCalc);
+			// inversion configuration for it (required for target MFDs, and then to calc misfits)
+			InversionConfiguration config = factory .buildInversionConfig(analyticalRupSet, branch, threads);
+			FaultSystemSolution analyticalSol = analytical.run(analyticalRupSet, config);
+			double[] analyticalRates = analyticalSol.getRateForAllRups();
+			
+			int origNumRups = rupSet.getNumRuptures();
+			
+			double[] allInitialRates = inversionSol.hasModule(InitialSolution.class) ?
+					Arrays.copyOf(inversionSol.getModule(InitialSolution.class).get(), origNumRups) : new double[origNumRups];
+			double[] allRates = Arrays.copyOf(inversionSol.getRateForAllRups(), origNumRups);
+			
+			RuptureSubSetMappings mappings = analyticalRupSet.requireModule(RuptureSubSetMappings.class);
+			for (int subsetRupIndex=0; subsetRupIndex<analyticalRupSet.getNumRuptures(); subsetRupIndex++) {
+				int origRupIndex = mappings.getOrigRupID(subsetRupIndex);
+				allRates[origRupIndex] = analyticalRates[subsetRupIndex];
+				allInitialRates[origRupIndex] = analyticalRates[subsetRupIndex];
+			}
+			
+			InversionMisfits inversionMisfits = inversionSol.requireModule(InversionMisfits.class);
+			InversionMisfits analyticalMisfits = analyticalSol.requireModule(InversionMisfits.class);
+			FaultSystemSolution combinedSol = new FaultSystemSolution(rupSet, allRates);
+			
+			if (analyticalSol.hasModule(WaterLevelRates.class) || inversionSol.hasModule(WaterLevelRates.class)) {
+				WaterLevelRates inversionWaterLevel = inversionSol.getModule(WaterLevelRates.class);
+				WaterLevelRates analyticalWaterLevel = analyticalSol.getModule(WaterLevelRates.class);
+				
+				if (analyticalWaterLevel == null) {
+					// simple case
+					combinedSol.addModule(inversionWaterLevel);
+				} else {
+					// need to map
+					double[] newWaterLevel = inversionWaterLevel == null ?
+							new double[origNumRups] : Arrays.copyOf(inversionWaterLevel.get(), origNumRups);
+					for (int subsetRupIndex=0; subsetRupIndex<analyticalRupSet.getNumRuptures(); subsetRupIndex++) {
+						int origRupIndex = mappings.getOrigRupID(subsetRupIndex);
+						newWaterLevel[origRupIndex] = analyticalWaterLevel.get(subsetRupIndex);
+					}
+					combinedSol.addModule(new WaterLevelRates(newWaterLevel));
+				}
+			}
+			combinedSol.addModule(new InitialSolution(allInitialRates));
+			InversionMisfits combMisfits = InversionMisfits.appendSeparate(List.of(inversionMisfits, analyticalMisfits));
+			combinedSol.addModule(combMisfits);
+			combinedSol.addModule(combMisfits.getMisfitStats());
+			if (inversionSol.hasModule(ConnectivityClusterSolutionMisfits.class)) {
+				ConnectivityClusterSolutionMisfits clusterMisfits = inversionSol.requireModule(ConnectivityClusterSolutionMisfits.class);
+				Map<ConnectivityCluster, InversionMisfitStats> clusterMisfitsMap = new HashMap<>();
+				InversionMisfitProgress largestProgress = clusterMisfits.getLargestClusterMisfitProgress();
+				for (int i=0; i<clusters.size(); i++) {
+					ConnectivityCluster cluster = clusters.get(i);
+					InversionMisfitStats misfits = clusterMisfits.getMisfitStats(i);
+					clusterMisfitsMap.put(cluster, misfits);
+				}
+				combinedSol.addModule(new ConnectivityClusterSolutionMisfits(combinedSol, clusterMisfitsMap, largestProgress));
+			}
+
+			// attach any relevant modules before writing out
+			SolutionProcessor processor = factory.getSolutionLogicTreeProcessor();
+
+			if (processor != null)
+				processor.processSolution(combinedSol, branch);
+			
+			return combinedSol;
+		}
+	}
+
+	@Override
+	public FaultSystemSolution run(FaultSystemRupSet rupSet, InversionConfiguration config, String info) {
+		// see if it's a single-fault rupture set
+		if (!NSHM23_InvConfigFactory.hasJumps(rupSet))
+			return analytical.run(rupSet, config, info);
+		return super.run(rupSet, config, info);
+	}
+	
+}


### PR DESCRIPTION
This pull request adds a new "classic" segmentation model to `NSHM23_SegmentationModels`. For the classic model, jumps are only allowed between sections that are part of the same "named fault" (as specified via the `NamedFaults` module). Multi fault clusters (on named faults) are solved via the inversion, but all other faults are now solved analytically.