### PR TITLE
SectIDRange memory usage improvements

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRange.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRange.java
@@ -2,6 +2,9 @@ package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
 
 import com.google.common.base.Preconditions;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Range of section IDs, inclusive, for memory efficient tracking of unique ruptures and contains
  * operations
@@ -10,53 +13,70 @@ import com.google.common.base.Preconditions;
  *
  */
 public abstract class SectIDRange implements Comparable<SectIDRange> {
-	
+
+	private final static Map<SectIDRange, SectIDRange> cache = new HashMap<>();
+
 	public static SectIDRange build(int startID, int endID) {
-		if (startID == endID)
-			return new SingleID(endID);
-		if (endID < Short.MAX_VALUE)
+		SectIDRange range = construct(startID, endID);
+		SectIDRange cached = cache.putIfAbsent(range, range);
+		return cached == null ? range : cached;
+	}
+
+	private static SectIDRange construct(int startID, int endID) {
+		if (endID < Short.MAX_VALUE) {
+			if (startID == endID) {
+				return new ShortSingleID(endID);
+			}
 			return new ShortIDRange(startID, endID);
+		}
+		if (startID == endID) {
+			return new SingleID(endID);
+		}
 		return new IntIDRange(startID, endID);
 	}
-	
+
 	private static class ShortIDRange extends SectIDRange {
-		
-		private final short[] values;
-		
+
+		private final short startID;
+		private final short endID;
+
 		private ShortIDRange(int startID, int endID) {
 			super(startID, endID);
-			values = new short[] { (short)startID, (short)endID };
+			this.startID = (short) startID;
+			this.endID = (short) endID;
 		}
 
 		@Override
 		int getStartID() {
-			return values[0];
+			return startID;
 		}
 
 		@Override
 		int getEndID() {
-			return values[1];
+			return endID;
 		}
-		
+
 	}
-	
+
 	private static class IntIDRange extends SectIDRange {
 		
-		private final int[] values;
+		private final int startID;
+		private final int endID;
 		
 		private IntIDRange(int startID, int endID) {
 			super(startID, endID);
-			values = new int[] { startID, endID };
+			this.startID = startID;
+			this.endID = endID;
 		}
 
 		@Override
 		int getStartID() {
-			return values[0];
+			return startID;
 		}
 
 		@Override
 		int getEndID() {
-			return values[1];
+			return endID;
 		}
 		
 	}
@@ -67,6 +87,25 @@ public abstract class SectIDRange implements Comparable<SectIDRange> {
 		private SingleID(int id) {
 			super(id, id);
 			this.id = id;
+		}
+
+		@Override
+		int getStartID() {
+			return id;
+		}
+
+		@Override
+		int getEndID() {
+			return id;
+		}
+	}
+
+	private static class ShortSingleID extends SectIDRange {
+		private final short id;
+
+		private ShortSingleID(int id) {
+			super(id, id);
+			this.id = (short) id;
 		}
 
 		@Override

--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureUtilTestSuite.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/RuptureUtilTestSuite.java
@@ -5,11 +5,12 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-	UniqueRuptureTest.class,
+		UniqueRuptureTest.class,
+		SectIDRangeTest.class
 	})
 
 public class RuptureUtilTestSuite {
 	public static void main(String args[]) {
-		org.junit.runner.JUnitCore.runClasses(RuptureUtilTestSuite.class);
+		org.junit.runner.JUnitCore.runClasses(RuptureUtilTestSuite.class, SectIDRangeTest.class);
 	}
 }

--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRangeTest.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SectIDRangeTest.java
@@ -1,0 +1,91 @@
+package org.opensha.sha.earthquake.faultSysSolution.ruptures.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SectIDRangeTest {
+
+    @Test
+    public void testSingleShort() {
+        SectIDRange rangeA = SectIDRange.build(1, 1);
+
+        assertEquals(1, rangeA.getStartID());
+        assertEquals(1, rangeA.getEndID());
+        assertEquals(1, rangeA.size());
+
+        SectIDRange rangeB = SectIDRange.build(1, 1);
+
+        assertSame(rangeA, rangeB);
+        assertEquals(rangeA, rangeB);
+        assertEquals(rangeA.hashCode(), rangeB.hashCode());
+
+        rangeB = SectIDRange.build(2, 2);
+
+        assertEquals(1, rangeB.size());
+        assertNotSame(rangeA, rangeB);
+        assertNotEquals(rangeA, rangeB);
+    }
+
+    @Test
+    public void testSingleInt() {
+
+        SectIDRange rangeA = SectIDRange.build(Short.MAX_VALUE + 5, Short.MAX_VALUE + 5);
+
+        assertEquals(Short.MAX_VALUE + 5, rangeA.getStartID());
+        assertEquals(Short.MAX_VALUE + 5, rangeA.getEndID());
+        assertEquals(1, rangeA.size());
+
+        SectIDRange rangeB = SectIDRange.build(Short.MAX_VALUE + 5, Short.MAX_VALUE + 5);
+
+        assertSame(rangeA, rangeB);
+        assertEquals(rangeA, rangeB);
+        assertEquals(rangeA.hashCode(), rangeB.hashCode());
+
+        rangeB = SectIDRange.build(Short.MAX_VALUE + 6, Short.MAX_VALUE + 6);
+
+        assertNotSame(rangeA, rangeB);
+        assertNotEquals(rangeA, rangeB);
+    }
+
+    @Test
+    public void testRangeShort() {
+        SectIDRange rangeA = SectIDRange.build(1, 2);
+
+        assertEquals(1, rangeA.getStartID());
+        assertEquals(2, rangeA.getEndID());
+        assertEquals(2, rangeA.size());
+
+        SectIDRange rangeB = SectIDRange.build(1, 2);
+
+        assertSame(rangeA, rangeB);
+        assertEquals(rangeA, rangeB);
+        assertEquals(rangeA.hashCode(), rangeB.hashCode());
+
+        rangeB = SectIDRange.build(2, 3);
+
+        assertNotSame(rangeA, rangeB);
+        assertNotEquals(rangeA, rangeB);
+    }
+
+    @Test
+    public void testRangeInt() {
+
+        SectIDRange rangeA = SectIDRange.build(Short.MAX_VALUE + 5, Short.MAX_VALUE + 15);
+
+        assertEquals(Short.MAX_VALUE + 5, rangeA.getStartID());
+        assertEquals(Short.MAX_VALUE + 15, rangeA.getEndID());
+        assertEquals(11, rangeA.size());
+
+        SectIDRange rangeB = SectIDRange.build(Short.MAX_VALUE + 5, Short.MAX_VALUE + 15);
+
+        assertSame(rangeA, rangeB);
+        assertEquals(rangeA, rangeB);
+        assertEquals(rangeA.hashCode(), rangeB.hashCode());
+
+        rangeB = SectIDRange.build(Short.MAX_VALUE + 5, Short.MAX_VALUE + 16);
+
+        assertNotSame(rangeA, rangeB);
+        assertNotEquals(rangeA, rangeB);
+    }
+}


### PR DESCRIPTION
## Problem
The particular rupture set that I'm currently investigating has ca 860 fault sub sections and takes ca 40 minutes to build with a 50GB heap which is nearly all used up towards the end.

Looking at the memory usage at 33 minutes, the largest chunk by far is taken up by `SectIDRange` instances:
- 15GB by `short[]` which looks related to `ShortIDRange` since the number of objects is nearly identical (473,958,109 vs 473,958,103)
- 11GB by `SectIDRange:ShortIDRange` 
- 2.5GB by `SectIDRange:SingleID`

![Screenshot 2024-04-04 160926](https://github.com/opensha/opensha/assets/3160916/54d7c38b-7e82-49e3-b2e0-924978df37a1)

## Approach
Modifications to `SectIDRange`:
- replaced arrays with primitive instance variables
- added `ShortSingleID`
- 473,958,103 individual `ShortIDRange` instances are way too many for 860 sub sections, so I've added caching to ensure that we do not keep multiple identical ranges in memory. For this application, a simple hash map is sufficient.

## Result
The rupture build now finishes after 24 minutes. It must have been getting too close to the 50GB limit before, resulting in the usual Java slowdown. Here is a `VisualVM` screenshot at 20 minutes, showing that the three problem areas `SectIDRange:ShortIDRange`, `SectIDRange:SingleID`, and `short[]` are now no longer pertinent. `short[]` no longer features, the other two are at the bottom of this screenshot.

![Screenshot 2024-04-04 215910](https://github.com/opensha/opensha/assets/3160916/86802ee5-1a6e-40d9-bca7-1a259dedbbd7)
