### PR TITLE
fix issue #134

### DIFF
--- a/src/test/java/org/opensha/sha/earthquake/faultSysSolution/modules/StandardFaultSysModulesTest.java
+++ b/src/test/java/org/opensha/sha/earthquake/faultSysSolution/modules/StandardFaultSysModulesTest.java
@@ -444,6 +444,7 @@ public class StandardFaultSysModulesTest {
 		withoutZip.close();
 		withZip.close();
 		rewrittenZip.close();
+		loaded.getInput().close();
 		
 		assertTrue("No unique files found for "+module.getName(), numTests > 0);
 	}


### PR DESCRIPTION
Fixes #134 by closing the `ModuleArchive`'s `'input` explicitly.

@kevinmilner do you think maybe `ModuleArchive` should be `Closeable` instead?

