### PR TITLE
New SourceFilter interface and implementations

### DIFF
--- a/src/main/java/org/opensha/commons/gui/LabeledBorderPanel.java
+++ b/src/main/java/org/opensha/commons/gui/LabeledBorderPanel.java
@@ -126,7 +126,10 @@ public class LabeledBorderPanel extends JPanel{
 	 */
 	public void setTitle( String newTitle ) {
 		title = newTitle;
-		if( titledBorder1 != null ) titledBorder1.setTitle( title );
+		if( titledBorder1 != null ) {
+			titledBorder1.setTitle( title );
+			mainPanel.repaint();
+		}
 	}
 	
 	public void initParameterLookAndFeel() {

--- a/src/main/java/org/opensha/commons/param/editor/AbstractParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/AbstractParameterEditor.java
@@ -34,6 +34,8 @@ public abstract class AbstractParameterEditor<E> extends LabeledBorderPanel impl
 	protected final static Border CONST_BORDER = BorderFactory.createLineBorder( Color.blue, 1 );
 	protected final static Border FOCUS_BORDER = BorderFactory.createLineBorder( Color.orange, 1 );
 	protected final static Border ETCHED = BorderFactory.createEtchedBorder();
+	
+	private boolean showDisabledStatusInTitle = false;
 
 //	public static Font DEFAULT_LABEL_FONT = new Font( "SansSerif", Font.BOLD, 12 );
 //	public static Color FORE_COLOR = new Color( 80, 80, 140 );
@@ -116,6 +118,10 @@ public abstract class AbstractParameterEditor<E> extends LabeledBorderPanel impl
 	 * @return
 	 */
 	public abstract boolean isParameterSupported(Parameter<E> param);
+	
+	public void setShowDisabledStatusInTitle(boolean showDisabledStatusInTitle) {
+		this.showDisabledStatusInTitle = showDisabledStatusInTitle;
+	}
 
 	protected void updateTitle() {
 		String label;
@@ -131,7 +137,13 @@ public abstract class AbstractParameterEditor<E> extends LabeledBorderPanel impl
 					label += " (" + units + ")";
 				label += ':';
 			}
+			if (showDisabledStatusInTitle && !isEnabled()) {
+				label = "(disabled) "+label;
+//				System.out.println("Updated label: "+label);
+			}
 		}
+//		System.out.println("Updated title: "+label+", showDisabledStatusInTitle="
+//				+showDisabledStatusInTitle+", isEnabled()="+isEnabled());
 		super.setTitle(label);
 	}
 
@@ -167,6 +179,9 @@ public abstract class AbstractParameterEditor<E> extends LabeledBorderPanel impl
 				this.add(widget);
 			}
 		}
+//		System.out.println("Refreshing "+param.getName());
+		if (showDisabledStatusInTitle)
+			updateTitle();
 		widget.validate();
 		this.validate();
 		super.setToolTipText(getLabelToolTipText());

--- a/src/main/java/org/opensha/commons/param/editor/AbstractParameterEditorConverter.java
+++ b/src/main/java/org/opensha/commons/param/editor/AbstractParameterEditorConverter.java
@@ -125,6 +125,11 @@ public abstract class AbstractParameterEditorConverter<E, F> implements
 	public void setEnabled(boolean isEnabled) {
 		editor.setEnabled(isEnabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return editor.isEnabled();
+	}
 
 	@Override
 	public void setVisible(boolean isVisible) {

--- a/src/main/java/org/opensha/commons/param/editor/ParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/ParameterEditor.java
@@ -60,7 +60,18 @@ public interface ParameterEditor<E> {
     /** Returns the focusEnabled boolean indicating this is the GUI componet with the current focus */
     public boolean isFocusEnabled();
     
+    /**
+     * Set if the parameter is enabled or not (i.e., accepts user input and edits)
+     * 
+     * @param isEnabled
+     */
     public void setEnabled(boolean isEnabled);
+    
+    /**
+     * 
+     * @return if the parameter is enabled  (i.e., accepts user input and edits)
+     */
+    public boolean isEnabled();
     
     public void setVisible(boolean isVisible);
     

--- a/src/main/java/org/opensha/commons/param/editor/document/NumericPlainDocument.java
+++ b/src/main/java/org/opensha/commons/param/editor/document/NumericPlainDocument.java
@@ -196,14 +196,10 @@ public class NumericPlainDocument extends PlainDocument
      * Helper function that converts the String
      * representation model data into an Long.
      */
-    public Long getLongValue() throws ParseException {
+    public long getLongValue() throws ParseException {
 
         Number result = getNumberValue();
-        if (result instanceof Long == false) {
-            String S = "NumericPlainDocument: getLongValue(): ";
-            throw new ParseException( S + "Not a valid Long: " + result, 0);
-        }
-        return (Long) result;
+        return result.longValue();
 
     }
 
@@ -211,14 +207,10 @@ public class NumericPlainDocument extends PlainDocument
      * Helper function that converts the String representation model data into
      * an Double, i.e. what the model represents
      */
-    public Double getDoubleValue() throws ParseException {
+    public double getDoubleValue() throws ParseException {
 
         Number result = getNumberValue();
-        if (result instanceof Double == false) {
-            String S = "NumericPlainDocument: getDoubleValue(): ";
-            throw new ParseException(S + "Not a valid Double: " + result, 0);
-        }
-        return (Double) result;
+        return result.doubleValue();
     }
 
 

--- a/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncParameterEditor.java
@@ -99,7 +99,6 @@ implements ActionListener, DocumentListener, TableModelListener
 		// TODO: fix this
 		//		this.xValsTextArea.setEnabled(isEnabled);
 		//		this.yValsTextArea.setEnabled(isEnabled);
-
 		this.table.setEnabled(isEnabled);
 		this.tableModel.setEnabled(isEnabled);
 		xField.setEnabled(isEnabled);
@@ -108,6 +107,11 @@ implements ActionListener, DocumentListener, TableModelListener
 		this.removeButton.setEnabled(isEnabled);
 
 		//		super.setEnabled(isEnabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return table != null && this.table.isEnabled();
 	}
 
 	public void actionPerformed(ActionEvent e) {

--- a/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncParameterEditor.java
@@ -102,6 +102,8 @@ implements ActionListener, DocumentListener, TableModelListener
 
 		this.table.setEnabled(isEnabled);
 		this.tableModel.setEnabled(isEnabled);
+		xField.setEnabled(isEnabled);
+		yField.setEnabled(isEnabled);
 		this.addButton.setEnabled(isEnabled);
 		this.removeButton.setEnabled(isEnabled);
 

--- a/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncTableModel.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ArbitrarilyDiscretizedFuncTableModel.java
@@ -5,6 +5,7 @@ import java.awt.Dimension;
 import java.text.DecimalFormat;
 
 import javax.swing.JLabel;
+import javax.swing.UIManager;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 
@@ -24,7 +25,8 @@ public class ArbitrarilyDiscretizedFuncTableModel extends AbstractTableModel {
 	
 	public static DecimalFormat format;
 	
-	public final static Color disabledColor = new Color(210, 210, 210);
+	public Color disabledBackgroundColor;
+	public Color enabledBackgroundColor;
 	
 	ArbitrarilyDiscretizedFuncTableCellRenderer renderer = null;
 	
@@ -37,6 +39,18 @@ public class ArbitrarilyDiscretizedFuncTableModel extends AbstractTableModel {
 //		System.out.println("Func: " + func);
 		this.func = func;
 //		this.fireTableDataChanged();
+		
+		Color defaultBackground = UIManager.getColor ( "Panel.background" );
+		double avgColor = (defaultBackground.getRed() + defaultBackground.getGreen() + defaultBackground.getBlue())/3d;
+		if (avgColor > 127d) {
+			// light theme
+			enabledBackgroundColor = Color.WHITE;
+			disabledBackgroundColor = new Color(210, 210, 210);
+		} else {
+			// dark theme
+			enabledBackgroundColor = defaultBackground;
+			disabledBackgroundColor = new Color(80, 80, 80);
+		}
 	}
 	
 	public void updateData(ArbitrarilyDiscretizedFunc newFunc) {
@@ -214,10 +228,11 @@ public class ArbitrarilyDiscretizedFuncTableModel extends AbstractTableModel {
 	
 	public void setEnabled(boolean isEnabled) {
 		ArbitrarilyDiscretizedFuncTableCellRenderer renderer = getRenderer();
+		
 		if (isEnabled)
-			renderer.setBackground(Color.WHITE);
+			renderer.setBackground(enabledBackgroundColor);
 		else
-			renderer.setBackground(disabledColor);
+			renderer.setBackground(disabledBackgroundColor);
 	}
 
 	/**

--- a/src/main/java/org/opensha/commons/param/editor/impl/BooleanParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/BooleanParameterEditor.java
@@ -62,7 +62,13 @@ ItemListener{
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEnabled(enabled);
+		if (widget != null)
+			widget.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/ButtonParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ButtonParameterEditor.java
@@ -30,7 +30,13 @@ public class ButtonParameterEditor extends AbstractParameterEditor<Integer> impl
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		button.setEnabled(enabled);
+		if (button != null)
+			button.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return button != null && button.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedCPTParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedCPTParameterEditor.java
@@ -53,7 +53,13 @@ public class ConstrainedCPTParameterEditor extends AbstractParameterEditor<CPT> 
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		combo.setEnabled(enabled);
+		if (combo != null)
+			combo.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return combo != null && combo.isEnabled();
 	}
 	
 	private ListBasedConstraint<CPT> getListConst() {

--- a/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedDoubleDiscreteParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedDoubleDiscreteParameterEditor.java
@@ -113,6 +113,11 @@ implements ItemListener
 		if (widget != null)
 			widget.setEnabled(enabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
+	}
 
 	@Override
 	protected JComponent buildWidget() {

--- a/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedIntegerDiscreteParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedIntegerDiscreteParameterEditor.java
@@ -110,8 +110,13 @@ implements ItemListener
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		// TODO Auto-generated method stub
-
+		if (widget != null)
+			this.widget.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedStringParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ConstrainedStringParameterEditor.java
@@ -112,7 +112,13 @@ implements ItemListener
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEnabled(enabled);
+		if (widget != null)
+			widget.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/DoubleParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/DoubleParameterEditor.java
@@ -236,7 +236,15 @@ public class DoubleParameterEditor extends AbstractParameterEditor<Double> imple
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEditable(enabled);
+		if (widget != null) {
+			widget.setEditable(enabled);
+			widget.setEnabled(enabled);
+		}
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/EnumParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/EnumParameterEditor.java
@@ -63,8 +63,14 @@ public class EnumParameterEditor<E extends Enum<E>> extends
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEnabled(enabled);
+		if (widget != null)
+			widget.setEnabled(enabled);
 //		widget.repaint();
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/FileParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/FileParameterEditor.java
@@ -31,7 +31,13 @@ public class FileParameterEditor extends AbstractParameterEditor<File> implement
 	
 	@Override
 	public void setEnabled(boolean isEnabled) {
-		browseButton.setEnabled(isEnabled);
+		if (browseButton != null)
+			browseButton.setEnabled(isEnabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return browseButton != null && browseButton.isEnabled();
 	}
 
 	private JButton getBrowseButton() {

--- a/src/main/java/org/opensha/commons/param/editor/impl/IntegerParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/IntegerParameterEditor.java
@@ -171,6 +171,11 @@ public class IntegerParameterEditor extends AbstractParameterEditor<Integer> imp
 		if (widget != null)
 			widget.setEnabled(enabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
+	}
 
 	@Override
 	protected JComponent buildWidget() {

--- a/src/main/java/org/opensha/commons/param/editor/impl/LongParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/LongParameterEditor.java
@@ -35,7 +35,13 @@ public class LongParameterEditor extends AbstractParameterEditor<Long> implement
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEnabled(enabled);
+		if (widget != null)
+			widget.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 	
 	/**

--- a/src/main/java/org/opensha/commons/param/editor/impl/ParameterListParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/ParameterListParameterEditor.java
@@ -91,6 +91,11 @@ ActionListener,ParameterChangeListener{
 		if (useButton)
 			this.button.setEnabled(isEnabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return editor != null && editor.isEnabled();
+	}
 
 
 //	/**

--- a/src/main/java/org/opensha/commons/param/editor/impl/RangeParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/RangeParameterEditor.java
@@ -39,6 +39,11 @@ public class RangeParameterEditor extends AbstractParameterEditor<Range> impleme
 		lowerField.setEnabled(enabled);
 		upperField.setEnabled(enabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return lowerField != null && lowerField.isEnabled();
+	}
 
 	@Override
 	protected JComponent buildWidget() {

--- a/src/main/java/org/opensha/commons/param/editor/impl/StringParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/StringParameterEditor.java
@@ -176,7 +176,13 @@ extends AbstractParameterEditor<String> implements FocusListener, KeyListener
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		widget.setEnabled(enabled);
+		if (widget != null)
+			widget.setEnabled(enabled);
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return widget != null && widget.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/param/editor/impl/WeightedListParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/WeightedListParameterEditor.java
@@ -47,6 +47,11 @@ public class WeightedListParameterEditor extends AbstractParameterEditor<Weighte
 		gui.setEnabled(isEnabled);
 	}
 	
+	@Override
+	public boolean isEnabled() {
+		return gui != null && gui.isEnabled();
+	}
+	
 	public static void main(String[] args) {
 		ArrayList<String> objects = new ArrayList<String>();
 		ArrayList<Double> weights = new ArrayList<Double>();

--- a/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -145,6 +145,10 @@ public class HazardCurveCalculator implements HazardCurveCalculatorAPI, Paramete
 
 	}
 	
+	public SourceFilterManager getSourceFilterManager() {
+		return sourceFilters;
+	}
+	
 	public List<SourceFilter> getSourceFilters() {
 		return sourceFilters.getEnabledFilters();
 	}

--- a/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -15,8 +15,11 @@ import org.opensha.commons.data.function.LightFixedXFunc;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.param.Parameter;
 import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
 import org.opensha.commons.param.event.ParameterChangeWarningEvent;
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
+import org.opensha.commons.param.impl.BooleanParameter;
 import org.opensha.commons.util.ExceptionUtils;
 import org.opensha.sha.calc.params.IncludeMagDistFilterParam;
 import org.opensha.sha.calc.params.MagDistCutoffParam;
@@ -26,6 +29,15 @@ import org.opensha.sha.calc.params.NonSupportedTRT_OptionsParam;
 import org.opensha.sha.calc.params.NumStochasticEventSetsParam;
 import org.opensha.sha.calc.params.PtSrcDistanceCorrectionParam;
 import org.opensha.sha.calc.params.SetTRTinIMR_FromSourceParam;
+import org.opensha.sha.calc.params.filters.FixedDistanceCutoffFilter;
+import org.opensha.sha.calc.params.filters.MagDependentDistCutoffFilter;
+import org.opensha.sha.calc.params.filters.MinMagFilter;
+import org.opensha.sha.calc.params.filters.SourceFilter;
+import org.opensha.sha.calc.params.filters.SourceFilterManager;
+import org.opensha.sha.calc.params.filters.SourceFilters;
+import org.opensha.sha.calc.params.filters.SourceFiltersParam;
+import org.opensha.sha.calc.params.filters.TectonicRegionDistCutoffFilter;
+import org.opensha.sha.calc.params.filters.TectonicRegionDistCutoffFilter.TectonicRegionDistanceCutoffs;
 import org.opensha.sha.earthquake.AbstractERF;
 import org.opensha.sha.earthquake.ERF;
 import org.opensha.sha.earthquake.EqkRupture;
@@ -55,8 +67,7 @@ import com.google.common.base.Preconditions;
  * @version 1.0
  */
 
-public class HazardCurveCalculator
-implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
+public class HazardCurveCalculator implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 	/**
 	 * 
@@ -65,18 +76,21 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	protected final static String C = "HazardCurveCalculator";
 	protected final static boolean D = false;
 
-	//Info for parameter that sets the maximum distance considered
-	private MaxDistanceParam maxDistanceParam;
-
-	//Info for parameter that sets the maximum distance considered
-	private MinMagnitudeParam minMagnitudeParam;
-
-	//Info for parameter tells whether to apply a magnitude-dependent distance cutoff
-	private IncludeMagDistFilterParam includeMagDistFilterParam;
+	/*
+	 * Source filters
+	 */
 	
-	//Info for parameter that specifies a magnitude-dependent distance cutoff
-	// (distance on x-axis and mag on y-axis)
-	private MagDistCutoffParam magDistCutoffParam;
+	private SourceFilterManager sourceFilters;
+	private SourceFiltersParam sourceFilterParam;
+	
+	private FixedDistanceCutoffFilter fixedDistanceFilter;
+	private MagDependentDistCutoffFilter magDependentFilter;
+	private TectonicRegionDistCutoffFilter trtDependentFilter;
+	private MinMagFilter minMagFilter;
+	
+	/*
+	 * Other params
+	 */
 	
 	//Info for parameter that sets the maximum distance considered
 	private NumStochasticEventSetsParam numStochEventSetRealizationsParam;
@@ -89,7 +103,6 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	
 	// This tell what type of point-source distance correction to apply
 	private PtSrcDistanceCorrectionParam ptSrcDistCorrParam;
-	
 
 	private ParameterList adjustableParams;
 
@@ -106,16 +119,13 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	public HazardCurveCalculator() {
 
 		// Create adjustable parameters and add to list
-
-		// Max Distance Parameter
-		maxDistanceParam = new MaxDistanceParam();
-
-		// Include Mag-Distance Filter Parameter
-		includeMagDistFilterParam = new IncludeMagDistFilterParam();
-
-		magDistCutoffParam = new MagDistCutoffParam();
+		sourceFilterParam = new SourceFiltersParam();
+		sourceFilters = sourceFilterParam.getValue();
 		
-		minMagnitudeParam = new MinMagnitudeParam();
+		fixedDistanceFilter = (FixedDistanceCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.FIXED_DIST_CUTOFF);
+		magDependentFilter = (MagDependentDistCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.MAG_DIST_CUTOFFS);
+		trtDependentFilter = (TectonicRegionDistCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.TRT_DIST_CUTOFFS);
+		minMagFilter = (MinMagFilter) sourceFilters.getFilterInstance(SourceFilters.MIN_MAG);
 
 		// Max Distance Parameter
 		numStochEventSetRealizationsParam = new NumStochasticEventSetsParam();
@@ -127,17 +137,17 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		ptSrcDistCorrParam = new PtSrcDistanceCorrectionParam();
 
 		adjustableParams = new ParameterList();
-		adjustableParams.addParameter(maxDistanceParam);
-		adjustableParams.addParameter(minMagnitudeParam);
+		adjustableParams.addParameter(sourceFilterParam);
 		adjustableParams.addParameter(numStochEventSetRealizationsParam);
-		adjustableParams.addParameter(includeMagDistFilterParam);
-		adjustableParams.addParameter(magDistCutoffParam);
 		adjustableParams.addParameter(setTRTinIMR_FromSourceParam);
 		adjustableParams.addParameter(nonSupportedTRT_OptionsParam);
 		adjustableParams.addParameter(ptSrcDistCorrParam);
 
 	}
 	
+	public List<SourceFilter> getSourceFilters() {
+		return sourceFilters.getEnabledFilters();
+	}
 	
 //	@Override
 	public void setPtSrcDistCorrType(PtSrcDistCorr.Type type) {
@@ -152,8 +162,11 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 
 	@Override
-	public void setMaxSourceDistance(double distance){
-		maxDistanceParam.setValue(distance);
+	public void setMaxSourceDistance(double distance) {
+		sourceFilters.setEnabled(SourceFilters.FIXED_DIST_CUTOFF, true);
+		fixedDistanceFilter.setMaxDistance(distance);
+		if (sourceFilterParam.isEditorBuilt())
+			sourceFilterParam.getEditor().refreshParamEditor();
 	}
 	
 	/**
@@ -164,10 +177,11 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	 */
 	@Override
 	public void setMinMagnitude(double magnitude) {
-		minMagnitudeParam.setValue(magnitude);
+		sourceFilters.setEnabled(SourceFilters.MIN_MAG, true);
+		minMagFilter.setMinMagnitude(magnitude);
+		if (sourceFilterParam.isEditorBuilt())
+			sourceFilterParam.getEditor().refreshParamEditor();
 	}
-
-
 
 	@Override
 	public void setNumStochEventSetRealizations(int numRealizations) {
@@ -176,28 +190,36 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 	@Override
 	public double getMaxSourceDistance() { 
-		return maxDistanceParam.getValue().doubleValue(); 
+		double maxDist = Double.POSITIVE_INFINITY;
+		if (sourceFilters.isEnabled(SourceFilters.FIXED_DIST_CUTOFF))
+			maxDist = fixedDistanceFilter.getMaxDistance();
+		if (sourceFilters.isEnabled(SourceFilters.MAG_DIST_CUTOFFS))
+			maxDist = Math.min(maxDist, magDependentFilter.getMagDistFunc().getMaxX());
+		if (sourceFilters.isEnabled(SourceFilters.TRT_DIST_CUTOFFS))
+			maxDist = Math.min(maxDist, trtDependentFilter.getCutoffs().getLargestCutoffDist());
+		return maxDist;
 	}
 
 	@Override
 	public void setMagDistCutoffFunc(ArbitrarilyDiscretizedFunc magDistfunc) {
-		includeMagDistFilterParam.setValue(true);
-		magDistCutoffParam.setValue(magDistfunc);
+		sourceFilters.setEnabled(SourceFilters.MAG_DIST_CUTOFFS, true);
+		magDependentFilter.setMagDistFunc(magDistfunc);
+		if (sourceFilterParam.isEditorBuilt())
+			sourceFilterParam.getEditor().refreshParamEditor();
 	}
 
 	@Override
 	public void setIncludeMagDistCutoff(boolean include) {
-		this.includeMagDistFilterParam.setValue(include);
+		sourceFilters.setEnabled(SourceFilters.MAG_DIST_CUTOFFS, include);
 	}
 
 	@Override
 	public ArbitrarilyDiscretizedFunc getMagDistCutoffFunc() {
-		if(includeMagDistFilterParam.getValue())
-			return magDistCutoffParam.getValue();
+		if (sourceFilters.isEnabled(SourceFilters.MAG_DIST_CUTOFFS))
+			return magDependentFilter.getMagDistFunc();
 		else
 			return null;
 	}
-
 
 	@Override
 	public DiscretizedFunc getAnnualizedRates(DiscretizedFunc hazFunction, double years) {
@@ -208,9 +230,6 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		}
 		return annualizedRateFunc;
 	}
-
-
-
 
 	@Override
 	public DiscretizedFunc getHazardCurve(DiscretizedFunc hazFunction,
@@ -229,8 +248,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		//	  System.out.println("Haz Curv Calc: maxDistanceParam.getValue()="+maxDistanceParam.getValue().toString());
 		//	  System.out.println("Haz Curv Calc: numStochEventSetRealizationsParam.getValue()="+numStochEventSetRealizationsParam.getValue().toString());
 		//	  System.out.println("Haz Curv Calc: includeMagDistFilterParam.getValue()="+includeMagDistFilterParam.getValue().toString());
-		if(includeMagDistFilterParam.getValue() && D)
-			System.out.println("Haz Curv Calc: magDistCutoffParam.getValue()="+magDistCutoffParam.getValue().toString());
+//		if(includeMagDistFilterParam.getValue() && D)
+//			System.out.println("Haz Curv Calc: magDistCutoffParam.getValue()="+magDistCutoffParam.getValue().toString());
 		
 		boolean setTRTinIMR_FromSource = setTRTinIMR_FromSourceParam.getValue();
 		HashMap<ScalarIMR, TectonicRegionType> trtOrigVals = null;
@@ -262,10 +281,9 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		// get the number of points
 		int numPoints = hazFunction.size();
 
-		// define distance filtering stuff
-		double maxDistance = maxDistanceParam.getValue();
-		boolean includeMagDistFilter = includeMagDistFilterParam.getValue();
-		double magThresh=0.0;
+		// define source/rup filtering stuff
+		double maxDistance = getMaxSourceDistance();
+		List<SourceFilter> filters = getSourceFilters();
 
 		// initialize IMRs w/ max distance, site, and reset parameter listeners 
 		// (the latter allows server versions to listen to parameter changes)
@@ -319,19 +337,10 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 				TRTUtils.setTRTinIMR(imr, trt, nonSupportedTRT_OptionsParam, trtOrigVals.get(imr));
 			}
 
-			// compute the source's distance from the site and skip if it's too far away
-			distance = source.getMinDistance(site);
-
-			// apply distance cutoff to source
-			if(distance > maxDistance) {
+			// apply any filters
+			if (canSkipSource(filters, source, site)) {
 				currRuptures += source.getNumRuptures();  //update progress bar for skipped ruptures
 				continue;
-			}
-			//System.out.println(" dist: " + distance);
-
-			// get magThreshold if we're to use the mag-dist cutoff filter
-			if(includeMagDistFilter) {
-				magThresh = magDistCutoffParam.getValue().getInterpolatedY(distance);
 			}
 
 			// determine whether it's poissonian (calcs depend on this)
@@ -356,15 +365,9 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 					if (qkProb == 0d)
 						continue;
 					
-					// skip small magnitudes
-					if(rupture.getMag() < minMagnitudeParam.getValue()) {
-						numRupRejected += 1;
-						continue;
-					}
-
-					// apply magThreshold if we're to use the mag-dist cutoff filter
-					if(includeMagDistFilter && rupture.getMag() < magThresh) {
-						numRupRejected += 1;
+					// apply any filters
+					if (canSkipRupture(filters, rupture, site)) {
+						numRupRejected ++;
 						continue;
 					}
 					
@@ -372,7 +375,7 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 					if(rupture.getRuptureSurface() instanceof PointSurface)
 						((PointSurface)rupture.getRuptureSurface()).setDistCorrMagAndType(rupture.getMag(), distCorrType);
 					
-					// indicate that a source has been used (put here because of above filter)
+					// indicate that a source has been used (put here because of above filters)
 					sourceUsed = true;
 
 					// set the EqkRup in the IMR
@@ -446,6 +449,31 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 		return hazFunction;
 	}
+	
+	private static boolean canSkipSource(List<SourceFilter> filters, ProbEqkSource source, Site site) {
+		if (filters == null || filters.isEmpty())
+			return false;
+		if (!filters.isEmpty()) {
+			// source-site distance
+			double distance = source.getMinDistance(site);
+			
+			for (SourceFilter filter : filters)
+				if (filter.canSkipSource(source, site, distance))
+					return true;
+		}
+		return false;
+	}
+	
+	private static boolean canSkipRupture(List<SourceFilter> filters, EqkRupture rupture, Site site) {
+		if (filters == null || filters.isEmpty())
+			return false;
+		if (!filters.isEmpty()) {
+			for (SourceFilter filter : filters)
+				if (filter.canSkipRupture(rupture, site))
+					return true;
+		}
+		return false;
+	}
 
 	@Override
 	public DiscretizedFunc getAverageEventSetHazardCurve(DiscretizedFunc hazFunction,
@@ -468,7 +496,7 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		//	  totRuptures=numEventSets;
 
 		for(int i=0;i<numEventSets;i++) {
-			List<EqkRupture> events = eqkRupForecast.drawRandomEventSet();
+			List<EqkRupture> events = eqkRupForecast.drawRandomEventSet(site, getSourceFilters());
 			if(i==0) totRuptures = events.size()*numEventSets; // this is an approximate total number of events
 			currRuptures+=events.size();
 			getEventSetHazardCurve( hazCurve,site, imr, events, false);
@@ -500,7 +528,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		int numPoints = hazFunction.size();
 
 		// define distance filtering stuff
-		double maxDistance = maxDistanceParam.getValue();
+		double maxDistance = getMaxSourceDistance();
+		List<SourceFilter> filters = getSourceFilters();
 
 		// set the maximum distance in the attenuation relationship
 		imr.setUserMaxDistance(maxDistance);
@@ -532,24 +561,13 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 			EqkRupture rupture = eqkRupList.get(n);
 			
-			// skip small magnitudes
-			if(rupture.getMag() < minMagnitudeParam.getValue())
+			// apply any filters
+			if (canSkipRupture(filters, rupture, site))
 				continue;
 			
 			// set point-source distance correction type (& mag) if it's a pointSurface
 			if(rupture.getRuptureSurface() instanceof PointSurface)
 				((PointSurface)rupture.getRuptureSurface()).setDistCorrMagAndType(rupture.getMag(), distCorrType);
-
-
-			/*
-    		// apply mag-dist cutoff filter
-    		if(includeMagDistFilter) {
-    			//distance=??; // NEED TO COMPUTE THIS DISTANCE
-     			if(rupture.getMag() < magDistCutoffParam.getValue().getInterpolatedY(distance) {
-    			numRupRejected += 1;
-    			continue;
-    		}
-			 */
 
 			// set the EqkRup in the IMR
 			imr.setEqkRupture(rupture);
@@ -607,7 +625,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		int numPoints = hazFunction.size();
 
 		// define distance filtering stuff
-		double maxDistance = maxDistanceParam.getValue();
+		double maxDistance = getMaxSourceDistance();
+		List<SourceFilter> filters = getSourceFilters();
 
 		// set the maximum distance in the attenuation relationship
 		imr.setUserMaxDistance(maxDistance);
@@ -639,8 +658,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 			EqkRupture rupture = eqkRupList.get(n);
 			
-			// skip small magnitudes
-			if(rupture.getMag() < minMagnitudeParam.getValue())
+			// apply any filters
+			if (canSkipRupture(filters, rupture, site))
 				continue;
 			
 			// set point-source distance correction type (& mag) if it's a pointSurface
@@ -706,7 +725,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		int numPoints = hazFunction.size();
 
 		// define distance filtering stuff
-		double maxDistance = maxDistanceParam.getValue();
+		double maxDistance = getMaxSourceDistance();
+		List<SourceFilter> filters = getSourceFilters();
 
 		// set the maximum distance in the attenuation relationship
 		imr.setUserMaxDistance(maxDistance);
@@ -736,8 +756,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 			EqkRupture rupture = eqkRupList.get(n);
 			
-			// skip small magnitudes
-			if(rupture.getMag() < minMagnitudeParam.getValue())
+			// apply any filters
+			if (canSkipRupture(filters, rupture, site))
 				continue;
 			
 			// set point-source distance correction type (& mag) if it's a pointSurface
@@ -793,7 +813,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 		((AttenuationRelationship)imr).resetParameterEventListeners();
 
 		// define distance filtering stuff
-		double maxDistance = maxDistanceParam.getValue();
+		double maxDistance = getMaxSourceDistance();
+		List<SourceFilter> filters = getSourceFilters();
 
 		// set the maximum distance in the attenuation relationship
 		imr.setUserMaxDistance(maxDistance);
@@ -821,8 +842,8 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 
 			EqkRupture rupture = eqkRupList.get(n);
 			
-			// skip small magnitudes
-			if(rupture.getMag() < minMagnitudeParam.getValue())
+			// apply any filters
+			if (canSkipRupture(filters, rupture, site))
 				continue;
 			
 			// set point-source distance correction type (& mag) if it's a pointSurface
@@ -867,13 +888,13 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 //		System.out.println("Haz Curv Calc: includeMagDistFilterParam.getValue()="+includeMagDistFilterParam.getValue().toString());
 //		if(includeMagDistFilterParam.getValue())
 //			System.out.println("Haz Curv Calc: magDistCutoffParam.getValue()="+magDistCutoffParam.getValue().toString());
+		
+		List<SourceFilter> filters = getSourceFilters();
 
-		// skip small magnitudes
-		if(rupture.getMag() < minMagnitudeParam.getValue()) {
-			hazFunction.scale(0.0);;
+		if (canSkipRupture(filters, rupture, site)) {
+			hazFunction.scale(0.0);
 			return hazFunction;
 		}
-
 
 		// resetting the Parameter change Listeners on the AttenuationRelationship parameters,
 		// allowing the Server version of our application to listen to the parameter changes.
@@ -936,13 +957,15 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	@Override
 	public void setAdjustableParams(ParameterList paramList) {
 		this.adjustableParams = paramList;
-		this.maxDistanceParam = (MaxDistanceParam)paramList.getParameter(MaxDistanceParam.NAME);
-		this.minMagnitudeParam = (MinMagnitudeParam)paramList.getParameter(MinMagnitudeParam.NAME);
+		this.sourceFilterParam = (SourceFiltersParam)paramList.getParameter(SourceFiltersParam.NAME);
+		sourceFilters = sourceFilterParam.getValue();
+		
+		fixedDistanceFilter = (FixedDistanceCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.FIXED_DIST_CUTOFF);
+		magDependentFilter = (MagDependentDistCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.MAG_DIST_CUTOFFS);
+		trtDependentFilter = (TectonicRegionDistCutoffFilter) sourceFilters.getFilterInstance(SourceFilters.TRT_DIST_CUTOFFS);
+		minMagFilter = (MinMagFilter) sourceFilters.getFilterInstance(SourceFilters.MIN_MAG);
 		this.numStochEventSetRealizationsParam =
 			(NumStochasticEventSetsParam)paramList.getParameter(NumStochasticEventSetsParam.NAME);
-		this.includeMagDistFilterParam =
-			(IncludeMagDistFilterParam)paramList.getParameter(IncludeMagDistFilterParam.NAME);
-		this.magDistCutoffParam = (MagDistCutoffParam)paramList.getParameter(MagDistCutoffParam.NAME);
 		this.setTRTinIMR_FromSourceParam =
 			(SetTRTinIMR_FromSourceParam)paramList.getParameter(SetTRTinIMR_FromSourceParam.NAME);
 		this.nonSupportedTRT_OptionsParam =
@@ -960,9 +983,9 @@ implements HazardCurveCalculatorAPI, ParameterChangeWarningListener{
 	 */
 	public void testEventSetHazardCurve(int numIterations) {
 		// set distance filter large since these are handled slightly differently in each calc
-		maxDistanceParam.setValue(300);
+//		maxDistanceParam.setValue(300);
+		setMaxSourceDistance(300d);
 		// do not apply mag-dist fileter
-		includeMagDistFilterParam.setValue(false);
 		numStochEventSetRealizationsParam.setValue(numIterations);
 
 		ScalarIMR imr = new BJF_1997_AttenRel(this); 

--- a/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
+++ b/src/main/java/org/opensha/sha/calc/HazardCurveCalculator.java
@@ -279,7 +279,7 @@ public class HazardCurveCalculator implements HazardCurveCalculatorAPI, Paramete
 		DiscretizedFunc sourceHazFunc = new LightFixedXFunc(hazFunction);
 
 		// declare some varibles used in the calculation
-		double qkProb, distance;
+		double qkProb;
 		int k;
 
 		// get the number of points

--- a/src/main/java/org/opensha/sha/calc/params/filters/FixedDistanceCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/FixedDistanceCutoffFilter.java
@@ -1,0 +1,63 @@
+ package org.opensha.sha.calc.params.filters;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.sha.calc.params.MaxDistanceParam;
+import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.earthquake.EqkSource;
+
+/**
+ * Fixed distance cutoff, applied at the source level ({@link #canSkipRupture(EqkRupture, Site)} always returns false)
+ */
+public class FixedDistanceCutoffFilter implements SourceFilter, ParameterChangeListener {
+	
+	private MaxDistanceParam distParam;
+	private double maxDist;
+	private ParameterList params;
+	
+	public FixedDistanceCutoffFilter() {
+		distParam = new MaxDistanceParam();
+		maxDist = distParam.getValue();
+		distParam.addParameterChangeListener(this);
+		
+		params = new ParameterList();
+		params.addParameter(distParam);
+	}
+	
+	public FixedDistanceCutoffFilter(double maxDistance) {
+		this();
+		distParam.setValue(maxDistance);
+	}
+	
+	public void setMaxDistance(double maxDist) {
+		distParam.setValue(maxDist);
+	}
+	
+	public double getMaxDistance() {
+		return maxDist;
+	}
+
+	@Override
+	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance) {
+		return sourceSiteDistance > maxDist;
+	}
+
+	@Override
+	public boolean canSkipRupture(EqkRupture rup, Site site) {
+		// this is applied at the source level, individual ruptures can be further away
+		return false;
+	}
+
+	@Override
+	public ParameterList getAdjustableParams() {
+		return params;
+	}
+
+	@Override
+	public void parameterChange(ParameterChangeEvent event) {
+		maxDist = distParam.getValue();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/FixedDistanceCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/FixedDistanceCutoffFilter.java
@@ -9,7 +9,7 @@ import org.opensha.sha.earthquake.EqkRupture;
 import org.opensha.sha.earthquake.EqkSource;
 
 /**
- * Fixed distance cutoff, applied at the source level ({@link #canSkipRupture(EqkRupture, Site)} always returns false)
+ * Fixed distance cutoff, applied at the source and rupture level
  */
 public class FixedDistanceCutoffFilter implements SourceFilter, ParameterChangeListener {
 	
@@ -46,8 +46,7 @@ public class FixedDistanceCutoffFilter implements SourceFilter, ParameterChangeL
 
 	@Override
 	public boolean canSkipRupture(EqkRupture rup, Site site) {
-		// this is applied at the source level, individual ruptures can be further away
-		return false;
+		return rup.getRuptureSurface().getQuickDistance(site.getLocation()) > maxDist;
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/calc/params/filters/MagDependentDistCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/MagDependentDistCutoffFilter.java
@@ -1,0 +1,68 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.sha.calc.params.MagDistCutoffParam;
+import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.earthquake.EqkSource;
+
+/**
+ * Magnitude-dependent distance cutoffs, applied at the rupture level ({@link #canSkipSource(EqkSource, Site, double)} always returns false).
+ */
+public class MagDependentDistCutoffFilter implements SourceFilter, ParameterChangeListener {
+	
+	private MagDistCutoffParam magDist;
+	private ArbitrarilyDiscretizedFunc magDistFunc;
+	private ParameterList params;
+	
+	public MagDependentDistCutoffFilter() {
+		magDist = new MagDistCutoffParam();
+		magDist.addParameterChangeListener(this);
+		magDistFunc = magDist.getValue();
+		
+		params = new ParameterList();
+		params.addParameter(magDist);
+	}
+	
+	public void setMagDistFunc(ArbitrarilyDiscretizedFunc magDistFunc) {
+		this.magDist.setValue(magDistFunc);
+	}
+	
+	public ArbitrarilyDiscretizedFunc getMagDistFunc() {
+		return magDistFunc;
+	}
+
+	@Override
+	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance) {
+		// never skip a source, this is done on a per-rupture basis
+		return false;
+	}
+
+	@Override
+	public boolean canSkipRupture(EqkRupture rup, Site site) {
+		double dist = rup.getRuptureSurface().getQuickDistance(site.getLocation());
+		if (dist < magDistFunc.getMinX())
+			// closer than the smallest cutoff, don't skip
+			return false;
+		if (dist > magDistFunc.getMaxX())
+			// further than the largest cutoff, always skip
+			return true;
+		double magThresh = magDistFunc.getInterpolatedY(dist);
+		// skip if the magnitude is less than the distance-dependent threshold
+		return rup.getMag() < magThresh;
+	}
+
+	@Override
+	public ParameterList getAdjustableParams() {
+		return params;
+	}
+
+	@Override
+	public void parameterChange(ParameterChangeEvent event) {
+		magDistFunc = magDist.getValue();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/MagDependentDistCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/MagDependentDistCutoffFilter.java
@@ -10,7 +10,8 @@ import org.opensha.sha.earthquake.EqkRupture;
 import org.opensha.sha.earthquake.EqkSource;
 
 /**
- * Magnitude-dependent distance cutoffs, applied at the rupture level ({@link #canSkipSource(EqkSource, Site, double)} always returns false).
+ * Magnitude-dependent distance cutoffs, generally applied at the rupture level, but also checked at the source level
+ * against the largest stated cutoff 
  */
 public class MagDependentDistCutoffFilter implements SourceFilter, ParameterChangeListener {
 	
@@ -37,8 +38,8 @@ public class MagDependentDistCutoffFilter implements SourceFilter, ParameterChan
 
 	@Override
 	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance) {
-		// never skip a source, this is done on a per-rupture basis
-		return false;
+		// skip if it's further than the largest allowed cutoff
+		return sourceSiteDistance > magDistFunc.getMaxX();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/calc/params/filters/MinMagFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/MinMagFilter.java
@@ -1,0 +1,55 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.sha.calc.params.MinMagnitudeParam;
+import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.earthquake.EqkSource;
+
+public class MinMagFilter implements SourceFilter, ParameterChangeListener {
+	
+	private MinMagnitudeParam param;
+	private double minMag;
+	private ParameterList params;
+	
+	public MinMagFilter() {
+		param = new MinMagnitudeParam();
+		minMag = param.getValue();
+		param.addParameterChangeListener(this);
+		
+		params = new ParameterList();
+		params.addParameter(param);
+	}
+	
+	public void setMinMagnitude(double minMag) {
+		param.setValue(minMag);
+	}
+	
+	public double getMinMagnitude() {
+		return minMag;
+	}
+
+	@Override
+	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance) {
+		// applied at the rupture level
+		return false;
+	}
+
+	@Override
+	public boolean canSkipRupture(EqkRupture rup, Site site) {
+		return rup.getMag() < minMag;
+	}
+
+	@Override
+	public ParameterList getAdjustableParams() {
+		return params;
+	}
+
+	@Override
+	public void parameterChange(ParameterChangeEvent event) {
+		minMag = param.getValue();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFilter.java
@@ -1,0 +1,30 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.opensha.commons.data.Site;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.earthquake.EqkSource;
+
+public interface SourceFilter {
+	
+	/**
+	 * @param source source in question
+	 * @param site site in question
+	 * @param sourceSiteDistance distance between the source and the site
+	 * @return true if this entire source can be skipped for this site, false otherwise
+	 */
+	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance);
+	
+	/**
+	 * @param rup rupture in question
+	 * @param site site in question
+	 * @return true if this rupture can be skipped for this site, false otherwise
+	 */
+	public boolean canSkipRupture(EqkRupture rup, Site site);
+	
+	/**
+	 * @return adjustable parameter list for this filter
+	 */
+	public ParameterList getAdjustableParams();
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFilterManager.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFilterManager.java
@@ -1,0 +1,55 @@
+package org.opensha.sha.calc.params.filters;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+
+public class SourceFilterManager {
+	static final SourceFilters[] filters = SourceFilters.values();
+	private SourceFilter[] filterInstances;
+	private boolean[] filterEnableds;
+	
+	private List<SourceFilter> enabledFilterList = null;
+	
+	public SourceFilterManager(SourceFilters... enabledByDefault) {
+		filterInstances = new SourceFilter[filters.length];
+		filterEnableds = new boolean[filters.length];
+		
+		for (SourceFilters filter : enabledByDefault) {
+			filterInstances[filter.ordinal()] = filter.initFilter();
+			filterEnableds[filter.ordinal()] = true;
+		}
+	}
+	
+	public List<SourceFilter> getEnabledFilters() {
+		if (enabledFilterList == null) {
+			List<SourceFilter> ret = new ArrayList<>();
+			for (int i=0; i<filterInstances.length; i++) {
+				if (filterEnableds[i]) {
+					Preconditions.checkNotNull(filterInstances[i]);
+					ret.add(filterInstances[i]);
+				}
+			}
+			enabledFilterList = ret;
+		}
+		return enabledFilterList;
+	}
+	
+	public void setEnabled(SourceFilters filter, boolean enabled) {
+		enabledFilterList = null;
+		filterEnableds[filter.ordinal()] = enabled;
+		if (enabled && filterInstances[filter.ordinal()] == null)
+			filterInstances[filter.ordinal()] = filter.initFilter();
+	}
+	
+	public boolean isEnabled(SourceFilters filter) {
+		return filterEnableds[filter.ordinal()];
+	}
+	
+	public SourceFilter getFilterInstance(SourceFilters filter) {
+		if (filterInstances[filter.ordinal()] == null)
+			filterInstances[filter.ordinal()] = filter.initFilter();
+		return filterInstances[filter.ordinal()];
+	}
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFilters.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFilters.java
@@ -1,0 +1,45 @@
+package org.opensha.sha.calc.params.filters;
+
+public enum SourceFilters {
+	
+	FIXED_DIST_CUTOFF("Fixed Distance Cutoff") {
+		@Override
+		public synchronized SourceFilter initFilter() {
+			return new FixedDistanceCutoffFilter();
+		}
+	},
+	TRT_DIST_CUTOFFS("Tectonic Regime-Specific Distance Cutoffs") {
+		@Override
+		public synchronized SourceFilter initFilter() {
+			return new TectonicRegionDistCutoffFilter();
+		}
+	},
+	MAG_DIST_CUTOFFS("Magnitude-Dependent Distance Cutoffs") {
+		@Override
+		public synchronized SourceFilter initFilter() {
+			return new MagDependentDistCutoffFilter();
+		}
+	},
+	MIN_MAG("Minimum Magnitude") {
+		@Override
+		public synchronized SourceFilter initFilter() {
+			return new MinMagFilter();
+		}
+	};
+	
+	private String label;
+
+	private SourceFilters(String label) {
+		this.label = label;
+	}
+	
+	@Override
+	public String toString() {
+		return label;
+	}
+
+	public abstract SourceFilter initFilter();
+	
+	
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParam.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParam.java
@@ -1,0 +1,41 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.dom4j.Element;
+import org.opensha.commons.param.AbstractParameter;
+
+public class SourceFiltersParam extends AbstractParameter<SourceFilterManager> {
+	
+	public static final String NAME = "Source Filters";
+	
+	private SourceFiltersParamEditor editor = null;
+	
+	public SourceFiltersParam() {
+		super(NAME, null, null, new SourceFilterManager(SourceFilters.FIXED_DIST_CUTOFF));
+	}
+
+	@Override
+	public SourceFiltersParamEditor getEditor() {
+		if (editor == null)
+			editor = new SourceFiltersParamEditor(this);
+		return editor;
+	}
+
+	@Override
+	public boolean isEditorBuilt() {
+		return editor != null;
+	}
+
+	@Override
+	public Object clone() {
+		SourceFiltersParam other = new SourceFiltersParam();
+		other.setValue(getValue());
+		return other;
+	}
+
+	@Override
+	protected boolean setIndividualParamValueFromXML(Element el) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParamEditor.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParamEditor.java
@@ -1,0 +1,149 @@
+package org.opensha.sha.calc.params.filters;
+
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.util.List;
+
+import javax.swing.BoxLayout;
+import javax.swing.JCheckBox;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
+import org.opensha.commons.param.Parameter;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.editor.AbstractParameterEditor;
+import org.opensha.commons.param.editor.impl.ParameterListEditor;
+
+public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilterManager> implements ActionListener {
+	
+	private static final SourceFilters[] filters = SourceFilters.values();
+	
+	private JPanel panel;
+	
+	private JCheckBox[] checkBoxes;
+	
+	private ParameterList params;
+	private ParameterListEditor paramsEdit;
+	
+	private boolean globalEnabled = true;
+	
+	public SourceFiltersParamEditor(SourceFiltersParam param) {
+		super(param);
+	}
+
+	@Override
+	public boolean isParameterSupported(Parameter<SourceFilterManager> param) {
+		return param instanceof SourceFiltersParam;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		if (panel == null)
+			return;
+		
+		globalEnabled = false;
+		updateWidget();
+		
+		for (JCheckBox box : checkBoxes)
+			box.setEnabled(enabled);
+		
+		SourceFilterManager manager = getParameter().getValue();
+		for (int i=0; i<filters.length; i++) {
+			boolean selected = manager.isEnabled(filters[i]);
+			
+			ParameterList filterParams = manager.getFilterInstance(filters[i]).getAdjustableParams();
+			if (filterParams != null)
+				for (Parameter<?> param : filterParams)
+					param.getEditor().setEnabled(enabled && selected);
+		}
+		paramsEdit.refreshParamEditor();
+	}
+
+	@Override
+	protected JComponent buildWidget() {
+		globalEnabled = true;
+		panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		
+		SourceFilterManager manager = getParameter().getValue();
+		
+		params = new ParameterList();
+		checkBoxes = new JCheckBox[filters.length];
+		
+		for (int i=0; i<filters.length; i++) {
+			SourceFilters filter = filters[i];
+			checkBoxes[i] = new JCheckBox(filter.toString(), null, manager.isEnabled(filter));
+			checkBoxes[i].addActionListener(this);
+			checkBoxes[i].setHorizontalAlignment(SwingConstants.LEFT);
+//			panel.add(checkBoxes[i]);
+			JPanel subPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+			subPanel.add(checkBoxes[i]);
+			panel.add(subPanel);
+			
+			ParameterList filterParams = manager.getFilterInstance(filter).getAdjustableParams();
+			if (filterParams != null)
+				params.addParameterList(filterParams);
+		}
+		
+		paramsEdit = new ParameterListEditor(params);
+		paramsEdit.setTitle("Adjustable Parameters");
+		panel.add(paramsEdit);
+		
+		updateWidget();
+		return panel;
+	}
+
+	@Override
+	protected JComponent updateWidget() {
+		SourceFilterManager manager = getParameter().getValue();
+		for (int i=0; i<filters.length; i++) {
+			boolean checked = checkBoxes[i].isSelected();
+			boolean filterEnabled = manager.isEnabled(filters[i]);
+			if (filterEnabled != checked)
+				checkBoxes[i].setSelected(filterEnabled);
+			checkBoxes[i].setEnabled(globalEnabled);
+			
+			ParameterList filterParams = manager.getFilterInstance(filters[i]).getAdjustableParams();
+			if (filterParams != null) {
+				for (Parameter<?> param : filterParams) {
+					param.getEditor().setEnabled(globalEnabled && filterEnabled);
+					param.getEditor().refreshParamEditor();
+				}
+			}
+		}
+		paramsEdit.refreshParamEditor();
+		return panel;
+	}
+
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		for (int i=0; i<checkBoxes.length; i++) {
+			if (e.getSource() == checkBoxes[i]) {
+				boolean selected = checkBoxes[i].isSelected();
+				SourceFilterManager manager = getParameter().getValue();
+				manager.setEnabled(filters[i], selected);
+				updateWidget();;
+				break;
+			}
+		}
+	}
+	
+	public static void main(String[] args) {
+		SourceFiltersParam param = new SourceFiltersParam();
+		
+		SourceFiltersParamEditor editor = new SourceFiltersParamEditor(param);
+		
+		JFrame frame = new JFrame();
+		frame.setContentPane(editor.buildWidget());
+		
+		frame.setVisible(true);
+//		frame.setPreferredSize(new Dimension(400, 400));
+		frame.setSize(400, 400);
+		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		frame.validate();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParamEditor.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/SourceFiltersParamEditor.java
@@ -15,6 +15,7 @@ import javax.swing.SwingConstants;
 import org.opensha.commons.param.Parameter;
 import org.opensha.commons.param.ParameterList;
 import org.opensha.commons.param.editor.AbstractParameterEditor;
+import org.opensha.commons.param.editor.ParameterEditor;
 import org.opensha.commons.param.editor.impl.ParameterListEditor;
 
 public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilterManager> implements ActionListener {
@@ -44,7 +45,7 @@ public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilt
 		if (panel == null)
 			return;
 		
-		globalEnabled = false;
+		globalEnabled = enabled;
 		updateWidget();
 		
 		for (JCheckBox box : checkBoxes)
@@ -60,6 +61,11 @@ public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilt
 					param.getEditor().setEnabled(enabled && selected);
 		}
 		paramsEdit.refreshParamEditor();
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return globalEnabled;
 	}
 
 	@Override
@@ -84,8 +90,16 @@ public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilt
 			panel.add(subPanel);
 			
 			ParameterList filterParams = manager.getFilterInstance(filter).getAdjustableParams();
-			if (filterParams != null)
+			if (filterParams != null) {
+				for (Parameter<?> param : filterParams) {
+					params.addParameter(param);
+					ParameterEditor<?> editor = param.getEditor();
+					if (editor instanceof AbstractParameterEditor<?>)
+						// to make it clear what is enabled vs disabled
+						((AbstractParameterEditor<?>)editor).setShowDisabledStatusInTitle(true);
+				}
 				params.addParameterList(filterParams);
+			}
 		}
 		
 		paramsEdit = new ParameterListEditor(params);
@@ -125,7 +139,7 @@ public class SourceFiltersParamEditor extends AbstractParameterEditor<SourceFilt
 				boolean selected = checkBoxes[i].isSelected();
 				SourceFilterManager manager = getParameter().getValue();
 				manager.setEnabled(filters[i], selected);
-				updateWidget();;
+				updateWidget();
 				break;
 			}
 		}

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffFilter.java
@@ -1,0 +1,101 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.apache.commons.math3.stat.StatUtils;
+import org.opensha.commons.data.Site;
+import org.opensha.commons.param.ParameterList;
+import org.opensha.commons.param.event.ParameterChangeEvent;
+import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.earthquake.EqkSource;
+import org.opensha.sha.util.TectonicRegionType;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Tectonic region-specific fixed distance cutoffs, applied at the source level
+ * ({@link #canSkipRupture(EqkRupture, Site)} always returns false)
+ */
+public class TectonicRegionDistCutoffFilter implements SourceFilter, ParameterChangeListener {
+	
+	private TectonicRegionDistCutoffParam param;
+	private TectonicRegionDistanceCutoffs cutoffs;
+	private ParameterList params;
+	
+	public TectonicRegionDistCutoffFilter() {
+		param = new TectonicRegionDistCutoffParam();
+		cutoffs = param.getValue();
+		param.addParameterChangeListener(this);
+		
+		params = new ParameterList();
+		params.addParameter(param);
+	}
+	
+	public TectonicRegionDistanceCutoffs getCutoffs() {
+		return cutoffs;
+	}
+
+	@Override
+	public boolean canSkipSource(EqkSource source, Site site, double sourceSiteDistance) {
+		TectonicRegionType trt = source.getTectonicRegionType();
+		double maxDist = cutoffs.getCutoffDist(trt);
+		return sourceSiteDistance > maxDist;
+	}
+
+	@Override
+	public boolean canSkipRupture(EqkRupture rup, Site site) {
+		// done at the source level
+		return false;
+	}
+
+	@Override
+	public ParameterList getAdjustableParams() {
+		return params;
+	}
+	
+	public static class TectonicRegionDistanceCutoffs {
+		private TectonicRegionType[] trts;
+		private double[] cutoffDists;
+		private double unknownDist;
+		
+		public TectonicRegionDistanceCutoffs(double unknownDist) {
+			trts = TectonicRegionType.values();
+			cutoffDists = new double[trts.length];
+			for (int i=0; i<trts.length; i++)
+				cutoffDists[i] = trts[i].defaultCutoffDist();
+			this.unknownDist = unknownDist;
+		}
+		
+		public double getCutoffDist(TectonicRegionType trt) {
+			if (trt == null)
+				return unknownDist;
+			return cutoffDists[trt.ordinal()];
+		}
+		
+		public void setCutoffDist(TectonicRegionType trt, double dist) {
+			Preconditions.checkState(dist > 0, "Distance must be >0: %s", dist);
+			if (trt == null) {
+				unknownDist = dist;
+			} else {
+				for (int i=0; i<trts.length; i++) {
+					if (trt == trts[i]) {
+						cutoffDists[i] = dist;
+						return;
+					}
+				}
+				throw new IllegalStateException("TRT not found? "+trt);
+			}
+		}
+		
+		public double getLargestCutoffDist() {
+			return Math.max(unknownDist, StatUtils.max(cutoffDists));
+		}
+	}
+
+	@Override
+	public void parameterChange(ParameterChangeEvent event) {
+		cutoffs = param.getValue();
+	}
+	
+	
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffFilter.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffFilter.java
@@ -55,39 +55,33 @@ public class TectonicRegionDistCutoffFilter implements SourceFilter, ParameterCh
 	public static class TectonicRegionDistanceCutoffs {
 		private TectonicRegionType[] trts;
 		private double[] cutoffDists;
-		private double unknownDist;
 		
-		public TectonicRegionDistanceCutoffs(double unknownDist) {
+		public TectonicRegionDistanceCutoffs() {
 			trts = TectonicRegionType.values();
 			cutoffDists = new double[trts.length];
 			for (int i=0; i<trts.length; i++)
 				cutoffDists[i] = trts[i].defaultCutoffDist();
-			this.unknownDist = unknownDist;
 		}
 		
 		public double getCutoffDist(TectonicRegionType trt) {
-			if (trt == null)
-				return unknownDist;
+			Preconditions.checkNotNull(trt, "Tectonic region type must be non-null");
 			return cutoffDists[trt.ordinal()];
 		}
 		
 		public void setCutoffDist(TectonicRegionType trt, double dist) {
+			Preconditions.checkNotNull(trt, "Tectonic region type must be non-null");
 			Preconditions.checkState(dist > 0, "Distance must be >0: %s", dist);
-			if (trt == null) {
-				unknownDist = dist;
-			} else {
-				for (int i=0; i<trts.length; i++) {
-					if (trt == trts[i]) {
-						cutoffDists[i] = dist;
-						return;
-					}
+			for (int i=0; i<trts.length; i++) {
+				if (trt == trts[i]) {
+					cutoffDists[i] = dist;
+					return;
 				}
-				throw new IllegalStateException("TRT not found? "+trt);
 			}
+			throw new IllegalStateException("TRT not found? "+trt);
 		}
 		
 		public double getLargestCutoffDist() {
-			return Math.max(unknownDist, StatUtils.max(cutoffDists));
+			return StatUtils.max(cutoffDists);
 		}
 	}
 

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParam.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParam.java
@@ -17,7 +17,7 @@ public class TectonicRegionDistCutoffParam extends AbstractParameter<TectonicReg
 	}
 	
 	public TectonicRegionDistCutoffParam(String name) {
-		this(name, new TectonicRegionDistanceCutoffs(TectonicRegionType.ACTIVE_SHALLOW.defaultCutoffDist()));
+		this(name, new TectonicRegionDistanceCutoffs());
 	}
 	
 	public TectonicRegionDistCutoffParam(String name, TectonicRegionDistanceCutoffs cutoffs) {

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParam.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParam.java
@@ -1,0 +1,51 @@
+package org.opensha.sha.calc.params.filters;
+
+import org.dom4j.Element;
+import org.opensha.commons.param.AbstractParameter;
+import org.opensha.commons.param.editor.ParameterEditor;
+import org.opensha.sha.calc.params.filters.TectonicRegionDistCutoffFilter.TectonicRegionDistanceCutoffs;
+import org.opensha.sha.util.TectonicRegionType;
+
+public class TectonicRegionDistCutoffParam extends AbstractParameter<TectonicRegionDistanceCutoffs> {
+	
+	public static final String NAME = "Tectonic Region Distance Cutoffs";
+	
+	private TectonicRegionDistCutoffParamEditor editor = null;
+	
+	public TectonicRegionDistCutoffParam() {
+		this(NAME);
+	}
+	
+	public TectonicRegionDistCutoffParam(String name) {
+		this(name, new TectonicRegionDistanceCutoffs(TectonicRegionType.ACTIVE_SHALLOW.defaultCutoffDist()));
+	}
+	
+	public TectonicRegionDistCutoffParam(String name, TectonicRegionDistanceCutoffs cutoffs) {
+		super(name, null, "km", cutoffs);
+	}
+
+	@Override
+	public synchronized ParameterEditor getEditor() {
+		if (editor == null)
+			editor = new TectonicRegionDistCutoffParamEditor(this);
+		return editor;
+	}
+
+	@Override
+	public boolean isEditorBuilt() {
+		return editor != null;
+	}
+
+	@Override
+	public Object clone() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	protected boolean setIndividualParamValueFromXML(Element el) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+}

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
@@ -32,7 +32,6 @@ implements FocusListener, KeyListener {
 	
 	private static TectonicRegionType[] trts = TectonicRegionType.values();
 	
-	static final String UNKNOWN_LABEL = "Unknown";
 	static final DecimalFormat oDF = new DecimalFormat("0.##");
 	static final int DIST_COLS = 7;
 	
@@ -66,22 +65,15 @@ implements FocusListener, KeyListener {
 	protected JComponent buildWidget() {
 		TectonicRegionDistanceCutoffs cutoffs = getParameter().getValue();
 		Preconditions.checkNotNull(cutoffs, "Cutoffs are null in the parameter");
-		int rows = trts.length + 1; // +1 for unknown
+		int rows = trts.length;
 		fields = new NumericTextField[rows];
 		
 		JPanel panel = new JPanel();
 		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 		
 		for (int i=0; i<rows; i++) {
-			String text;
-			double val;
-			if (i < rows-1) {
-				text = trts[i].toString();
-				val = cutoffs.getCutoffDist(trts[i]);
-			} else {
-				text = UNKNOWN_LABEL;
-				val = cutoffs.getCutoffDist(null);
-			}
+			String text = trts[i].toString();
+			double val = cutoffs.getCutoffDist(trts[i]);
 			JLabel label = new JLabel(text);
 //			label.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
 //			label.setPreferredSize(new Dimension(40, 20));
@@ -172,7 +164,7 @@ implements FocusListener, KeyListener {
 				reset = true;
 			} else {
 				if (D) System.out.println("Updating "+index+" to "+(float)val);
-				cutoffs.setCutoffDist(index < trts.length-1 ? trts[index] : null, val);
+				cutoffs.setCutoffDist(trts[index], val);
 			}
 		} catch (ParseException e) {
 			e.printStackTrace();
@@ -182,12 +174,7 @@ implements FocusListener, KeyListener {
 		}
 		
 		if (reset) {
-			double val;
-			if (index < trts.length-1) {
-				val = cutoffs.getCutoffDist(trts[index]);
-			} else {
-				val = cutoffs.getCutoffDist(null);
-			}
+			double val = cutoffs.getCutoffDist(trts[index]);
 			field.setValue(val);
 			field.invalidate();
 		}

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
@@ -28,7 +28,7 @@ import com.google.common.base.Preconditions;
 class TectonicRegionDistCutoffParamEditor extends AbstractParameterEditor<TectonicRegionDistanceCutoffs>
 implements FocusListener, KeyListener {
 	
-	private static final boolean D = true;
+	private static final boolean D = false;
 	
 	private static TectonicRegionType[] trts = TectonicRegionType.values();
 	
@@ -50,9 +50,16 @@ implements FocusListener, KeyListener {
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		if (fields != null)
+		if (fields != null) {
+			panel.setEnabled(enabled);
 			for (NumericTextField field : fields)
 				field.setEnabled(enabled);
+		}
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return panel != null && panel.isEnabled();
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
+++ b/src/main/java/org/opensha/sha/calc/params/filters/TectonicRegionDistCutoffParamEditor.java
@@ -1,0 +1,204 @@
+package org.opensha.sha.calc.params.filters;
+
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.text.DecimalFormat;
+import java.text.ParseException;
+
+import javax.swing.BoxLayout;
+import javax.swing.JComponent;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
+import org.opensha.commons.param.Parameter;
+import org.opensha.commons.param.editor.AbstractParameterEditor;
+import org.opensha.commons.param.editor.impl.NumericTextField;
+import org.opensha.sha.calc.params.filters.TectonicRegionDistCutoffFilter.TectonicRegionDistanceCutoffs;
+import org.opensha.sha.util.TectonicRegionType;
+
+import com.google.common.base.Preconditions;
+
+class TectonicRegionDistCutoffParamEditor extends AbstractParameterEditor<TectonicRegionDistanceCutoffs>
+implements FocusListener, KeyListener {
+	
+	private static final boolean D = true;
+	
+	private static TectonicRegionType[] trts = TectonicRegionType.values();
+	
+	static final String UNKNOWN_LABEL = "Unknown";
+	static final DecimalFormat oDF = new DecimalFormat("0.##");
+	static final int DIST_COLS = 7;
+	
+	private JPanel panel;
+	private NumericTextField[] fields;
+
+	public TectonicRegionDistCutoffParamEditor(Parameter<TectonicRegionDistanceCutoffs> param) {
+		super(param);
+	}
+
+	@Override
+	public boolean isParameterSupported(Parameter<TectonicRegionDistanceCutoffs> param) {
+		return param != null && param.getValue() instanceof TectonicRegionDistanceCutoffs;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		if (fields != null)
+			for (NumericTextField field : fields)
+				field.setEnabled(enabled);
+	}
+
+	@Override
+	protected JComponent buildWidget() {
+		TectonicRegionDistanceCutoffs cutoffs = getParameter().getValue();
+		Preconditions.checkNotNull(cutoffs, "Cutoffs are null in the parameter");
+		int rows = trts.length + 1; // +1 for unknown
+		fields = new NumericTextField[rows];
+		
+		JPanel panel = new JPanel();
+		panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+		
+		for (int i=0; i<rows; i++) {
+			String text;
+			double val;
+			if (i < rows-1) {
+				text = trts[i].toString();
+				val = cutoffs.getCutoffDist(trts[i]);
+			} else {
+				text = UNKNOWN_LABEL;
+				val = cutoffs.getCutoffDist(null);
+			}
+			JLabel label = new JLabel(text);
+//			label.setFont(new Font(Font.SANS_SERIF, Font.BOLD, 16));
+//			label.setPreferredSize(new Dimension(40, 20));
+			fields[i] = new NumericTextField(text, 7, oDF);
+			fields[i].setText(oDF.format(val));
+			fields[i].addFocusListener(this);
+			fields[i].addKeyListener(this);
+//			fields[i].setPreferredSize(new Dimension(40, 20));
+			
+			JPanel subPanel = new JPanel();
+			subPanel.setLayout(new BorderLayout());
+			label.setPreferredSize(new Dimension(100, 18));
+			fields[i].setPreferredSize(new Dimension(30, 18));
+			subPanel.add(label, BorderLayout.CENTER);
+			subPanel.add(fields[i], BorderLayout.EAST);
+			panel.add(subPanel);
+		}
+		panel.setPreferredSize(new Dimension(130, 18*rows));
+		panel.setMinimumSize(new Dimension(130, 18*rows));
+		this.panel = panel;
+		return panel;
+	}
+
+	@Override
+	protected JComponent updateWidget() {
+		TectonicRegionDistanceCutoffs cutoffs = getParameter().getValue();
+		Preconditions.checkNotNull(cutoffs, "Cutoffs are null in the parameter");
+		Preconditions.checkNotNull(panel, "Can't update, not yet built");
+		for (int i=0; i<fields.length; i++) {
+			double val;
+			if (i<trts.length)
+				val = cutoffs.getCutoffDist(trts[i]);
+			else
+				val = cutoffs.getCutoffDist(null);
+			fields[i].setText(oDF.format(val));
+			fields[i].invalidate();
+		}
+		return panel;
+	}
+
+	@Override
+	public void focusGained(FocusEvent e) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	public void focusLost(FocusEvent e) {
+		for (int i=0; i<fields.length; i++) {
+			if (e.getComponent() == fields[i]) {
+				if (D) System.out.println("Focust lost for "+i);
+				updateForIndex(i);
+				break;
+			}
+		}
+	}
+
+	@Override
+	public void keyTyped(KeyEvent e) {
+		if (e.getKeyChar() == '\n') {
+			// enter was pressed
+			for (int i=0; i<fields.length; i++) {
+				if (e.getComponent() == fields[i]) {
+					if (D) System.out.println("Enter was pressed for "+i);
+					updateForIndex(i);
+					break;
+				}
+			}
+		}
+	}
+
+	@Override
+	public void keyPressed(KeyEvent e) {}
+
+	@Override
+	public void keyReleased(KeyEvent e) {}
+	
+	private void updateForIndex(int index) {
+		TectonicRegionDistanceCutoffs cutoffs = getParameter().getValue();
+		Preconditions.checkNotNull(cutoffs, "Cutoffs are null in the parameter");
+		NumericTextField field = fields[index];
+		boolean reset = false;
+		try {
+			double val = field.getDoubleValue();
+			if (val <= 0d) {
+				JOptionPane.showMessageDialog(panel, "Bad distance: "+val,
+						"Error Parsing Distance", JOptionPane.ERROR_MESSAGE);
+				reset = true;
+			} else {
+				if (D) System.out.println("Updating "+index+" to "+(float)val);
+				cutoffs.setCutoffDist(index < trts.length-1 ? trts[index] : null, val);
+			}
+		} catch (ParseException e) {
+			e.printStackTrace();
+			JOptionPane.showMessageDialog(panel, "Error parsing text: "+e.getMessage(),
+					"Error Parsing Distance", JOptionPane.ERROR_MESSAGE);
+			reset = true;
+		}
+		
+		if (reset) {
+			double val;
+			if (index < trts.length-1) {
+				val = cutoffs.getCutoffDist(trts[index]);
+			} else {
+				val = cutoffs.getCutoffDist(null);
+			}
+			field.setValue(val);
+			field.invalidate();
+		}
+	}
+	
+	public static void main(String[] args) {
+		TectonicRegionDistCutoffParam param = new TectonicRegionDistCutoffParam();
+		
+		TectonicRegionDistCutoffParamEditor editor = new TectonicRegionDistCutoffParamEditor(param);
+		
+		JFrame frame = new JFrame();
+		frame.setContentPane(editor.buildWidget());
+		
+		frame.setVisible(true);
+//		frame.setPreferredSize(new Dimension(400, 400));
+//		frame.setSize(400, 400);
+		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		frame.validate();
+	}
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/ERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF.java
@@ -1,9 +1,12 @@
 package org.opensha.sha.earthquake;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
+import org.opensha.commons.data.Site;
 import org.opensha.sha.calc.disaggregation.DisaggregationSourceRuptureInfo;
+import org.opensha.sha.calc.params.filters.SourceFilter;
 
 /**
  * This is the base interface for an Earthquake Rupture Forecast</b> <br>
@@ -56,7 +59,15 @@ public interface ERF extends BaseERF, Iterable<ProbEqkSource> {
 	 * Returns a random set of ruptures.
 	 * @return a random set of ruptures
 	 */
-	public List<EqkRupture> drawRandomEventSet();
+	public default List<EqkRupture> drawRandomEventSet() {
+		return drawRandomEventSet(null, null);
+	}
+
+	/**
+	 * Returns a random set of ruptures, filtered for the given site and {@link SourceFilter}s
+	 * @return a random set of ruptures
+	 */
+	public List<EqkRupture> drawRandomEventSet(Site site, Collection<SourceFilter> sourceFilters);
 	
 	/**
 	 * If non null, this can be used to consolidate disaggregation results into a consolidatd (and potentially more useful)

--- a/src/main/java/org/opensha/sha/earthquake/ERFSubset.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERFSubset.java
@@ -1,15 +1,19 @@
 package org.opensha.sha.earthquake;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 
+import org.opensha.commons.data.Site;
 import org.opensha.commons.data.TimeSpan;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.Region;
 import org.opensha.commons.param.Parameter;
 import org.opensha.commons.param.ParameterList;
+import org.opensha.sha.calc.params.filters.SourceFilter;
 import org.opensha.sha.util.TectonicRegionType;
 
 /**
@@ -74,8 +78,8 @@ public class ERFSubset implements ERF {
 	}
 
 	@Override
-	public ArrayList<EqkRupture> drawRandomEventSet() {
-		throw new RuntimeException("WARNING: drawRandomEventSet not implemented for test ERF!");
+	public List<EqkRupture> drawRandomEventSet(Site site, Collection<SourceFilter> sourceFilters) {
+		throw new RuntimeException("WARNING: drawRandomEventSet not implemented for subset ERF!");
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/gcim/ui/GCIM_HazardCurveApp.java
+++ b/src/main/java/org/opensha/sha/gcim/ui/GCIM_HazardCurveApp.java
@@ -424,7 +424,7 @@ public class GCIM_HazardCurveApp  extends HazardCurveApplication {
 		//		saveButton.addActionListener(this);
 		//		toolbar.add(saveButton);
 
-		Color bg = new Color(220,220,220);
+		Color bg = HazardCurveApplication.getBottomBarColor();
 
 		// ======== button panel ========
 		JPanel buttonPanel = new JPanel(new GridBagLayout()) {

--- a/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
+++ b/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
@@ -368,6 +368,18 @@ ScalarIMRChangeListener {
 		
 		return builder.buildMenu();
 	}
+	
+	public static Color getBottomBarColor() {
+		Color defaultBackground = UIManager.getColor ( "Panel.background" );
+		double avgColor = (defaultBackground.getRed() + defaultBackground.getGreen() + defaultBackground.getBlue())/3d;
+		if (avgColor > 127d) {
+			// light theme
+			return new Color(220,220,220);
+		} else {
+			// dark theme
+			return new Color(35,35,35);
+		}
+	}
 
 	// Component initialization TODO should be private
 	protected void jbInit() throws Exception {
@@ -409,7 +421,8 @@ ScalarIMRChangeListener {
 		//		saveButton.addActionListener(this);
 		//		toolbar.add(saveButton);
 
-		Color bg = new Color(220,220,220);
+		
+		Color bg = getBottomBarColor();
 
 		// ======== button panel ========
 		JPanel buttonPanel = new JPanel(new GridBagLayout()) {

--- a/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
@@ -24,6 +24,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JList;
 import javax.swing.JPanel;
+import javax.swing.UIManager;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 
 import org.opensha.commons.gui.LabeledBoxPanel;
@@ -82,6 +83,8 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	private int maxChooserChars = Integer.MAX_VALUE;
 	
 	private int defaultIMRIndex = 0;
+	
+	private Color backgroundColor;
 
 	/**
 	 * Initializes the GUI with the given list of IMRs
@@ -92,6 +95,16 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		this.imrs = imrs;
 		Preconditions.checkNotNull(imrs, "IMR list cannot be null!");
 		Preconditions.checkArgument(!imrs.isEmpty(), "IMR list cannot be empty!");
+		
+		Color defaultBackground = UIManager.getColor ( "Panel.background" );
+		double avgColor = (defaultBackground.getRed() + defaultBackground.getGreen() + defaultBackground.getBlue())/3d;
+		if (avgColor > 127d) {
+			// light theme
+			backgroundColor = Color.WHITE;
+		} else {
+			// dark theme
+			backgroundColor = defaultBackground;
+		}
 		
 		// check no duplicate names
 		ArrayList<String> names = new ArrayList<String>();
@@ -204,7 +217,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 				chooser.resetRenderer();
 			} else {
 				chooser = new ChooserComboBox(0);
-				chooser.setBackground(Color.WHITE);
+				chooser.setBackground(backgroundColor);
 //				chooser.addActionListener(this);
 				chooserBoxes.add(chooser);
 			}
@@ -361,7 +374,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 				int index, boolean isSelected, boolean cellHasFocus) {
 			Component comp = super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 			if (!isSelected)
-				comp.setBackground(Color.white);
+				comp.setBackground(backgroundColor);
 			if (index >= 0) {
 				comp.setEnabled(imrEnables.get(index));
 				setFont(comp, index);

--- a/src/main/java/org/opensha/sha/gui/controls/CalculationSettingsControlPanel.java
+++ b/src/main/java/org/opensha/sha/gui/controls/CalculationSettingsControlPanel.java
@@ -64,7 +64,7 @@ public class CalculationSettingsControlPanel extends ControlPanel {
 	}
 	
 	private void jbInit() throws Exception {
-		frame.setSize(350,500);
+		frame.setSize(350,800);
 		frame.setTitle("Calculation Settings");
 		frame.getContentPane().setLayout(new GridBagLayout());
 		frame.getContentPane().add(editor,new GridBagConstraints(0, 0, 1, 1, 1.0, 1.0

--- a/src/main/java/org/opensha/sha/imr/mod/impl/stewartSiteSpecific/PeriodDependentParamSetEditor.java
+++ b/src/main/java/org/opensha/sha/imr/mod/impl/stewartSiteSpecific/PeriodDependentParamSetEditor.java
@@ -88,6 +88,11 @@ extends AbstractParameterEditor<PeriodDependentParamSet<E>> implements ActionLis
 		this.addButton.setEnabled(enabled);
 		this.removeButton.setEnabled(enabled);
 	}
+	
+	@Override
+	public boolean isEnabled() {
+		return table != null && table.isEnabled();
+	}
 
 	@Override
 	protected JComponent buildWidget() {

--- a/src/test/java/org/opensha/sha/calc/params/filters/SourceFilterTests.java
+++ b/src/test/java/org/opensha/sha/calc/params/filters/SourceFilterTests.java
@@ -1,0 +1,438 @@
+package org.opensha.sha.calc.params.filters;
+
+import static org.junit.Assert.*;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.opensha.commons.data.Site;
+import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
+import org.opensha.commons.data.function.DiscretizedFunc;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationList;
+import org.opensha.commons.geo.LocationUtils;
+import org.opensha.sha.calc.HazardCurveCalculator;
+import org.opensha.sha.calc.params.filters.TectonicRegionDistCutoffFilter.TectonicRegionDistanceCutoffs;
+import org.opensha.sha.earthquake.AbstractERF;
+import org.opensha.sha.earthquake.ProbEqkRupture;
+import org.opensha.sha.earthquake.ProbEqkSource;
+import org.opensha.sha.earthquake.rupForecastImpl.PointEqkSource;
+import org.opensha.sha.faultSurface.RuptureSurface;
+import org.opensha.sha.gui.infoTools.IMT_Info;
+import org.opensha.sha.imr.AttenRelRef;
+import org.opensha.sha.imr.ScalarIMR;
+import org.opensha.sha.magdist.GutenbergRichterMagFreqDist;
+import org.opensha.sha.magdist.IncrementalMagFreqDist;
+import org.opensha.sha.util.TectonicRegionType;
+
+public class SourceFilterTests {
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		calc = new HazardCurveCalculator();
+		filterManager = calc.getSourceFilterManager();
+		
+		testIMR = AttenRelRef.ASK_2014.get();
+		testIMR.setParamDefaults();
+		
+		testSite = new Site(new Location(34, -118));
+		testSite.addParameterList(testIMR.getSiteParams());
+		
+		DiscretizedFunc linearXVals = new IMT_Info().getDefaultHazardCurve(testIMR.getIntensityMeasure());
+		xVals = new ArbitrarilyDiscretizedFunc();
+		for (Point2D pt : linearXVals)
+			xVals.set(Math.log(pt.getX()), 0d);
+		
+		erf = new TestERF();
+		System.out.println("erf has "+erf.getNumSources()+" sources");
+		int numRups = 0;
+		for (ProbEqkSource source : erf)
+			numRups += source.getNumRuptures();
+		System.out.println("erf has "+numRups+" ruptures");
+	}
+	
+	private static final TectonicRegionType[] TRTs = TectonicRegionType.values();
+	
+	private static final int NUM_DIST = 51;
+	private static final double MIN_DIST = 15d;
+	private static final double DELTA_DIST = 20d;
+	
+	private static final int NUM_MAG = 15;
+	private static final double MIN_MAG= 5.05d;
+	private static final double DELTA_MAG = 0.25d;
+	
+	private static Site testSite;
+	
+	private static TestERF erf;
+	
+	private static HazardCurveCalculator calc;
+	private static ScalarIMR testIMR;
+	private static DiscretizedFunc xVals;
+	
+	private static SourceFilterManager filterManager;
+	
+	private static class TestERF extends AbstractERF {
+		
+		private List<AccessTrackingPointEqkSource> sources;
+		
+		public TestERF() {
+			sources = new ArrayList<>(TRTs.length*NUM_DIST);
+			
+			GutenbergRichterMagFreqDist mfd = new GutenbergRichterMagFreqDist(MIN_MAG, NUM_MAG, DELTA_MAG);
+			mfd.setAllButTotMoRate(mfd.getMinX(), mfd.getMaxX(), 1d, 1d);
+			
+			for (int t=0; t<TRTs.length; t++) {
+				for (int d=0; d<NUM_DIST; d++) {
+					double dist = MIN_DIST + d*DELTA_DIST;
+					Location loc = LocationUtils.location(testSite.getLocation(), Math.PI*0.5, dist);
+					AccessTrackingPointEqkSource source = new AccessTrackingPointEqkSource(loc, mfd, 1d, 0d, 90d);
+					source.setTectonicRegionType(TRTs[t]);
+					sources.add(source);
+				}
+			}
+		}
+
+		@Override
+		public int getNumSources() {
+			return sources.size();
+		}
+
+		@Override
+		public AccessTrackingPointEqkSource getSource(int idx) {
+			return sources.get(idx);
+		}
+
+		@Override
+		public void updateForecast() {}
+
+		@Override
+		public String getName() {
+			return "Test ERF";
+		}
+		
+	}
+	
+	private static class AccessTrackingPointEqkSource extends ProbEqkSource {
+		
+		private PointEqkSource source;
+		private List<AccessTrackingPointEqkRup> rups;
+		
+		boolean sourceAccessed = false;
+		
+		public AccessTrackingPointEqkSource(Location loc, IncrementalMagFreqDist magFreqDist,double duration,
+				double aveRake, double aveDip){
+			super();
+			source = new PointEqkSource(loc, magFreqDist, duration, aveRake, aveDip);
+			rups = new ArrayList<>(source.getNumRuptures());
+			for (ProbEqkRupture rup : source)
+				rups.add(new AccessTrackingPointEqkRup(rup));
+		}
+
+		@Override
+		public LocationList getAllSourceLocs() {
+			return source.getAllSourceLocs();
+		}
+
+		@Override
+		public RuptureSurface getSourceSurface() {
+			return source.getSourceSurface();
+		}
+
+		@Override
+		public double getMinDistance(Site site) {
+			return source.getMinDistance(site);
+		}
+
+		@Override
+		public int getNumRuptures() {
+			return rups.size();
+		}
+
+		@Override
+		public AccessTrackingPointEqkRup getRupture(int nRupture) {
+			sourceAccessed = true;
+			return rups.get(nRupture);
+		}
+		
+		public void clearAccess() {
+			sourceAccessed = false;
+			for (AccessTrackingPointEqkRup rup : rups)
+				rup.clearAccess();
+		}
+		
+		public boolean hasSourceBeenAccessed() {
+			return sourceAccessed;
+		}
+	}
+	
+	private static class AccessTrackingPointEqkRup extends ProbEqkRupture {
+		
+		boolean rupAccessed = false;
+		
+		public AccessTrackingPointEqkRup(ProbEqkRupture rup) {
+			super(rup.getMag(), rup.getAveRake(), rup.getProbability(), rup.getRuptureSurface(), rup.getHypocenterLocation());
+		}
+		
+		@Override
+		public double getAveRake() {
+			rupAccessed = true;
+			return super.getAveRake();
+		}
+
+		public void clearAccess() {
+			rupAccessed = false;
+		}
+		
+		public boolean hasRupBeenAccessed() {
+			return rupAccessed;
+		}
+		
+	}
+	
+	private static void disableAllFilters() {
+		for (SourceFilters filterType : SourceFilters.values())
+			filterManager.setEnabled(filterType, false);
+	}
+
+	@Test
+	public void testFilterByTRT() {
+		disableAllFilters();
+		filterManager.setEnabled(SourceFilters.TRT_DIST_CUTOFFS, true);
+		TectonicRegionDistCutoffFilter filter = (TectonicRegionDistCutoffFilter)
+				filterManager.getFilterInstance(SourceFilters.TRT_DIST_CUTOFFS);
+		doTestTRTFilter(filter);
+		checkEnabledFitlers(filter);
+		TectonicRegionDistanceCutoffs cutoffs = filter.getCutoffs();
+		// set them all to infinity
+		for (TectonicRegionType trt : TectonicRegionType.values())
+			cutoffs.setCutoffDist(trt, Double.POSITIVE_INFINITY);
+		int noExclusion = doTestTRTFilter(filter);
+		// set each to almost zero individually
+		for (TectonicRegionType trt : TectonicRegionType.values()) {
+			cutoffs.setCutoffDist(trt, Double.MIN_VALUE);
+			int numRups = doTestTRTFilter(filter);
+			assertTrue("We enabled a TRT filter, but the number or ruptures included didn't change?", numRups < noExclusion);
+			cutoffs.setCutoffDist(trt, trt.defaultCutoffDist());
+			doTestTRTFilter(filter);
+			cutoffs.setCutoffDist(trt, Double.POSITIVE_INFINITY);
+		}
+		
+		// reset to defaults for use later
+		for (TectonicRegionType trt : TectonicRegionType.values())
+			cutoffs.setCutoffDist(trt, trt.defaultCutoffDist());
+	}
+	
+	private int doTestTRTFilter(TectonicRegionDistCutoffFilter filter) {
+		TectonicRegionDistanceCutoffs cutoffs = filter.getCutoffs();
+		for (ProbEqkSource source : erf.sources) {
+			TectonicRegionType trt = source.getTectonicRegionType();
+			double dist = source.getMinDistance(testSite);
+			double trtDist = cutoffs.getCutoffDist(trt);
+			assertEquals(dist > trtDist, filter.canSkipSource(source, testSite, dist));
+			for (ProbEqkRupture rup : source)
+				assertFalse("TRT filter should never apply to a rupture, just sources", filter.canSkipRupture(rup, testSite));
+		}
+		return doTestHazardCalc();
+	}
+	
+	@Test
+	public void testFilterByDist() {
+		disableAllFilters();
+		FixedDistanceCutoffFilter filter = (FixedDistanceCutoffFilter)
+				filterManager.getFilterInstance(SourceFilters.FIXED_DIST_CUTOFF);
+		filterManager.setEnabled(SourceFilters.FIXED_DIST_CUTOFF, true);
+		checkEnabledFitlers(filter);
+		int rupsWithDefault = doTestDistFilter(filter);
+		
+		filter.setMaxDistance(Double.MIN_VALUE);
+		int rupsWithFull = doTestDistFilter(filter);
+		assertTrue("Rupture count should be less with max distance at near-zero", rupsWithFull < rupsWithDefault);
+		
+		filter.setMaxDistance(10000d);
+		int rupsWithNone = doTestDistFilter(filter);
+		assertTrue("Rupture count should be more with max distance at near-infinite", rupsWithNone > rupsWithDefault);
+		
+		filter.setMaxDistance(200d);
+		doTestDistFilter(filter);
+	}
+	
+	private int doTestDistFilter(FixedDistanceCutoffFilter filter) {
+		double maxDist = filter.getMaxDistance();
+		for (ProbEqkSource source : erf.sources) {
+			double dist = source.getMinDistance(testSite);
+			assertEquals(dist > maxDist, filter.canSkipSource(source, testSite, dist));
+			for (ProbEqkRupture rup : source)
+				assertFalse("Fixed distance filter should never apply to a rupture, just sources", filter.canSkipRupture(rup, testSite));
+		}
+		return doTestHazardCalc();
+	}
+	
+	@Test
+	public void testFilterByMag() {
+		disableAllFilters();
+		MinMagFilter filter = (MinMagFilter)
+				filterManager.getFilterInstance(SourceFilters.MIN_MAG);
+		filterManager.setEnabled(SourceFilters.MIN_MAG, true);
+		checkEnabledFitlers(filter);
+		doTestMagFilter(filter);
+		
+		filter.setMinMagnitude(0d);
+		int rupsWith0 = doTestMagFilter(filter);
+		
+		filter.setMinMagnitude(8d);
+		int rupsWith8 = doTestMagFilter(filter);
+		
+		assertTrue("Ruptures include with minMag=8 should be less than with minMag=0", rupsWith8 < rupsWith0);
+		
+		filter.setMinMagnitude(5d);
+		doTestMagFilter(filter);
+	}
+	
+	private int doTestMagFilter(MinMagFilter filter) {
+		double minMag = filter.getMinMagnitude();
+		for (ProbEqkSource source : erf.sources) {
+			double dist = source.getMinDistance(testSite);
+			assertFalse("Minimum magnitude filter should never exclude a whole source (applied to ruptures)",
+				filter.canSkipSource(source, testSite, dist));
+			for (ProbEqkRupture rup : source)
+				assertEquals(rup.getMag() < minMag, filter.canSkipRupture(rup, testSite));
+		}
+		return doTestHazardCalc();
+	}
+	
+	@Test
+	public void testFilterByMagDist() {
+		disableAllFilters();
+		MagDependentDistCutoffFilter filter = (MagDependentDistCutoffFilter)
+				filterManager.getFilterInstance(SourceFilters.MAG_DIST_CUTOFFS);
+		filterManager.setEnabled(SourceFilters.MAG_DIST_CUTOFFS, true);
+		checkEnabledFitlers(filter);
+		int numWithDefault = doTestMagDistFilter(filter);
+		
+		ArbitrarilyDiscretizedFunc func = filter.getMagDistFunc();
+		ArbitrarilyDiscretizedFunc origFunc = func.deepClone();
+		func.clear();
+		for (int i=0; i<origFunc.size(); i++)
+			func.set(10000d+i, origFunc.getY(i));
+		int numWithLarge = doTestMagDistFilter(filter);
+		assertTrue("Fewer ruptures should be include with default mag-dist ("+numWithDefault+") than large ("+numWithLarge+")", numWithDefault < numWithLarge);
+		
+		func.clear();
+		for (int i=0; i<origFunc.size(); i++)
+			func.set(0.01d*i, origFunc.getY(i));
+		int numWithSmall = doTestMagDistFilter(filter);
+		assertTrue("Fewer ruptures should be include with small distance than large", numWithSmall < numWithLarge);
+		
+		func.clear();
+		for (int i=0; i<origFunc.size(); i++)
+			func.set(origFunc.getX(i), origFunc.getY(i));
+		doTestMagDistFilter(filter);
+	}
+	
+	private int doTestMagDistFilter(MagDependentDistCutoffFilter filter) {
+		ArbitrarilyDiscretizedFunc func = filter.getMagDistFunc();
+		for (ProbEqkSource source : erf.sources) {
+			double dist = source.getMinDistance(testSite);
+			assertFalse("Mag-Dist filter should never exclude a whole source (applied to ruptures)",
+					filter.canSkipSource(source, testSite, dist));
+			for (ProbEqkRupture rup : source) {
+				dist = rup.getRuptureSurface().getQuickDistance(testSite.getLocation());
+				boolean skip;
+				double mag = rup.getMag();
+				if (dist < func.getMinX()) {
+					// closer than the smallest cutoff, don't skip
+					skip = false;
+				} else if (dist > func.getMaxX()) {
+					// further than the largest cutoff, always skip
+					skip = true;
+				} else {
+					double magThresh = func.getInterpolatedY(dist);
+					// skip if the magnitude is less than the distance-dependent threshold
+					skip = mag < magThresh;
+				}
+				assertEquals(skip, filter.canSkipRupture(rup, testSite));
+			}
+		}
+		return doTestHazardCalc();
+	}
+	
+	@Test
+	public void testCalcWithoutFilters() {
+		disableAllFilters();
+		checkEnabledFitlers();
+		int num = doTestHazardCalc();
+		int numRups = 0;
+		for (ProbEqkSource source : erf)
+			numRups += source.getNumRuptures();
+		assertEquals("All filters were disabled but some ruptures were still skipped?", numRups, num);
+	}
+	
+	private void checkEnabledFitlers(SourceFilter... filters) {
+		List<SourceFilter> reportedFitlers = filterManager.getEnabledFilters();
+		if (filters == null || filters.length == 0) {
+			assertTrue("No filters should be enabled", reportedFitlers == null || reportedFitlers.isEmpty());
+		} else {
+			assertEquals("Expected "+filters.length+" filters, but "+reportedFitlers.size()+" were enabled",
+					filters.length, reportedFitlers.size());
+			for (SourceFilter filter : filters)
+				assertTrue(reportedFitlers.contains(filter));
+		}
+	}
+	
+	private int doTestHazardCalc() {
+		for (AccessTrackingPointEqkSource source : erf.sources)
+			source.clearAccess();
+		calc.getHazardCurve(xVals, testSite, testIMR, erf);
+		List<SourceFilter> filters = filterManager.getEnabledFilters();
+		int rupsIncluded = 0;
+		for (AccessTrackingPointEqkSource source : erf.sources) {
+			if (filters == null || filters.isEmpty()) {
+				assertTrue("There are no filters enabled, but source wasn't accessed?", source.hasSourceBeenAccessed());
+				for (AccessTrackingPointEqkRup rup : source.rups) {
+					assertTrue("There are no filters enabled, but rupture wasn't accessed?", rup.hasRupBeenAccessed());
+					rupsIncluded++;
+				}
+			} else {
+				boolean canSkipSource = false;
+				double dist = source.getMinDistance(testSite);
+				for (SourceFilter filter : filters) {
+					if (filter.canSkipSource(source, testSite, dist)) {
+						canSkipSource = true;
+						break;
+					}
+				}
+				if (canSkipSource) {
+					assertFalse("Source should have been skipped in hazard calculation, but was accessed", source.hasSourceBeenAccessed());
+				} else {
+					assertTrue("Source shouldn't have been skipped in hazard calculation, but wasn't accessed", source.hasSourceBeenAccessed());
+					for (AccessTrackingPointEqkRup rup : source.rups) {
+						boolean canSkipRup = false;
+						for (SourceFilter filter : filters) {
+							if (filter.canSkipRupture(rup, testSite)) {
+								canSkipRup = true;
+								break;
+							}
+						}
+						if (canSkipRup) {
+							assertFalse("Rupture should have been skipped in hazard calculation, but was accessed", rup.hasRupBeenAccessed());
+						} else {
+							assertTrue("Rupture shouldn't have been skipped in hazard calculation, but wasn't accessed", rup.hasRupBeenAccessed());
+							rupsIncluded++;
+						}
+					}
+				}
+			}
+		}
+		
+		if (rupsIncluded > 0)
+			assertTrue("We had "+rupsIncluded+" included rups, but hazard curve is all zero", xVals.calcSumOfY_Vals() > 0d);
+		else
+			assertTrue("We had no included rups, but hazard curve is nonzero", xVals.calcSumOfY_Vals() == 0d);
+		return rupsIncluded;
+	}
+
+}


### PR DESCRIPTION
This introduces a new `SourceFilter` interface and adds a tectonic-region specific distance filter option. A new GUI has been created for selecting and modifying the various filter options. The default implementation remains unchanged for now (fixed distance of 200 km).

`SourceFilter`s can filter at the source and/or rupture level. The tectonic region distance filter only applies to sources as ruptures don't currently know their tectonic region.

Because event sets are created by the ERF, I added a new `ERF.drawRandomEventSet(Site, Collection<SourceFilter>)` method that respects these filters. HazardCurveCalculator uses this new method.

Finally, this updated implementation can introduce one very minor change to hazard curve calculations for sources where the source surface is larger than individual rupture surfaces. Previously, in full probabilistic calculations (but not in event set calculations), all rupture of a source would be included if the source surface is within the distance cutoff. That was true even if individual ruptures were further than the distance cutoff. The new implementation checks distances at both the source and rupture level, which means that event set calculations will now use the same filtering scheme as full probabilistic. But a few ruptures that may have been included in earlier full probabilistic calculations may now be excluded.