### PR TITLE
MagAreaRelationship is not thread safe

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/FaultSystemRupSet.java
@@ -1841,7 +1841,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 			this.mags = new double[sectionForRups.size()];
 			checkBuildRakesAndAreas();
 			checkBuildLengths();
-			IntStream.range(0, mags.length).parallel().forEach(r -> {
+			for (int r=0; r<mags.length; r++) {
 				double totOrigArea = 0;
 				for (int s : sectionForRups.get(r)) {
 					FaultSection sect = faultSectionData.get(s);
@@ -1849,7 +1849,7 @@ SubModule<ModuleArchive<OpenSHA_Module>> {
 				}
 				double origDDW = totOrigArea / rupLengths[r];
 				mags[r] = scale.getMag(rupAreas[r], rupLengths[r], rupAreas[r]/rupLengths[r], origDDW, rakes[r]);
-			});
+			}
 			modules.add(new ModuleBuilder() {
 				
 				@Override


### PR DESCRIPTION
My apologies, https://github.com/opensha/opensha/pull/113 needs to be partially reverted because magnitude calculation is not necessarily thread safe. This is because `MagAreaRelationship` may set the `rake` property before calculating the magnitude:

https://github.com/opensha/opensha/blob/master/src/main/java/org/opensha/commons/calc/magScalingRelations/MagAreaRelationship.java#L60