### PR TITLE
OutputCSVFile for writing large CSV files.

### DIFF
--- a/src/main/java/org/opensha/commons/data/CSVFile.java
+++ b/src/main/java/org/opensha/commons/data/CSVFile.java
@@ -30,7 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Doubles;
 
-public class CSVFile<E> implements Iterable<List<E>>, CSVWriter {
+public class CSVFile<E> implements Iterable<List<E>> {
 	
 	private List<List<E>> values;
 //	private List<String> colNames;
@@ -259,7 +259,6 @@ public class CSVFile<E> implements Iterable<List<E>>, CSVWriter {
 	 * @param stream
 	 * @throws IOException
 	 */
-	@Override
 	public void writeToStream(OutputStream stream) throws IOException {
 		if (!(stream instanceof BufferedOutputStream))
 			stream = new BufferedOutputStream(stream);

--- a/src/main/java/org/opensha/commons/data/CSVFile.java
+++ b/src/main/java/org/opensha/commons/data/CSVFile.java
@@ -30,7 +30,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Doubles;
 
-public class CSVFile<E> implements Iterable<List<E>> {
+public class CSVFile<E> implements Iterable<List<E>>, CSVWriter {
 	
 	private List<List<E>> values;
 //	private List<String> colNames;
@@ -259,6 +259,7 @@ public class CSVFile<E> implements Iterable<List<E>> {
 	 * @param stream
 	 * @throws IOException
 	 */
+	@Override
 	public void writeToStream(OutputStream stream) throws IOException {
 		if (!(stream instanceof BufferedOutputStream))
 			stream = new BufferedOutputStream(stream);

--- a/src/main/java/org/opensha/commons/data/CSVReader.java
+++ b/src/main/java/org/opensha/commons/data/CSVReader.java
@@ -1,175 +1,89 @@
 package org.opensha.commons.data;
 
-import com.google.common.base.Preconditions;
-
 import java.io.*;
 import java.util.*;
 
 /**
- * Memory efficient CSV reader. Not thread safe.
- * Calling next() advances the reader to the next row.
- * get*() methods can be used to get values from the columns of the current row.
- * next() must have been called at least once before a call to a get*() method.
+ * CSV reader that allows for CSV files to be read directly instead of
+ * having to load a potentially large intermediate structure into memory.
  */
 public class CSVReader implements Closeable {
 
-    protected LargeLineBuffer buffer;
+    protected BufferedReader reader;
 
-    // the data of the current row
-    protected List<String> line = null;
-
-    public CSVReader(InputStream in) throws IOException {
-        buffer = LargeLineBuffer.fromStream(in);
+    public CSVReader(InputStream in) {
+        reader = new BufferedReader(new InputStreamReader(in));
     }
 
     /**
-     * Advances the reader to the next row.
+     * Reads the next row.
      *
-     * @return true if the row exists, false if the end of the data has been reached.
+     * @return the row. Returns null if the end of the file has been reached.
      */
-    public boolean next() {
-        String bufferLine;
+    public Row read() {
+        String line;
         try {
-            bufferLine = buffer.readLine();
+            line = reader.readLine();
         } catch (IOException x) {
             throw new RuntimeException(x);
         }
-        if (bufferLine == null) {
-            return false;
+        if (line == null) {
+            return null;
         }
 
-        line = CSVFile.loadLine(bufferLine);
-        return true;
-    }
-
-    /**
-     * Get the number of rows in the CSV file.
-     *
-     * @return the number of rows
-     */
-    public int getNumRows() {
-        return buffer.getLineCount();
-    }
-
-    /**
-     * Get the data of the specified column in the current row.
-     *
-     * @param column the column index, 0-based
-     * @return the value as an unparsed string.
-     */
-    public String get(int column) {
-        return line.get(column);
-    }
-
-    /**
-     * Get an int values from the current row at the specified column.
-     *
-     * @param column the column index, 0-based
-     * @return the int value of the column
-     */
-    public int getInt(int column) {
-        return Integer.parseInt(get(column).trim());
-    }
-
-    /**
-     * Get a double value from the current row at the specified column.
-     *
-     * @param column the column index, 0-based
-     * @return the double value of the column
-     */
-    public double getDouble(int column) {
-        return Double.parseDouble(get(column).trim());
-    }
-
-    /**
-     * Gets all values of the current row.
-     *
-     * @return a list of all column values
-     */
-    public List<String> getLine() {
-        return line;
+        return new Row(line);
     }
 
     @Override
     public void close() throws IOException {
-        buffer = null;
-        line = null;
+        reader.close();
     }
 
-    /**
-     * A helper class to store the lines of a CSV file in memory. This is to avoid expanding each line into List<String>
-     *     which can be memory expensive.
-     * Java arrays can only store up to 2.1 billion entries, meaning we use a list of byte arrays in order to store files
-     * larger than 2 GB.
-     */
-    protected static class LargeLineBuffer {
-        protected List<byte[]> buffers = new ArrayList<>();
-        protected int lineCount = 0;
-        protected ByteArrayOutputStream outBuffer;
-        protected Writer out;
+    public static class Row {
 
-        BufferedReader reader;
-        int readBuffer = 0;
+        // the data of the current row
+        protected final List<String> line;
 
-        public LargeLineBuffer() {
-            outBuffer = new ByteArrayOutputStream();
-            out = new OutputStreamWriter(outBuffer);
+        Row(String row) {
+            this.line = CSVFile.loadLine(row);
         }
 
-        public static LargeLineBuffer fromStream(InputStream is)
-                throws IOException {
-            if (!(is instanceof BufferedInputStream))
-                is = new BufferedInputStream(is);
-            BufferedReader br = new BufferedReader(new InputStreamReader(is));
-            LargeLineBuffer buffer = new LargeLineBuffer();
-            String line = br.readLine();
-            while (line != null) {
-                buffer.append(line);
-                line = br.readLine();
-            }
-            br.close();
-            buffer.finalise();
-            return buffer;
+        /**
+         * Get the data of the specified column
+         *
+         * @param column the column index, 0-based
+         * @return the value as an unparsed string.
+         */
+        public String get(int column) {
+            return line.get(column);
         }
 
-        public void append(String line) throws IOException {
-            Preconditions.checkState(out != null, "Buffer is finalised.");
-            if (outBuffer.size() > Integer.MAX_VALUE - 1_000_000) {
-                buffers.add(outBuffer.toByteArray());
-                outBuffer = new ByteArrayOutputStream();
-                out = new OutputStreamWriter(outBuffer);
-            }
-            lineCount++;
-            out.write(line);
-            out.write('\n');
-            out.flush();
+        /**
+         * Get an int value at the specified column.
+         *
+         * @param column the column index, 0-based
+         * @return the int value of the column
+         */
+        public int getInt(int column) {
+            return Integer.parseInt(get(column).trim());
         }
 
-        public int getLineCount() {
-            return lineCount;
+        /**
+         * Get a double value at the specified column.
+         *
+         * @param column the column index, 0-based
+         * @return the double value of the column
+         */
+        public double getDouble(int column) {
+            return Double.parseDouble(get(column).trim());
         }
 
-        public void finalise() {
-            buffers.add(outBuffer.toByteArray());
-            outBuffer = null;
-            out = null;
-        }
-
-        public String readLine() throws IOException {
-            Preconditions.checkState(out == null, "Buffer is not finalised");
-            if (reader == null) {
-                if (readBuffer >= buffers.size()) {
-                    return null;
-                }
-                reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(buffers.get(readBuffer))));
-                readBuffer++;
-            }
-            String line = reader.readLine();
-            if (line == null) {
-                reader.close();
-                reader = null;
-                return readLine();
-            }
+        /**
+         * Get all values as strings.
+         *
+         * @return a list of all column values
+         */
+        public List<String> getLine() {
             return line;
         }
     }

--- a/src/main/java/org/opensha/commons/data/CSVReader.java
+++ b/src/main/java/org/opensha/commons/data/CSVReader.java
@@ -1,0 +1,176 @@
+package org.opensha.commons.data;
+
+import com.google.common.base.Preconditions;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * Memory efficient CSV reader. Not thread safe.
+ * Calling next() advances the reader to the next row.
+ * get*() methods can be used to get values from the columns of the current row.
+ * next() must have been called at least once before a call to a get*() method.
+ */
+public class CSVReader implements Closeable {
+
+    protected LargeLineBuffer buffer;
+
+    // the data of the current row
+    protected List<String> line = null;
+
+    public CSVReader(InputStream in) throws IOException {
+        buffer = LargeLineBuffer.fromStream(in);
+    }
+
+    /**
+     * Advances the reader to the next row.
+     *
+     * @return true if the row exists, false if the end of the data has been reached.
+     */
+    public boolean next() {
+        String bufferLine;
+        try {
+            bufferLine = buffer.readLine();
+        } catch (IOException x) {
+            throw new RuntimeException(x);
+        }
+        if (bufferLine == null) {
+            return false;
+        }
+
+        line = CSVFile.loadLine(bufferLine);
+        return true;
+    }
+
+    /**
+     * Get the number of rows in the CSV file.
+     *
+     * @return the number of rows
+     */
+    public int getNumRows() {
+        return buffer.getLineCount();
+    }
+
+    /**
+     * Get the data of the specified column in the current row.
+     *
+     * @param column the column index, 0-based
+     * @return the value as an unparsed string.
+     */
+    public String get(int column) {
+        return line.get(column);
+    }
+
+    /**
+     * Get an int values from the current row at the specified column.
+     *
+     * @param column the column index, 0-based
+     * @return the int value of the column
+     */
+    public int getInt(int column) {
+        return Integer.parseInt(get(column).trim());
+    }
+
+    /**
+     * Get a double value from the current row at the specified column.
+     *
+     * @param column the column index, 0-based
+     * @return the double value of the column
+     */
+    public double getDouble(int column) {
+        return Double.parseDouble(get(column).trim());
+    }
+
+    /**
+     * Gets all values of the current row.
+     *
+     * @return a list of all column values
+     */
+    public List<String> getLine() {
+        return line;
+    }
+
+    @Override
+    public void close() throws IOException {
+        buffer = null;
+        line = null;
+    }
+
+    /**
+     * A helper class to store the lines of a CSV file in memory. This is to avoid expanding each line into List<String>
+     *     which can be memory expensive.
+     * Java arrays can only store up to 2.1 billion entries, meaning we use a list of byte arrays in order to store files
+     * larger than 2 GB.
+     */
+    protected static class LargeLineBuffer {
+        protected List<byte[]> buffers = new ArrayList<>();
+        protected int lineCount = 0;
+        protected ByteArrayOutputStream outBuffer;
+        protected Writer out;
+
+        BufferedReader reader;
+        int readBuffer = 0;
+
+        public LargeLineBuffer() {
+            outBuffer = new ByteArrayOutputStream();
+            out = new OutputStreamWriter(outBuffer);
+        }
+
+        public static LargeLineBuffer fromStream(InputStream is)
+                throws IOException {
+            if (!(is instanceof BufferedInputStream))
+                is = new BufferedInputStream(is);
+            BufferedReader br = new BufferedReader(new InputStreamReader(is));
+            LargeLineBuffer buffer = new LargeLineBuffer();
+            String line = br.readLine();
+            while (line != null) {
+                buffer.append(line);
+                line = br.readLine();
+            }
+            br.close();
+            buffer.finalise();
+            return buffer;
+        }
+
+        public void append(String line) throws IOException {
+            Preconditions.checkState(out != null, "Buffer is finalised.");
+            if (outBuffer.size() > Integer.MAX_VALUE - 1_000_000) {
+                buffers.add(outBuffer.toByteArray());
+                outBuffer = new ByteArrayOutputStream();
+                out = new OutputStreamWriter(outBuffer);
+            }
+            lineCount++;
+            out.write(line);
+            out.write('\n');
+            out.flush();
+        }
+
+        public int getLineCount() {
+            return lineCount;
+        }
+
+        public void finalise() {
+            buffers.add(outBuffer.toByteArray());
+            outBuffer = null;
+            out = null;
+        }
+
+        public String readLine() throws IOException {
+            Preconditions.checkState(out == null, "Buffer is not finalised");
+            if (reader == null) {
+                if (readBuffer >= buffers.size()) {
+                    return null;
+                }
+                reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(buffers.get(readBuffer))));
+                readBuffer++;
+            }
+            String line = reader.readLine();
+            if (line == null) {
+                reader.close();
+                reader = null;
+                return readLine();
+            }
+            return line;
+        }
+    }
+}

--- a/src/main/java/org/opensha/commons/data/CSVWriter.java
+++ b/src/main/java/org/opensha/commons/data/CSVWriter.java
@@ -1,0 +1,74 @@
+package org.opensha.commons.data;
+
+import com.google.common.base.Preconditions;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.Stream;
+
+/**
+ * A CSVFile for sequentially writing large CSV data to file in a memory efficient way while avoiding storing
+ * intermediate internal List<String> representations.
+ * This interface is not meant for manipulating or querying CSV data.
+ */
+
+public interface CSVWriter {
+
+    /**
+     * Writes the CSV file to the given output stream. The stream will not be closed.
+     *
+     * @param stream
+     * @throws IOException
+     */
+    void writeToStream(OutputStream out) throws IOException;
+
+    /**
+     * A CSVWriter based on a lazy stream of List<String> objects.
+     * Usage: Instead of creating a CSVFile and repeatedly calling addline(), create a stream of List<String> objects
+     * and pass the stream into the constructor. In effect, this is like passing a function that can lazily produce
+     * all CSV lines.
+     */
+    class CSVWriterStream implements CSVWriter {
+
+        Stream<List<String>> stream;
+        boolean strictRowSizes;
+        int cols = 0;
+
+        public CSVWriterStream(Stream<List<String>> lines, boolean strictRowSizes) {
+            this.stream = lines;
+            this.strictRowSizes = strictRowSizes;
+        }
+
+        protected boolean validateLine(List<String> line) {
+            if (!strictRowSizes) {
+                return true;
+            }
+
+            if (cols == 0) {
+                cols = line.size();
+            }
+
+            Preconditions.checkArgument(line.size() == cols, "New line must contain" +
+                    " same number of values as columns (expected " + cols + ", got " + line.size() + ")");
+
+            return true;
+        }
+
+        @Override
+        public void writeToStream(OutputStream out) throws IOException {
+            OutputStreamWriter writer = new OutputStreamWriter(out);
+            stream.
+                    filter(this::validateLine).
+                    map(CSVFile::getLineStr).
+                    forEach(line -> {
+                        try {
+                            writer.write(line);
+                            writer.write('\n');
+                        } catch (IOException x) {
+                            throw new RuntimeException(x);
+                        }
+                    });
+            writer.flush();
+        }
+    }
+}

--- a/src/main/java/org/opensha/commons/util/modules/helpers/CSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/CSV_BackedModule.java
@@ -7,6 +7,8 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.data.CSVReader;
+import org.opensha.commons.data.CSVWriter;
 import org.opensha.commons.util.modules.ArchivableModule;
 import org.opensha.commons.util.modules.ModuleHelper;
 
@@ -42,7 +44,7 @@ public interface CSV_BackedModule extends FileBackedModule {
 		initFromCSV(csv);
 	}
 	
-	public static void writeToArchive(CSVFile<?> csv, ZipOutputStream zout, String entryPrefix, String fileName)
+	public static void writeToArchive(CSVWriter csv, ZipOutputStream zout, String entryPrefix, String fileName)
 			throws IOException {
 		FileBackedModule.initEntry(zout, entryPrefix, fileName);
 		BufferedOutputStream out = new BufferedOutputStream(zout);
@@ -56,6 +58,15 @@ public interface CSV_BackedModule extends FileBackedModule {
 		
 		CSVFile<String> csv = CSVFile.readStream(zin, false);
 		
+		zin.close();
+		return csv;
+	}
+
+	public static CSVReader loadLargeFileFromArchive(ZipFile zip, String entryPrefix, String fileName) throws IOException {
+		BufferedInputStream zin = FileBackedModule.getInputStream(zip, entryPrefix, fileName);
+
+		CSVReader csv = new CSVReader(zin);
+
 		zin.close();
 		return csv;
 	}

--- a/src/main/java/org/opensha/commons/util/modules/helpers/CSV_BackedModule.java
+++ b/src/main/java/org/opensha/commons/util/modules/helpers/CSV_BackedModule.java
@@ -8,7 +8,6 @@ import java.util.zip.ZipOutputStream;
 
 import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.data.CSVReader;
-import org.opensha.commons.data.CSVWriter;
 import org.opensha.commons.util.modules.ArchivableModule;
 import org.opensha.commons.util.modules.ModuleHelper;
 
@@ -44,7 +43,7 @@ public interface CSV_BackedModule extends FileBackedModule {
 		initFromCSV(csv);
 	}
 	
-	public static void writeToArchive(CSVWriter csv, ZipOutputStream zout, String entryPrefix, String fileName)
+	public static void writeToArchive(CSVFile<?> csv, ZipOutputStream zout, String entryPrefix, String fileName)
 			throws IOException {
 		FileBackedModule.initEntry(zout, entryPrefix, fileName);
 		BufferedOutputStream out = new BufferedOutputStream(zout);
@@ -52,7 +51,7 @@ public interface CSV_BackedModule extends FileBackedModule {
 		out.flush();
 		zout.closeEntry();
 	}
-	
+
 	public static CSVFile<String> loadFromArchive(ZipFile zip, String entryPrefix, String fileName) throws IOException {
 		BufferedInputStream zin = FileBackedModule.getInputStream(zip, entryPrefix, fileName);
 		
@@ -65,9 +64,6 @@ public interface CSV_BackedModule extends FileBackedModule {
 	public static CSVReader loadLargeFileFromArchive(ZipFile zip, String entryPrefix, String fileName) throws IOException {
 		BufferedInputStream zin = FileBackedModule.getInputStream(zip, entryPrefix, fileName);
 
-		CSVReader csv = new CSVReader(zin);
-
-		zin.close();
-		return csv;
+		return new CSVReader(zin);
 	}
 }

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -1,29 +1,29 @@
 package org.opensha.sha.earthquake.faultSysSolution;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 import javax.annotation.Nullable;
 
 import org.apache.commons.math3.stat.StatUtils;
+import org.checkerframework.common.value.qual.IntRange;
 import org.dom4j.DocumentException;
 import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.data.CSVReader;
+import org.opensha.commons.data.CSVWriter;
 import org.opensha.commons.geo.LocationList;
 import org.opensha.commons.geo.Region;
 import org.opensha.commons.geo.RegionUtils;
@@ -69,8 +69,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
 
-import scratch.UCERF3.enumTreeBranches.SlipAlongRuptureModels;
-import scratch.UCERF3.griddedSeismicity.AbstractGridSourceProvider;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSetFactory;
 import scratch.UCERF3.logicTree.U3LogicTreeBranch;
 import scratch.UCERF3.utils.U3FaultSystemIO;
@@ -315,9 +313,8 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 	
 	public static final String RUP_SECTS_FILE_NAME = "indices.csv";
 	
-	public static CSVFile<String> buildRupSectsCSV(FaultSystemRupSet rupSet) {
-		CSVFile<String> csv = new CSVFile<>(false);
 		
+	public static CSVWriter buildRupSectsCSV(FaultSystemRupSet rupSet) {
 		int maxNumSects = 0;
 		for (int r=0; r<rupSet.getNumRuptures(); r++)
 			maxNumSects = Integer.max(maxNumSects, rupSet.getSectionsIndicesForRup(r).size());
@@ -326,21 +323,25 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 		
 		for (int s=0; s<maxNumSects; s++)
 			header.add("# "+(s+1));
-		
-		csv.addLine(header);
-		
-		for (int r=0; r<rupSet.getNumRuptures(); r++) {
-			List<Integer> sectIDs = rupSet.getSectionsIndicesForRup(r);
-			List<String> line = new ArrayList<>(2+sectIDs.size());
-			
-			line.add(r+"");
-			line.add(sectIDs.size()+"");
-			for (int s : sectIDs)
-				line.add(s+"");
-			csv.addLine(line);
-		}
-		
-		return csv;
+
+		Stream<List<String>> lines = IntStream.
+				range(0, rupSet.getNumRuptures() + 1).
+				mapToObj(row -> {
+					if (row == 0) {
+						return header;
+					}
+					int ruptureId = row - 1;
+					List<Integer> sectIDs = rupSet.getSectionsIndicesForRup(ruptureId);
+					List<String> line = new ArrayList<>(2 + sectIDs.size());
+
+					line.add(ruptureId + "");
+					line.add(sectIDs.size() + "");
+					for (int s : sectIDs)
+						line.add(s + "");
+					return line;
+				});
+
+		return new CSVWriter.CSVWriterStream(lines, false);
 	}
 	
 	public static final String RUP_PROPS_FILE_NAME = "properties.csv";
@@ -398,61 +399,66 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 				areas[r] = rupSet.getAreaForRup(r);
 			}
 		}
-		
-		public CSVFile<String> buildCSV() {
-			CSVFile<String> csv = new CSVFile<>(true);
-			
+
+		public CSVWriter.CSVWriterStream buildCSV() {
+
 			List<String> header = new ArrayList<>(List.of("Rupture Index", "Magnitude", "Average Rake (degrees)",
 					"Area (m^2)", "Length (m)"));
-			
-			csv.addLine(header);
-			
-			for (int r=0; r<mags.length; r++) {
-				List<String> line = new ArrayList<>(5);
-				
-				line.add(r+"");
-				line.add(mags[r]+"");
-				line.add(rakes[r]+"");
-				line.add(areas[r]+"");
-				if (lengths == null)
-					line.add("");
-				else
-					line.add(lengths[r]+"");
-				csv.addLine(line);
-			}
-			
-			return csv;
+
+			Stream<List<String>> lines = IntStream.
+					range(0, mags.length + 1).
+					mapToObj(row -> {
+
+						if (row == 0) {
+							return header;
+						}
+						int ruptureId = row - 1;
+						List<String> line = new ArrayList<>(5);
+
+						line.add(ruptureId + "");
+						line.add(mags[ruptureId] + "");
+						line.add(rakes[ruptureId] + "");
+						line.add(areas[ruptureId] + "");
+						if (lengths == null)
+							line.add("");
+						else
+							line.add(lengths[ruptureId] + "");
+						return line;
+					});
+			return new CSVWriter.CSVWriterStream(lines, true);
 		}
 	}
 	
-	public static List<List<Integer>> loadRupSectsCSV(CSVFile<String> rupSectsCSV, int numSections) {
+	public static List<List<Integer>> loadRupSectsCSV(CSVReader rupSectsCSV, int numSections) {
 		int numRuptures = rupSectsCSV.getNumRows()-1;
 		List<List<Integer>> rupSectsList = new ArrayList<>(numRuptures);
 		boolean shortSafe = numSections < Short.MAX_VALUE;
+		rupSectsCSV.next();
 		for (int r=0; r<numRuptures; r++) {
 			int row = r+1;
 			int col = 0;
+			rupSectsCSV.next();
 			// load rupture sections
-			Preconditions.checkState(r == rupSectsCSV.getInt(row, col++),
+			Preconditions.checkState(r == rupSectsCSV.getInt(col++),
 					"Ruptures out of order or not 0-based in CSV file, expected id=%s at row %s", r, row);
-			int numRupSects = rupSectsCSV.getInt(row, col++);
+			int numRupSects = rupSectsCSV.getInt(col++);
 			Preconditions.checkState(numRupSects > 0, "Rupture %s has no sections!", r);
 			List<Integer> rupSects;
 			if (shortSafe) {
 				short[] sectIDs = new short[numRupSects];
 				for (int i=0; i<numRupSects; i++)
-					sectIDs[i] = (short)rupSectsCSV.getInt(row, col++);
+					sectIDs[i] = (short)rupSectsCSV.getInt(col++);
 				rupSects = new ShortListWrapper(sectIDs);
 			} else {
 				int[] sectIDs = new int[numRupSects];
 				for (int i=0; i<numRupSects; i++)
-					sectIDs[i] = rupSectsCSV.getInt(row, col++);
+					sectIDs[i] = rupSectsCSV.getInt(col++);
 				rupSects = new IntListWrapper(sectIDs);
 			}
-			int rowSize = rupSectsCSV.getLine(row).size();
+			int rowSize = rupSectsCSV.getLine().size();
 			while (col < rowSize) {
 				// make sure any further columns are empty
-				String str = rupSectsCSV.get(row, col++);
+				String str = rupSectsCSV.get(col++);
 				Preconditions.checkState(str.isBlank(),
 						"Rupture has %s sections, but data exists in %s column %s: %s", RUP_SECTS_FILE_NAME, col, str);
 			}
@@ -467,7 +473,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 	@Override
 	public final void initFromArchive(ZipFile zip, String entryPrefix) throws IOException {
 		System.out.println("\tLoading ruptures CSV...");
-		CSVFile<String> rupSectsCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, RUP_SECTS_FILE_NAME);
+		CSVReader rupSectsCSV = CSV_BackedModule.loadLargeFileFromArchive(zip, entryPrefix, RUP_SECTS_FILE_NAME);
 		CSVFile<String> rupPropsCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, RUP_PROPS_FILE_NAME);
 		
 		// fault sections

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -25,6 +25,7 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
 import org.opensha.commons.data.CSVFile;
+import org.opensha.commons.data.CSVReader;
 import org.opensha.commons.geo.GriddedRegion;
 import org.opensha.commons.geo.json.Feature;
 import org.opensha.commons.logicTree.BranchWeightProvider;
@@ -1197,7 +1198,7 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 			rupIndices = prevRupIndices;
 		} else {
 			System.out.println("\tLoading rupture indices from "+indicesFile);
-			CSVFile<String> rupSectsCSV = CSV_BackedModule.loadFromArchive(zip, entryPrefix, indicesFile);
+			CSVReader rupSectsCSV = CSV_BackedModule.loadLargeFileFromArchive(zip, entryPrefix, indicesFile);
 			rupIndices = FaultSystemRupSet.loadRupSectsCSV(rupSectsCSV, subSects.size());
 			prevRupIndices = rupIndices;
 			prevIndicesFile = indicesFile;

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/SolutionLogicTree.java
@@ -24,6 +24,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import org.opensha.commons.data.CSVWriter;
 import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.data.CSVReader;
 import org.opensha.commons.geo.GriddedRegion;
@@ -860,13 +861,21 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 		
 		String indicesFile = getRecordBranchFileName(branch, prefix, FaultSystemRupSet.RUP_SECTS_FILE_NAME, true, mappings);
 		if (!writtenFiles.contains(indicesFile)) {
-			CSV_BackedModule.writeToArchive(FaultSystemRupSet.buildRupSectsCSV(rupSet), zout, entryPrefix, indicesFile);
+			FileBackedModule.initEntry(zout, entryPrefix, indicesFile);
+			CSVWriter entryWriter = new CSVWriter(zout, false);
+			FaultSystemRupSet.buildRupSectsCSV(rupSet,entryWriter);
+			entryWriter.flush();
+			zout.closeEntry();
 			writtenFiles.add(indicesFile);
 		}
 		
 		String propsFile = getRecordBranchFileName(branch, prefix, FaultSystemRupSet.RUP_PROPS_FILE_NAME, true, mappings);
 		if (!writtenFiles.contains(propsFile)) {
-			CSV_BackedModule.writeToArchive(new RuptureProperties(rupSet).buildCSV(), zout, entryPrefix, propsFile);
+			FileBackedModule.initEntry(zout, entryPrefix, propsFile);
+			CSVWriter entryWriter = new CSVWriter(zout, true);
+			new RuptureProperties(rupSet).buildCSV(entryWriter);
+			entryWriter.flush();
+			zout.closeEntry();
 			writtenFiles.add(propsFile);
 		}
 		
@@ -1190,7 +1199,9 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 			prevSubSects = subSects;
 			prevSectsFile = sectsFile;
 		}
-		
+
+		RuptureProperties props = loadPropsForBranch(branch);
+
 		String indicesFile = getBranchFileName(branch, FaultSystemRupSet.RUP_SECTS_FILE_NAME, true);
 		List<List<Integer>> rupIndices;
 		if (prevRupIndices != null && indicesFile.equals(prevIndicesFile)) {
@@ -1199,13 +1210,11 @@ public class SolutionLogicTree extends AbstractLogicTreeModule {
 		} else {
 			System.out.println("\tLoading rupture indices from "+indicesFile);
 			CSVReader rupSectsCSV = CSV_BackedModule.loadLargeFileFromArchive(zip, entryPrefix, indicesFile);
-			rupIndices = FaultSystemRupSet.loadRupSectsCSV(rupSectsCSV, subSects.size());
+			rupIndices = FaultSystemRupSet.loadRupSectsCSV(rupSectsCSV, subSects.size(), props.mags.length);
 			prevRupIndices = rupIndices;
 			prevIndicesFile = indicesFile;
 		}
-		
-		RuptureProperties props = loadPropsForBranch(branch);
-		
+
 		FaultSystemRupSet rupSet = new FaultSystemRupSet(subSects, rupIndices,
 				props.mags, props.rakes, props.areas, props.lengths);
 		if (process && processor != null)

--- a/src/test/java/org/opensha/commons/data/CSVReaderTests.java
+++ b/src/test/java/org/opensha/commons/data/CSVReaderTests.java
@@ -17,15 +17,16 @@ public class CSVReaderTests {
                         + "1,2,3";
         CSVReader reader = new CSVReader(new ByteArrayInputStream(sourceCSV.getBytes(StandardCharsets.UTF_8)));
 
-        assertEquals(2, reader.getNumRows());
-        assertTrue(reader.next());
-        assertEquals("a", reader.get(0));
-        assertEquals(1, reader.getInt(1));
-        assertEquals(2.3, reader.getDouble(2), 0.0000000001);
-        assertEquals(" a comma,", reader.get(3));
-        assertEquals(" the end", reader.get(4));
-        assertTrue(reader.next());
-        assertEquals(1, reader.getInt(0));
-        assertFalse(reader.next());
+        CSVReader.Row row = reader.read();
+        assertNotNull(row);
+        assertEquals("a", row.get(0));
+        assertEquals(1, row.getInt(1));
+        assertEquals(2.3, row.getDouble(2), 0.0000000001);
+        assertEquals(" a comma,", row.get(3));
+        assertEquals(" the end", row.get(4));
+        row = reader.read();
+        assertNotNull(row);
+        assertEquals(1, row.getInt(0));
+        assertNull(reader.read());
     }
 }

--- a/src/test/java/org/opensha/commons/data/CSVReaderTests.java
+++ b/src/test/java/org/opensha/commons/data/CSVReaderTests.java
@@ -1,0 +1,31 @@
+package org.opensha.commons.data;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class CSVReaderTests {
+
+    @Test
+    public final void testRead() throws IOException {
+        String sourceCSV =
+                          "a, 1, 2.3, \"a comma,\", the end\n"
+                        + "1,2,3";
+        CSVReader reader = new CSVReader(new ByteArrayInputStream(sourceCSV.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(2, reader.getNumRows());
+        assertTrue(reader.next());
+        assertEquals("a", reader.get(0));
+        assertEquals(1, reader.getInt(1));
+        assertEquals(2.3, reader.getDouble(2), 0.0000000001);
+        assertEquals(" a comma,", reader.get(3));
+        assertEquals(" the end", reader.get(4));
+        assertTrue(reader.next());
+        assertEquals(1, reader.getInt(0));
+        assertFalse(reader.next());
+    }
+}

--- a/src/test/java/org/opensha/commons/data/CSVWriterTests.java
+++ b/src/test/java/org/opensha/commons/data/CSVWriterTests.java
@@ -2,10 +2,8 @@ package org.opensha.commons.data;
 
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.Arrays;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -13,60 +11,46 @@ public class CSVWriterTests {
 
     @Test
     public void testWrite() throws IOException {
-        List<List<String>> csvLines =
-        Arrays.asList(
-                Arrays.asList("a", "b", "c"),
-                Arrays.asList("1", "2")
-        );
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), false);
+        CSVWriter writer = new CSVWriter(out, false);
+        writer.write(Arrays.asList("a", "b", "c"));
+        writer.write(Arrays.asList("1", "2"));
+        writer.flush();
 
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        writer.writeToStream(buffer);
-        assertEquals("a,b,c\n1,2\n", buffer.toString());
+        assertEquals("a,b,c\n1,2\n", out.toString());
     }
 
     @Test
     public void testWriteSpecialChars() throws IOException {
-        List<List<String>> csvLines =
-                Arrays.asList(
-                        Arrays.asList("a", "b, and more ", "c"),
-                        Arrays.asList("1", "2")
-                );
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), false);
+        CSVWriter writer = new CSVWriter(out, false);
+        writer.write(Arrays.asList("a", "b, and more ", "c"));
+        writer.write(Arrays.asList("1", "2"));
+        writer.flush();
 
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        writer.writeToStream(buffer);
-        assertEquals("a,\"b, and more \",c\n1,2\n", buffer.toString());
+        assertEquals("a,\"b, and more \",c\n1,2\n", out.toString());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testWriteStrictRowSizesFail() throws IOException {
-        List<List<String>> csvLines =
-                Arrays.asList(
-                        Arrays.asList("a", "b", "c"),
-                        Arrays.asList("1", "2")
-                );
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), true);
-
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        writer.writeToStream(buffer);
+        CSVWriter writer = new CSVWriter(out, true);
+        writer.write(Arrays.asList("a", "b", "c"));
+        writer.write(Arrays.asList("1", "2"));
     }
 
     @Test
     public void testWriteStrictRowSizesPass() throws IOException {
-        List<List<String>> csvLines =
-                Arrays.asList(
-                        Arrays.asList("a", "b", "c"),
-                        Arrays.asList("1", "2", "3")
-                );
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), true);
+        CSVWriter writer = new CSVWriter(out, true);
+        writer.write(Arrays.asList("a", "b", "c"));
+        writer.write(Arrays.asList("1", "2", "3"));
+        writer.flush();
 
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        writer.writeToStream(buffer);
-        assertEquals("a,b,c\n1,2,3\n", buffer.toString());
+        assertEquals("a,b,c\n1,2,3\n", out.toString());
     }
 }

--- a/src/test/java/org/opensha/commons/data/CSVWriterTests.java
+++ b/src/test/java/org/opensha/commons/data/CSVWriterTests.java
@@ -1,0 +1,72 @@
+package org.opensha.commons.data;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class CSVWriterTests {
+
+    @Test
+    public void testWrite() throws IOException {
+        List<List<String>> csvLines =
+        Arrays.asList(
+                Arrays.asList("a", "b", "c"),
+                Arrays.asList("1", "2")
+        );
+
+        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), false);
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        writer.writeToStream(buffer);
+        assertEquals("a,b,c\n1,2\n", buffer.toString());
+    }
+
+    @Test
+    public void testWriteSpecialChars() throws IOException {
+        List<List<String>> csvLines =
+                Arrays.asList(
+                        Arrays.asList("a", "b, and more ", "c"),
+                        Arrays.asList("1", "2")
+                );
+
+        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), false);
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        writer.writeToStream(buffer);
+        assertEquals("a,\"b, and more \",c\n1,2\n", buffer.toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testWriteStrictRowSizesFail() throws IOException {
+        List<List<String>> csvLines =
+                Arrays.asList(
+                        Arrays.asList("a", "b", "c"),
+                        Arrays.asList("1", "2")
+                );
+
+        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), true);
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        writer.writeToStream(buffer);
+    }
+
+    @Test
+    public void testWriteStrictRowSizesPass() throws IOException {
+        List<List<String>> csvLines =
+                Arrays.asList(
+                        Arrays.asList("a", "b", "c"),
+                        Arrays.asList("1", "2", "3")
+                );
+
+        CSVWriter writer = new CSVWriter.CSVWriterStream(csvLines.stream(), true);
+
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        writer.writeToStream(buffer);
+        assertEquals("a,b,c\n1,2,3\n", buffer.toString());
+    }
+}

--- a/src/test/java/org/opensha/commons/data/DataSuite.java
+++ b/src/test/java/org/opensha/commons/data/DataSuite.java
@@ -16,6 +16,8 @@ import org.opensha.commons.geo.RegionTest;
 	TimeSpanTests.class,
 	XY_DataSetTests.class,
 	WeightedListTest.class,
+	CSVReaderTests.class,
+	CSVWriterTests.class,
 	
 	// siteData
 	SiteDataProvidersTest.class,


### PR DESCRIPTION
We've started to create large rupture sets while exploring joint ruptures. This is mostly due to the large number of sections in our subduction faults.

This PR introduces a `CSVWriter` and a `CSVReader` that allow us to write the generated ruptures to file without requiring tens of gigabytes of heap. This is mainly achieved by not populating the `List<List<E>> values` property of `CSVFile`. The largest `indices.csv` file we have written with this so far was 4.9GB on disk.