### PR TITLE
Rupture building peformance improvements

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/path/PathPlausibilityFilter.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/path/PathPlausibilityFilter.java
@@ -170,6 +170,13 @@ public class PathPlausibilityFilter implements PlausibilityFilter {
 					result = result.logicalOr(subResult);
 				else
 					result = result.logicalAnd(subResult);
+
+				if (logicalOr && result.isPass() && !verbose) {
+					break;
+				}
+				if (!logicalOr && !result.canContinue() && !verbose){
+					break;
+				}
 			}
 			if (result.isPass())
 				numPasses++;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/CoulombSectRatioProb.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/plausibility/impl/prob/CoulombSectRatioProb.java
@@ -99,6 +99,9 @@ public class CoulombSectRatioProb implements RuptureProbabilityCalc {
 					System.out.println("Probability of adding "+receiver.getSectionId()+" with "
 							+currentSects.size()+" sources: "+track.sum+"/|"+track.getSumHighest()+"| = "+myProb);
 				prob *= myProb;
+				if (prob == 0 && !verbose) {
+					return 0;
+				}
 			}
 			
 			currentSects = nav.getCurrentSects();

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PlausibleClusterConnectionStrategy.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/strategies/PlausibleClusterConnectionStrategy.java
@@ -743,7 +743,9 @@ public class PlausibleClusterConnectionStrategy extends ClusterConnectionStrateg
 							PlausibilityResult result = PlausibilityResult.PASS;
 							boolean directional = false;
 							for (PlausibilityFilter filter : filters) {
-								result = result.logicalAnd(filter.apply(rupture, false));
+								if (result.canContinue()) {
+									result = result.logicalAnd(filter.apply(rupture, false));
+								}
 								directional = directional || filter.isDirectional(false);
 							}
 							if (debug)
@@ -761,8 +763,12 @@ public class PlausibleClusterConnectionStrategy extends ClusterConnectionStrateg
 								if (debug)
 									System.out.println("\tTrying reversed: "+rupture);
 								PlausibilityResult reverseResult = PlausibilityResult.PASS;
-								for (PlausibilityFilter filter : filters)
+								for (PlausibilityFilter filter : filters) {
 									reverseResult = reverseResult.logicalAnd(filter.apply(rupture, false));
+									if (!reverseResult.canContinue()) {
+										break;
+									}
+								}
 								if (debug)
 									System.out.println("\tResult: "+reverseResult);
 								if (scalarFilter != null && reverseResult.isPass()) {


### PR DESCRIPTION
Low-hanging-fruit performance improvements for rupture building. In my particular case, it reduced a 40 minute runtime to 33 minutes.

These changes are all about bailing out of loops when the result won't change anymore.