### PR TITLE
Feature/346 build info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ db_log.log
 FaultSystemRupSets
 *.swp
 .~lock*
+build.gitremoteurl

--- a/build-common.gradle
+++ b/build-common.gradle
@@ -11,6 +11,8 @@ java {
 }
 compileJava.options.encoding = "UTF-8"
 
+apply from: 'build-git.gradle'
+
 repositories {
     mavenCentral()
     maven {
@@ -41,60 +43,6 @@ ext.getDate = {
     new Date().format('yyyy_MM_dd')
 }
 
-ext.getGitHash = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--short', 'HEAD'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
-    }
-}
-
-ext.getGitLongHash = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', 'HEAD'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
-    }
-}
-
-ext.getGitBranch = { ->
-    try {
-        def stdout = new ByteArrayOutputStream()
-        exec {
-            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
-            standardOutput = stdout
-        }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return ""
-    }
-}
-
-void writeBuildFiles() {
-    logger.info("Writing build.date file")
-    new File(projectDir, "build.date").text = new Date().toString()+"\n"+System.currentTimeMillis()+"\n"
-    String hash = getGitLongHash()
-    if (hash?.trim()) {
-        logger.info("Writing build.githash file: "+hash)
-        new File(projectDir, "build.githash").text = hash+"\n"
-    }
-    String branch = getGitBranch()
-    if (branch?.trim()) {
-        logger.info("Writing build.gitbranch file: "+branch)
-        new File(projectDir, "build.gitbranch").text = branch+"\n"
-    }
-}
-
 logger.info('running settings with project='+project.name+' and rootProject.name='+rootProject.name)
 if (project.parentProject != null) {
     logger.info(project.name+" is a child of: "+project.parentProject)
@@ -111,6 +59,7 @@ if (project.parentProject != null) {
         from(project.projectDir) {
             include 'build.githash'
             include 'build.gitbranch'
+            include 'build.gitremoteurl'
             include 'build.date'
         }
     }
@@ -132,6 +81,7 @@ if (project.parentProject != null) {
         from zipTree(file('../'+project.parentProject+'/build/libs/'+project.parentProject+'-all.jar')).matching {
             exclude 'build.githash'
             exclude 'build.gitbranch'
+            exclude 'build.gitremoteurl'
             exclude 'build.date'
         }
     
@@ -145,12 +95,19 @@ if (project.parentProject != null) {
             include 'build.version'
             include 'build.githash'
             include 'build.gitbranch'
+            include 'build.gitremoteurl'
             include 'build.date'
         }
     }
     task fatJar(type: Jar) {
         doFirst {
             writeBuildFiles()
+        }
+        doLast {
+            delete new File(projectDir, "build.githash")
+            delete new File(projectDir, "build.gitbranch")
+            delete new File(projectDir, "build.gitremoteurl")
+            delete new File(projectDir, "build.date")
         }
         archiveBaseName = project.name + '-all'
         // include all 'api' dependencies
@@ -186,6 +143,7 @@ void createAppTask(String taskName, String prefix, String mainClass) {
             from zipTree(file('../'+project.parentProject+'/build/libs/'+project.parentProject+'-all.jar')).matching {
                 exclude 'build.githash'
                 exclude 'build.gitbranch'
+                exclude 'build.gitremoteurl'
                 exclude 'build.date'
                 exclude { it.path.contains('META-INF') }
             }
@@ -196,6 +154,7 @@ void createAppTask(String taskName, String prefix, String mainClass) {
             from(project.projectDir) {
                 include 'build.githash'
                 include 'build.gitbranch'
+                include 'build.gitremoteurl'
                 include 'build.date'
             }
             manifest {
@@ -228,6 +187,7 @@ void createAppTask(String taskName, String prefix, String mainClass) {
             from(project.projectDir) {
                 include 'build.githash'
                 include 'build.gitbranch'
+                include 'build.gitremoteurl'
                 include 'build.date'
             }
             manifest {

--- a/build-git.gradle
+++ b/build-git.gradle
@@ -1,0 +1,85 @@
+ext.getGitHash = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--short', 'HEAD'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e) {
+        return ""
+    }
+}
+
+ext.getGitLongHash = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', 'HEAD'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e) {
+        return ""
+    }
+}
+
+ext.getGitBranch = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'rev-parse', '--abbrev-ref', 'HEAD'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e) {
+        return ""
+    }
+}
+
+ext.getGitRemoteUrl = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'name-rev', '--name-only', 'HEAD'
+            standardOutput = stdout
+        }
+        def branch = stdout.toString().trim()
+
+        stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'config', 'branch.' + branch + '.remote'
+            standardOutput = stdout
+        }
+        def remote = stdout.toString().trim()
+
+        stdout = new ByteArrayOutputStream()
+        exec {
+            commandLine 'git', 'config', 'remote.' + remote + '.url'
+            standardOutput = stdout
+        }
+        return stdout.toString().trim()
+    } catch (Exception e) {
+        return ""
+    }
+}
+
+ext.writeBuildFiles = { prefix='build' ->
+    logger.info("Writing build.date file")
+    new File(projectDir, prefix+".date").text = new Date().toString()+"\n"+System.currentTimeMillis()+"\n"
+    String hash = getGitLongHash()
+    if (hash?.trim()) {
+        logger.info("Writing build.githash file: "+hash)
+        new File(projectDir, prefix+".githash").text = hash+"\n"
+    }
+    String branch = getGitBranch()
+    if (branch?.trim()) {
+        logger.info("Writing build.gitbranch file: "+branch)
+        new File(projectDir, prefix+".gitbranch").text = branch+"\n"
+    }
+    String remoteUrl = getGitRemoteUrl()
+    if (remoteUrl?.trim()) {
+        logger.info("Writing build.gitremoteurl file: "+remoteUrl)
+        new File(projectDir, prefix+".gitremoteurl").text = remoteUrl+"\n"
+    }
+}

--- a/src/main/java/org/opensha/commons/util/ApplicationVersion.java
+++ b/src/main/java/org/opensha/commons/util/ApplicationVersion.java
@@ -212,118 +212,7 @@ public class ApplicationVersion implements Comparable<ApplicationVersion> {
 		}
 		return new ApplicationVersion(major, minor, build);
 	}
-	
-	private static final String[] possible_githash_files = {}; // don't use a file for a local clone, use git to find it
-	private static final String[] possible_githash_resources = { "/build.githash"};
-	
-	public static String loadGitHash() throws IOException {
-		try {
-			URL url = locateURL(possible_githash_files, possible_githash_resources);
-			if (url != null) {
-//				System.out.println("URL: "+url);
-				for (String line : FileUtils.loadFile(url)) {
-					line = line.trim();
-					if (!line.isEmpty())
-						return line;
-				}
-			}
-		} catch (FileNotFoundException e) {}
-		// see if we can detect it
-		File cwd = new File("");
-		String[] command = { "/bin/bash", "-c",
-				"cd "+cwd.getAbsolutePath()+"; git log -n 1 --pretty='%H'" };
-		
-		try {
-			Process p = Runtime.getRuntime().exec(command);
-			int exit;
-			try {
-				exit = p.waitFor();
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-				return null;
-			}
-			if (exit != 0)
-				return null;
-			
-			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			String line;
-			while ((line = b.readLine()) != null)
-				if (line.trim().length() > 0)
-					return line;
-		} catch (Exception e) {
-			System.err.println("Exception detecting git hash: "+e.getMessage());
-//			e.printStackTrace();
-		}
-		return null;
-	}
-	
-	private static final String[] possible_gitbranch_files = {}; // don't use a file for a local clone, use git to find it
-	private static final String[] possible_gitbranch_resources = { "/build.gitbranch"};
-	
-	public static String loadGitBranch() throws IOException {
-		try {
-			URL url = locateURL(possible_gitbranch_files, possible_gitbranch_resources);
-			if (url != null) {
-//				System.out.println("URL: "+url);
-				for (String line : FileUtils.loadFile(url)) {
-					line = line.trim();
-					if (!line.isEmpty())
-						return line;
-				}
-			}
-		} catch (FileNotFoundException e) {}
-		// see if we can detect it
-		File cwd = new File("");
-		String[] command = { "/bin/bash", "-c",
-				"cd "+cwd.getAbsolutePath()+"; git rev-parse --abbrev-ref HEAD" };
-		
-		try {
-			Process p = Runtime.getRuntime().exec(command);
-			int exit;
-			try {
-				exit = p.waitFor();
-			} catch (InterruptedException e) {
-				e.printStackTrace();
-				return null;
-			}
-			if (exit != 0)
-				return null;
-			
-			BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
-			String line;
-			while ((line = b.readLine()) != null)
-				if (line.trim().length() > 0)
-					return line;
-		} catch (Exception e) {
-			System.err.println("Exception detecting git hash: "+e.getMessage());
-//			e.printStackTrace();
-		}
-		return null;
-	}
-	
-	private static final String[] possible_date_files = {}; // don't use a file for a local clone
-	private static final String[] possible_date_resources = { "/build.date"};
-	
-	public static Date loadBuildDate() throws IOException {
-		try {
-			URL url = locateURL(possible_date_files, possible_date_resources);
-			if (url != null) {
-//				System.out.println("URL: "+url);
-				for (String line : FileUtils.loadFile(url)) {
-					line = line.trim();
-					if (!line.isEmpty()) {
-						try {
-							long date = Long.parseLong(line);
-							if (date > 0l)
-								return new Date(date);
-						} catch(NumberFormatException e) {}
-					}
-				}
-			}
-		} catch (FileNotFoundException e) {}
-		return null;
-	}
-	
+
 	private static void testCompare(ApplicationVersion v1, ApplicationVersion v2) {
 		System.out.println("Comparing " + v1 + " to " + v2);
 		System.out.println(v1 + " > " + v2 + " ? " + v1.isGreaterThan(v2));
@@ -332,8 +221,6 @@ public class ApplicationVersion implements Comparable<ApplicationVersion> {
 	}
 	
 	public static void main(String args[]) throws IOException {
-		System.out.println(loadGitHash());
-		System.out.println(loadGitBranch());
 		System.exit(0);
 		System.out.println(loadBuildVersion());
 		System.out.println(fromString("0.4.2"));

--- a/src/main/java/org/opensha/commons/util/GitVersion.java
+++ b/src/main/java/org/opensha/commons/util/GitVersion.java
@@ -1,0 +1,178 @@
+package org.opensha.commons.util;
+
+import org.apache.commons.lang3.math.NumberUtils;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GitVersion {
+
+    final String filePrefix;
+    final File baseDirectory;
+
+    public GitVersion() {
+        this(new File(""), "/build");
+    }
+
+    public GitVersion(File baseDirectory, String filePrefix) {
+        this.baseDirectory = baseDirectory.getAbsoluteFile();
+        this.filePrefix = filePrefix;
+    }
+
+    public static String first(List<String> lines) {
+        if (lines == null) {
+            return null;
+        }
+        for (String line : lines) {
+            line = line.trim();
+            if (!line.isEmpty()) {
+                return line;
+            }
+        }
+        return null;
+    }
+
+    public static List<String> execute(String[] command, File directory) {
+        try {
+            Process p = Runtime.getRuntime().exec(command, null, directory);
+            int exit = p.waitFor();
+            if (exit != 0) {
+                return null;
+            }
+            return FileUtils.loadStream(p.getInputStream());
+        } catch (Exception e) {
+            System.err.println("Exception executing command " + String.join(" ", command) + " : " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public String loadGitHash() throws IOException {
+        String gitHashFile = filePrefix + ".githash";
+        try {
+            URL url = GitVersion.class.getResource(gitHashFile);
+            if (url != null) {
+                String gitHash = first(FileUtils.loadFile(url));
+                if (gitHash != null) {
+                    return gitHash;
+                }
+            }
+        } catch (FileNotFoundException x) {
+            System.out.println(gitHashFile + " resource not found");
+        }
+
+        String[] command = {"git", "rev-parse", "HEAD"};
+        return first(execute(command, baseDirectory));
+    }
+
+    public String loadGitBranch() throws IOException {
+        String gitBranchFileName = filePrefix + ".gitbranch";
+        try {
+            URL url = GitVersion.class.getResource(gitBranchFileName);
+            if (url != null) {
+                String branch = first(FileUtils.loadFile(url));
+                if (branch != null) {
+                    return branch;
+                }
+            }
+        } catch (FileNotFoundException x) {
+            System.out.println(gitBranchFileName + " resource not found.");
+        }
+
+        File cwd = new File("").getAbsoluteFile();
+        String[] command = {"git", "rev-parse", "--abbrev-ref", "HEAD"};
+        return first(execute(command, cwd));
+    }
+
+    public String loadGitRemote() throws IOException {
+        String gitBranchFileName = filePrefix + ".gitremoteurl";
+        try {
+            URL url = GitVersion.class.getResource(gitBranchFileName);
+            if (url != null) {
+                String branch = first(FileUtils.loadFile(url));
+                if (branch != null) {
+                    return branch;
+                }
+            }
+        } catch (FileNotFoundException x) {
+            System.out.println(gitBranchFileName + " resource not found.");
+        }
+
+        String[] command = {"git", "name-rev", "--name-only", "HEAD"};
+        String branch = first(execute(command, baseDirectory));
+        command = new String[]{"git", "config", "branch." + branch + ".remote"};
+        String remote = first(execute(command, baseDirectory));
+        command = new String[]{"git", "config", "remote." + remote + ".url"};
+        return first(execute(command, baseDirectory));
+    }
+
+    public Date loadBuildDate() throws IOException {
+        URL url = GitVersion.class.getResource(filePrefix + ".date");
+        if (url == null) {
+            return null;
+        }
+
+        for (String line : FileUtils.loadFile(url)) {
+            if (NumberUtils.isParsable(line)) {
+                long date = Long.parseLong(line);
+                if (date > 0) {
+                    return new Date(date);
+                }
+            }
+        }
+        return null;
+    }
+
+    public Map<String, String> getMap() {
+        Map<String, String> result = new HashMap<>();
+        try {
+            String gitHash = loadGitHash();
+            if (gitHash != null) {
+                result.put("gitHash", gitHash);
+            }
+        } catch (IOException x) {
+        }
+
+        try {
+            String branch = loadGitBranch();
+            if (branch != null) {
+                result.put("branch", branch);
+            }
+        } catch (IOException x) {
+        }
+
+        try {
+            Date buildDate = loadBuildDate();
+            if (buildDate != null) {
+            String buildTime = loadBuildDate().toString();
+                result.put("buildTime", buildTime);
+            }
+        } catch (IOException x) {
+        }
+
+        try {
+            String remoteUrl = loadGitRemote();
+            if (remoteUrl != null) {
+                result.put("remoteUrl", remoteUrl);
+            }
+        } catch (IOException x) {
+        }
+
+        return result;
+    }
+
+    public static void main(String[] args) throws IOException {
+        GitVersion git = new GitVersion();
+        System.out.println(git.loadGitBranch());
+        System.out.println(git.loadGitRemote());
+        System.out.println(git.loadGitHash());
+        System.out.println(git.loadBuildDate());
+    }
+
+}

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BuildInfoModule.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/BuildInfoModule.java
@@ -13,11 +13,13 @@ import com.google.gson.GsonBuilder;
 public class BuildInfoModule implements JSON_TypeAdapterBackedModule<BuildInfoModule> {
 	
 	private Long buildTime;
+	private String buildTimeHuman;
 	private String gitHash;
 	private String branch;
 	private String remoteUrl;
 	private ApplicationVersion openshaVersion;
 	private Long creationTime;
+	private String creationTimeHuman;
 	private List<Map<String, String>> extra;
 
 	@SuppressWarnings("unused") // used in deserialization
@@ -25,11 +27,15 @@ public class BuildInfoModule implements JSON_TypeAdapterBackedModule<BuildInfoMo
 	
 	public BuildInfoModule(Long buildTime, String gitHash, String branch, String remoteUrl, ApplicationVersion openshaVersion) {
 		this.buildTime = buildTime;
+		if(buildTime != null) {
+			this.buildTimeHuman = new Date(buildTime).toString();
+		}
 		this.gitHash = gitHash;
 		this.branch = branch;
 		this.remoteUrl = remoteUrl;
 		this.openshaVersion = openshaVersion;
 		this.creationTime = System.currentTimeMillis();
+		this.creationTimeHuman = new Date(creationTime).toString();
 	}
 
 	public static BuildInfoModule fromGitVersion(GitVersion git) throws IOException{
@@ -91,11 +97,17 @@ public class BuildInfoModule implements JSON_TypeAdapterBackedModule<BuildInfoMo
 	@Override
 	public void set(BuildInfoModule value) {
 		this.buildTime = value.buildTime;
+		if (buildTime != null) {
+			buildTimeHuman = new Date(buildTime).toString();
+		}
 		this.gitHash = value.gitHash;
 		this.branch = value.branch;
 		this.remoteUrl = value.remoteUrl;
 		this.openshaVersion = value.openshaVersion;
 		this.creationTime = value.creationTime;
+		if (creationTime != null) {
+			creationTimeHuman = new Date(creationTime).toString();
+		}
 		this.extra = value.extra;
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/util/ERF_TestFileWriter.java
+++ b/src/main/java/org/opensha/sha/earthquake/util/ERF_TestFileWriter.java
@@ -18,9 +18,9 @@ import org.opensha.commons.geo.LocationUtils;
 import org.opensha.commons.param.Parameter;
 import org.opensha.commons.param.ParameterList;
 import org.opensha.commons.param.impl.StringParameter;
-import org.opensha.commons.util.ApplicationVersion;
 import org.opensha.commons.util.ClassUtils;
 import org.opensha.commons.util.FileNameComparator;
+import org.opensha.commons.util.GitVersion;
 import org.opensha.sha.earthquake.BaseERF;
 import org.opensha.sha.earthquake.ERF;
 import org.opensha.sha.earthquake.ERF_Ref;
@@ -645,7 +645,7 @@ public class ERF_TestFileWriter {
 		
 		String branch;
 		try {
-			branch = ApplicationVersion.loadGitBranch();
+			branch = new GitVersion().loadGitBranch();
 		} catch (Exception e) {
 			branch = null;
 		}


### PR DESCRIPTION
We have had issues with determining the exact code that was used to create our data, so here are some changes to make that easier for us. Happy to discuss or modify, as usual.

It's quite a few changes, so here are some explanations of why I made these

- `git` commands failed under Windows.
   - Invoking the CLI version of git began with `/bin/bash` in order to change the directory. Now, the working directory is passed as an argument to the `exec()` method.
- git `build.*` files were picked up during local runs.
   - Having built a `fatJar` once locally, generated files like `build.githash` stuck around and were picked up during subsequent local runs, resulting in outdated data in the build info module. Now, these are deleted after creating the fatJar.
- For NZSHM, the build info was inconsistent between a local run and a fatJar run
   - A fatJar run would pick up the `opensha` data from the `build.*` files, while a local run would use `git` to get hash, branch, etc. from `nzshm-opensha` instead. This is why `GitVersion` (which contains the git code previously in `ApplicationVersion`) takes a `baseDirectory` to clarify where ad-hoc git information should come from.
- We wanted to document `nzshm-opensha` _and_ `opensha` versions
   - This is why `GitVersion` takes a `filePrefix`. Otherwise the generated files would overwrite each other in our fatJar. 
   - The same filePrefix can also be set in the gradle build script. 
   - This is also why the gradle git functionality is split into its own file, allowing our project to re-use the code to generate the build files.
   - And finally, `BuildInfoModule` allows for `extra` data to be added on. This makes it possible for us to add own own, custom version information. This mechanism ensures that old `build_info.json` files can still be read in.
- We wanted some extra information in `build_info.json`
    -  We wanted human readeable timestamps. I added these on as new files so that the code remains backwards compatible.
    - We also wanted to have the remote URL. For example, locally we have one remote for `opensha` and one for our fork of `opensha`

I tried implementing everything with minimal impact. Where possible, defaults are used to maintain existing behaviour.

Here is how we would use this on our project:
```Java
// opensha is not in the current working directory, keep using old old file names
BuildInfoModule buildInfo = BuildInfoModule.fromGitVersion(new GitVersion(new File("../opensha"), "/build"));
// nzshm-opensha is in the current working director, use new file prefix
buildInfo.addExtra(new GitVersion(new File(""), "/nzshm-build"));
// overwrite default build info
rupSet.addModule(buildInfo);
```

And this is what `build_info.json` would look like:

```JSON
{
  "buildTime": 1732241895218,
  "buildTimeHuman": "Fri Nov 22 15:18:15 NZDT 2024",
  "gitHash": "205f5f536437d1df66011e8b56e8455f8c6a7d67",
  "branch": "feature/346-build-info",
  "remoteUrl": "https://github.com/GNS-Science/opensha.git",
  "openshaVersion": "1.5.2",
  "creationTime": 1732241952272,
  "creationTimeHuman": "Fri Nov 22 15:19:12 NZDT 2024",
  "extra": [
    {
      "gitHash": "78dcfa8282deeb6e29000abdf1145e8f7c6c86ad",
      "buildTime": "Fri Nov 22 15:18:26 NZDT 2024",
      "remoteUrl": "https://github.com/GNS-Science/nzshm-opensha.git",
      "branch": "feature/346-build-info"
    }
  ]
}
```
