### PR TITLE
Fix normalize bug when all weights sum to zero

### DIFF
--- a/src/main/java/org/opensha/commons/data/WeightedList.java
+++ b/src/main/java/org/opensha/commons/data/WeightedList.java
@@ -379,6 +379,13 @@ public class WeightedList<E> extends AbstractList<WeightedValue<E>> implements X
 		double sum = getWeightSum();
 		if (sum == 1f)
 			return; // already normalized
+		if (sum == 0f) {
+			// can't normalize if all weights sum to 0, would divide by 0.
+			// set all weights to 1 and then normalize.
+			setWeightsToConstant(1d);
+			normalize();
+			return;
+		}
 		
 		List<WeightedValue<E>> normalized = new ArrayList<>(list.size());
 		for (int i=0; i<list.size(); i++) {

--- a/src/main/java/org/opensha/commons/data/WeightedList.java
+++ b/src/main/java/org/opensha/commons/data/WeightedList.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 
+import org.apache.commons.math3.util.Precision;
 import org.dom4j.Element;
 import org.opensha.commons.data.function.IntegerPDF_FunctionSampler;
 import org.opensha.commons.metadata.XMLSaveable;
@@ -204,7 +205,7 @@ public class WeightedList<E> extends AbstractList<WeightedValue<E>> implements X
 		
 		if (forceNormalization && list.size() > 0) {
 			if (!isNormalized(list))
-				throw new IllegalStateException("wights must sum to 1 (current sum: "+getWeightSum()+")");
+				throw new IllegalStateException("weights must sum to 1 (current sum: "+getWeightSum()+")");
 		}
 		
 		for (WeightedValue<?> value : list) {
@@ -377,15 +378,10 @@ public class WeightedList<E> extends AbstractList<WeightedValue<E>> implements X
 	
 	public void normalize() {
 		double sum = getWeightSum();
-		if (sum == 1f)
+		if (Precision.equals(sum, 1d, 0.0001))
 			return; // already normalized
-		if (sum == 0f) {
-			// can't normalize if all weights sum to 0, would divide by 0.
-			// set all weights to 1 and then normalize.
-			setWeightsToConstant(1d);
-			normalize();
-			return;
-		}
+		Preconditions.checkState(sum > 0d && Double.isFinite(sum),
+				"Cannot normalize, weight sum must be finite and positive: %s", sum);
 		
 		List<WeightedValue<E>> normalized = new ArrayList<>(list.size());
 		for (int i=0; i<list.size(); i++) {


### PR DESCRIPTION
Fix for https://github.com/opensha/opensha/issues/145

When attempting to normalize all values, if the sum of all weights was zero this would result in a division by zero.

The error message is expected behavior, as normalization is not possible in this case.
This PR improves the error message when this occurs and adds precision checks for already normalized WeightedLists.


