### PR TITLE
Copy release/25.4.0 ServerPrefUtils structure for main

### DIFF
--- a/src/main/java/org/opensha/commons/util/ServerPrefUtils.java
+++ b/src/main/java/org/opensha/commons/util/ServerPrefUtils.java
@@ -97,7 +97,7 @@ public class ServerPrefUtils {
 	 * In practice, this means that it should be development prefs on trunk and nightly builds, and production
 	 * prefs on release branches and distribution applications.
 	 */
-	public static final ServerPrefs SERVER_PREFS = ServerPrefs.PRODUCTION_PREFS;
+	public static final ServerPrefs SERVER_PREFS = ServerPrefs.DEV_PREFS;
 	
 	public static void debug(String debugName, String message) {
 		String date = "[" + df.format(new Date()) + "]";

--- a/src/main/java/org/opensha/commons/util/ServerPrefUtils.java
+++ b/src/main/java/org/opensha/commons/util/ServerPrefUtils.java
@@ -22,6 +22,13 @@ public class ServerPrefUtils {
 	public static final DateFormat df = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy");
 	
 	/**
+	 * Current version of the production OpenSHA servlet in use.
+	 * Update this when distributing a new OpenSHA release.
+	 * This same backend may be in use for more than one OpenSHA version.
+	 */
+	private static final String PROD_VERSION = "25.4";
+	
+	/**
 	 * Hostname for all production services
 	 */
 	static final String OPENSHA_SERVER_PRODUCTION_HOST = "data.opensha.org";
@@ -44,7 +51,7 @@ public class ServerPrefUtils {
 	 * This is the path to the WEB-INF dir for production OpenSHA servlets
 	 */
 	static final File OPENSHA_TOMCAT_PRODUCTION_DIR =
-		new File(OPENSHA_TOMCAT_WEBAPPS_DIR+"/OpenSHA/WEB-INF/");
+		new File(OPENSHA_TOMCAT_WEBAPPS_DIR+"/OpenSHA_"+PROD_VERSION+"/WEB-INF/");
 	
 	/**
 	 * This is the path to the WEB-INF dir for development OpenSHA servlets
@@ -70,11 +77,11 @@ public class ServerPrefUtils {
 			hostName = null;
 		}
 		// TODO: switch to SSL. USC's firewall currently doesn't allow 8443 traffic, so we can't yet
-		String PROD_URL = "http://"+OPENSHA_SERVER_PRODUCTION_HOST+":8080/OpenSHA/";
+		String PROD_URL = "http://"+OPENSHA_SERVER_PRODUCTION_HOST+":8080/OpenSHA_"+PROD_VERSION+"/";
 		String DEV_URL = "http://"+OPENSHA_SERVER_DEV_HOST+":8080/OpenSHA_master/";
 		if (hostName != null && !hostName.isEmpty()) {
 			if (hostName.equalsIgnoreCase(OPENSHA_SERVER_PRODUCTION_HOST))
-				PROD_URL = "http://localhost:8080/OpenSHA/";
+				PROD_URL = "http://localhost:8080/OpenSHA_"+PROD_VERSION+"/";
 			if (hostName.equalsIgnoreCase(OPENSHA_SERVER_DEV_HOST))
 				DEV_URL = "http://localhost:8080/OpenSHA_master/";
 		}
@@ -90,7 +97,7 @@ public class ServerPrefUtils {
 	 * In practice, this means that it should be development prefs on trunk and nightly builds, and production
 	 * prefs on release branches and distribution applications.
 	 */
-	public static final ServerPrefs SERVER_PREFS = ServerPrefs.DEV_PREFS;
+	public static final ServerPrefs SERVER_PREFS = ServerPrefs.PRODUCTION_PREFS;
 	
 	public static void debug(String debugName, String message) {
 		String date = "[" + df.format(new Date()) + "]";


### PR DESCRIPTION
The layout for tracking production servlets used in release/25.4.0 is copied into the main branch to simplify creation of future releases. Still uses the dev backend on main.