### PR TITLE
Set UCERF3 Epistemic and NSHM23-WUS to production mode

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
@@ -144,15 +144,16 @@ public enum ERF_Ref {
 	/** Yucca Mountain ERF List */
 	YUCCA_MOUNTAIN_LIST(YuccaMountainERF_List.class, YuccaMountainERF_List.NAME, PRODUCTION, true),
 	
-	// DEVELOPMENT
-	
 	/** WGCEP UCERF3 Epistemic List */
-	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, DEVELOPMENT, true),
+	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, PRODUCTION, true),
+	
+	/** National Seismic Hazard Model 2023 Western US ERF */
+	NSHM23_WUS_BRANCH_AVG(NSHM23_WUS_BranchAveragedERF.class, NSHM23_WUS_BranchAveragedERF.NAME, PRODUCTION, false),
+
+	// DEVELOPMENT
 	
 	/** STEP Alaska Forecast */
 	STEP_ALASKA(STEP_AlaskanPipeForecast.class, STEP_AlaskanPipeForecast.NAME, DEVELOPMENT, false),
-	
-	NSHM23_WUS_BRANCH_AVG(NSHM23_WUS_BranchAveragedERF.class, NSHM23_WUS_BranchAveragedERF.NAME, DEVELOPMENT, false),
 		
 	// EXPERIMENTAL
 	


### PR DESCRIPTION
Set UCERF3 Epistemic List ERF and NSHM23-WUS ERF to production mode.

This PR ensures that these ERFs will be visible when using the production server. This was manually verified by setting the server prefs. After approval, this PR will merge into opensha/master, ensuring that the ERF is defined as production ready in all branches.

Without further review, opensha/master will be merged into opensha-fork/main, into opensha-fork/release/25.4.0 (omitting server pref changes), into opensha/release/25.4.0. Manual rebuilding on OpenSHA server will occur prior to release.
