### PR TITLE
Make cacheSs2R optional

### DIFF
--- a/src/main/java/org/opensha/sha/simulators/stiffness/AggregatedStiffnessCalculator.java
+++ b/src/main/java/org/opensha/sha/simulators/stiffness/AggregatedStiffnessCalculator.java
@@ -89,6 +89,7 @@ public class AggregatedStiffnessCalculator {
 		}
 		CACHE_ARRAY_SIZE = maxTerminalIndex+1;
 	}
+	private final boolean cacheSs2R;
 	
 	// multiplier to use for section IDs, to which patch IDs are added to get unique patch IDs
 	private transient int patch_sect_id_multiplier = -1;
@@ -539,6 +540,7 @@ public class AggregatedStiffnessCalculator {
 		private SubSectStiffnessCalculator calc;
 		private List<AggregationMethod> layers;
 		private boolean allowSectToSelf = false;
+		private boolean cacheSs2R = true;
 
 		private Builder(StiffnessType type, SubSectStiffnessCalculator calc) {
 			this.type = type;
@@ -554,6 +556,16 @@ public class AggregatedStiffnessCalculator {
 		 */
 		public Builder allowSectToSelf(boolean allowSectToSelf) {
 			this.allowSectToSelf = allowSectToSelf;
+			return this;
+		}
+
+		/**
+		 * Sets the cacheSs2R property.
+		 * @param cacheSs2R if true, caches section to section aggregations. True by default.
+		 * @return this builder
+		 */
+		public Builder cacheSs2R(boolean cacheSs2R) {
+			this.cacheSs2R = cacheSs2R;
 			return this;
 		}
 		
@@ -635,8 +647,21 @@ public class AggregatedStiffnessCalculator {
 		}
 		
 		public AggregatedStiffnessCalculator get() {
-			return new AggregatedStiffnessCalculator(type, calc, allowSectToSelf, this.layers.toArray(new AggregationMethod[0]));
+			return new AggregatedStiffnessCalculator(type, calc, allowSectToSelf, cacheSs2R, this.layers.toArray(new AggregationMethod[0]));
 		}
+	}
+
+	/**
+	 *
+	 * @param type stiffness type that we are calculating
+	 * @param calc stiffness calculator between two subsections
+	 * @param allowSectToSelf if true, calculations between the same source and receiver section will be included.
+	 * The calculation between the exact same source and receiver patch will always be excluded.
+	 * @param layers aggregations layers. Must supply at least 1, and the final layer must be a terminal layer.
+	 */
+	public AggregatedStiffnessCalculator(StiffnessType type, SubSectStiffnessCalculator calc, boolean allowSectToSelf,
+										  AggregationMethod... layers) {
+		this(type, calc, allowSectToSelf, true, layers);
 	}
 	
 	/**
@@ -645,11 +670,13 @@ public class AggregatedStiffnessCalculator {
 	 * @param calc stiffness calculator between two subsections
 	 * @param allowSectToSelf if true, calculations between the same source and receiver section will be included.
 		 * The calculation between the exact same source and receiver patch will always be excluded.
+	 * @param cacheSs2R whether to cache section to section values
 	 * @param layers aggregations layers. Must supply at least 1, and the final layer must be a terminal layer.
 	 */
 	public AggregatedStiffnessCalculator(StiffnessType type, SubSectStiffnessCalculator calc, boolean allowSectToSelf,
-			AggregationMethod... layers) {
+										 boolean cacheSs2R, AggregationMethod... layers) {
 		super();
+		this.cacheSs2R = cacheSs2R;
 		this.type = type;
 		this.calc = calc;
 		this.allowSectToSelf = allowSectToSelf;
@@ -962,18 +989,17 @@ public class AggregatedStiffnessCalculator {
 		return aggregated;
 	}
 
-	private static final boolean CACHE_SS2R = true;
 	// array by receiver index, to map of <sources, val>>
 	private transient List<ConcurrentMap<UniqueRupture, Double>> ss2rCache = null;
 	
 	public double calc(Collection<? extends FaultSection> sources, FaultSection receiver) {
-		return calc(sources, receiver, CACHE_SS2R ? UniqueRupture.forSects(sources) : null);
+		return calc(sources, receiver, cacheSs2R ? UniqueRupture.forSects(sources) : null);
 	}
 	
 	private double calc(Collection<? extends FaultSection> sources, FaultSection receiver, UniqueRupture sourcesUnique) {
 		Preconditions.checkState(layers.length > 2, "Sections-to-section aggregation layer not supplied");
 		
-		if (CACHE_SS2R) {
+		if (cacheSs2R) {
 			if (ss2rCache == null) {
 				synchronized (this) {
 					if (ss2rCache == null) {
@@ -1024,7 +1050,7 @@ public class AggregatedStiffnessCalculator {
 				return calc(sources, receivers.iterator().next());
 			double[] values = new double[receivers.size()];
 			int r = 0;
-			UniqueRupture sourcesUnique = CACHE_SS2R ? UniqueRupture.forSects(sources) : null;
+			UniqueRupture sourcesUnique = cacheSs2R ? UniqueRupture.forSects(sources) : null;
 			for (FaultSection receiver : receivers)
 				values[r++] = calc(sources, receiver, sourcesUnique);
 			return layers[3].calculate(values);

--- a/src/main/java/org/opensha/sha/simulators/stiffness/AggregatedStiffnessCalculator.java
+++ b/src/main/java/org/opensha/sha/simulators/stiffness/AggregatedStiffnessCalculator.java
@@ -962,7 +962,7 @@ public class AggregatedStiffnessCalculator {
 		return aggregated;
 	}
 
-	private static final boolean CACHE_SS2R = true;
+	private static final boolean CACHE_SS2R = false;
 	// array by receiver index, to map of <sources, val>>
 	private transient List<ConcurrentMap<UniqueRupture, Double>> ss2rCache = null;
 	


### PR DESCRIPTION
This PR changes the `AggregatedStiffnessCalculator.CACHE_SS2R` constant to an instance variable that can be configured in order to save heap space.

I'm experimenting with creating rupture sets that contain both crustal and subduction faults. We cannot create larger sets at the moment because our heap is flooded with `SectIDRange` arrays, 20GB in this screenshot:

![Screenshot 2024-04-06 205339](https://github.com/opensha/opensha/assets/3160916/be083bda-e530-46fa-8e21-f235e3c8dca0)

Note how the number of instance matches the number of `UniqueRupture` objects.

I found that setting `AggregatedStiffnessCalculator.CACHE_SS2R` to `false` will completely eliminate this problem with no impact on the running time. A further check showed that our builds actually never have a positive hit for this cache.