### PR TITLE
Distance X calculation fix (for #161)

### DIFF
--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/XYZDatasetWrapper.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/XYZDatasetWrapper.java
@@ -26,7 +26,7 @@ public class XYZDatasetWrapper extends AbstractXYZDataset implements IntervalXYD
 	
 	public XYZDatasetWrapper(XYZPlotSpec spec, boolean xLog, boolean yLog) {
 		this.xyz = spec.getXYZ_Data();
-		this.zLabel = spec.getZAxisLabel();
+		this.zLabel = spec.isIncludeZlabelInLegend() ? spec.getZAxisLabel() : "";
 		this.xLog = xLog;
 		this.yLog = yLog;
 		Double thicknessX = spec.getThicknessX();

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/XYZPlotSpec.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/XYZPlotSpec.java
@@ -33,6 +33,7 @@ public class XYZPlotSpec extends PlotSpec {
 	private XYZ_DataSet xyzData;
 	private CPT cpt;
 	private String zAxisLabel;
+	private boolean includeZlabelInLegend = true;
 	private boolean cptVisible = true;
 	private double cptTickUnit = -1;
 	private RectangleEdge cptPosition = RectangleEdge.TOP;
@@ -99,6 +100,14 @@ public class XYZPlotSpec extends PlotSpec {
 
 	public void setZAxisLabel(String zAxisLabel) {
 		this.zAxisLabel = zAxisLabel;
+	}
+	
+	public boolean isIncludeZlabelInLegend() {
+		return includeZlabelInLegend;
+	}
+	
+	public void setIncludeZlabelInLegend(boolean includeZlabelInLegend) {
+		this.includeZlabelInLegend = includeZlabelInLegend;
 	}
 
 	public RectangleEdge getCPTPosition() {

--- a/src/main/java/org/opensha/sha/faultSurface/utils/GriddedSurfaceUtils.java
+++ b/src/main/java/org/opensha/sha/faultSurface/utils/GriddedSurfaceUtils.java
@@ -1,20 +1,22 @@
 package org.opensha.sha.faultSurface.utils;
 
-import java.awt.Color;
+import static org.opensha.commons.geo.GeoTools.EARTH_RADIUS_MEAN;
+
 import java.awt.geom.Area;
+import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
+import org.apache.commons.math3.util.Precision;
 import org.opensha.commons.geo.BorderType;
 import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.LocationList;
 import org.opensha.commons.geo.LocationUtils;
 import org.opensha.commons.geo.LocationVector;
 import org.opensha.commons.geo.Region;
-import org.opensha.commons.geo.RegionUtils;
 import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
 import org.opensha.sha.faultSurface.CompoundSurface;
 import org.opensha.sha.faultSurface.EvenlyGriddedSurface;
@@ -138,12 +140,23 @@ public class GriddedSurfaceUtils {
 	}
 	
 	/**
-	 * This computes distanceX
+	 * This is the original OpenSHA DistanceX calculation method; it is slow an inaccurate, but preserved for posterity
+	 * in case we need to reproduce prior results.
+	 * 
+	 * It is slow because:
+	 * 1. It calculates everything using the static LocationUtils lat/lon methods, which each project internally rather
+	 * than projecting once
+	 * 2. It detects the sign (left or right of the trace) using a Region object which is slow to construct, and is
+	 * constructed on each invocation
+	 * 
+	 * It is inaccurate because it extends the trace out 1000 km in each direction, then calculates a distance to the
+	 * straight line at the location. This ends up exaggerating the curvature of the earth, especially at high latitudes
+	 * 
 	 * @param surface
 	 * @param siteLoc
 	 * @return
 	 */
-	public static double getDistanceX(FaultTrace trace, Location siteLoc) {
+	public static double getDistanceX_old(FaultTrace trace, Location siteLoc) {
 
 		double distanceX;
 		
@@ -211,7 +224,6 @@ public class GriddedSurfaceUtils {
 				try {
 					polygon = new Region(locsForRegion, BorderType.MERCATOR_LINEAR);
 				} catch (Exception e) {
-					// TODO Auto-generated catch block
 					e.printStackTrace();
 					System.out.println("==== trace  ====");
 					System.out.println(trace);
@@ -233,6 +245,293 @@ public class GriddedSurfaceUtils {
 		
 		return distanceX;
 	}
+	
+	/**
+	 * This computes distanceX
+	 * @param surface
+	 * @param siteLoc
+	 * @return
+	 */
+	public static double getDistanceX(FaultTrace trace, Location siteLoc) {
+		
+		// set to zero if it's a point source
+		if(trace.size() == 1) {
+			return 0d;
+		} else {
+			Location traceStart = trace.first();
+			Location traceEnd = trace.last();
+			
+			// projection reference frame, weighted 50% to the site location, and 50% to the middle of the trace
+			double latRefRad = 0.5*siteLoc.getLatRad() + 0.25*traceStart.getLatRad() + 0.25*traceEnd.getLatRad();
+			double lonRefRad = 0.5*siteLoc.getLonRad() + 0.25*traceStart.getLonRad() + 0.25*traceEnd.getLonRad();
+			double lonScale = Math.cos(latRefRad);
+			
+			double[] traceX = new double[trace.size()];
+			double[] traceY = new double[traceX.length];
+			for (int i=0; i<traceX.length; i++) {
+				Location loc = trace.get(i);
+				traceX[i] = (loc.getLonRad() - lonRefRad) * lonScale;
+				traceY[i] = loc.getLatRad() - latRefRad;
+			}
+			double siteX = (siteLoc.getLonRad() - lonRefRad) * lonScale;
+			double siteY = siteLoc.getLatRad() - latRefRad;
+			
+			// find the nearest segment
+			// keep track of angular (not-scaled to earth's radius) and squared distances for speed
+			double[] angularSegDistsSq = new double[trace.size()-1];
+			double minAngularSegDistSq = Double.POSITIVE_INFINITY;
+			int minSegDistIndex = -1;
+			for (int i=0; i<angularSegDistsSq.length; i++) {
+				angularSegDistsSq[i] = Line2D.ptSegDistSq(
+						traceX[i], traceY[i],
+						traceX[i+1], traceY[i+1],
+						siteX, siteY);
+				if (angularSegDistsSq[i] < minAngularSegDistSq) {
+					minAngularSegDistSq = angularSegDistsSq[i];
+					minSegDistIndex = i;
+				}
+			}
+			
+			// now convert the closest squared angluar segment distance to km
+			double minSegDist = Math.sqrt(minAngularSegDistSq) * EARTH_RADIUS_MEAN;
+
+			// now figure out if we're beyond the ends, in which case we're likely closest to the extension
+			double x0 = traceX[0];
+			double y0 = traceY[0];
+			double xN = traceX[traceX.length - 1];
+			double yN = traceY[traceY.length - 1];
+
+			double dxAll = xN - x0;
+			double dyAll = yN - y0;
+			double lenSqAll = dxAll*dxAll + dyAll*dyAll;
+	        
+			double sx = siteX - x0; // vector from start->site
+			double sy = siteY - y0;
+			double dotAll = dxAll*sx + dyAll*sy;
+
+			if (dotAll < 0.0 || dotAll > lenSqAll) {
+				// we're before or after
+				
+				boolean backwards = dotAll < 0.0;
+				double azRad = LocationUtils.azimuthRad(traceStart, traceEnd);
+				if (backwards) {
+					// before
+					return calcExtendedDistanceX(traceStart, siteLoc, azRad+Math.PI, minSegDist, minAngularSegDistSq, true);
+				} else {
+					// after
+					return calcExtendedDistanceX(traceEnd, siteLoc, azRad, minSegDist, minAngularSegDistSq, false);
+				}
+			}
+			
+			// we're within the bounds
+			boolean leftOfClosest = cross2D(
+					traceX[minSegDistIndex+1] - traceX[minSegDistIndex],
+					traceY[minSegDistIndex+1] - traceY[minSegDistIndex],
+					siteX - traceX[minSegDistIndex],
+					siteY - traceY[minSegDistIndex]) > 0;
+			// check for the special case where we're equidistant from 2 segments (closest to a corner)
+			// in that case, we could be left of the infinite extension of one but right of the other
+			double checkPrecision = 1e-10;
+			int equidistantIndex = -1;
+			if (minSegDistIndex > 0 &&
+					Precision.equals(angularSegDistsSq[minSegDistIndex], angularSegDistsSq[minSegDistIndex-1], checkPrecision)) {
+				equidistantIndex = minSegDistIndex-1;
+			} else if (minSegDistIndex < angularSegDistsSq.length-1 &&
+					Precision.equals(angularSegDistsSq[minSegDistIndex], angularSegDistsSq[minSegDistIndex+1], checkPrecision)) {
+				equidistantIndex = minSegDistIndex+1;
+			}
+			if (equidistantIndex >= 0) {
+				boolean leftOfEquidistant = cross2D(
+						traceX[equidistantIndex+1] - traceX[equidistantIndex],
+						traceY[equidistantIndex+1] - traceY[equidistantIndex],
+						siteX - traceX[equidistantIndex],
+						siteY - traceY[equidistantIndex]) > 0;
+				if (leftOfClosest != leftOfEquidistant) {
+					// we're closest to a corner, and in the intermediate zone where we're left of one's extension but right of another
+					
+					boolean leftBefore, leftAfter;
+					if (equidistantIndex < minSegDistIndex) {
+						leftBefore = leftOfEquidistant;
+						leftAfter = leftOfClosest;
+					} else {
+						leftBefore = leftOfClosest;
+						leftAfter = leftOfEquidistant;
+					}
+					int firstMatchIndex = Integer.min(equidistantIndex, minSegDistIndex);
+					double xBefore = traceX[firstMatchIndex];
+					double yBefore = traceY[firstMatchIndex];
+					double xCorner = traceX[firstMatchIndex+1];
+					double yCorner = traceY[firstMatchIndex+1];
+					double xAfter = traceX[firstMatchIndex+2];
+					double yAfter = traceY[firstMatchIndex+2];
+					
+					// Vector B = (corner->before), anchored at P_i
+				    double bx = xBefore - xCorner;
+				    double by = yBefore - yCorner;
+
+				    // Vector A = (corner->after), also anchored at P_i
+				    double ax = xAfter - xCorner;
+				    double ay = yAfter - yCorner;
+
+				    // Magnitudes
+				    double bLen = Math.hypot(bx, by);
+				    double aLen = Math.hypot(ax, ay);
+
+				    // Handle degenerate cases: no well-defined angle
+				    if (bLen < 1e-12 || aLen < 1e-12) {
+						// Corner is basically a repeated point or something nearly collinear.
+						// default to before
+						leftOfClosest = leftBefore; 
+					} else {
+						// Normalize
+					    double bxn = bx / bLen;
+					    double byn = by / bLen;
+					    double axn = ax / aLen;
+					    double ayn = ay / aLen;
+
+					    // Check the turn direction
+					    double crossBA = cross2D(bx, by, ax, ay);  // cross(B, A)
+
+					    // Start with the naive sum
+					    double wx = bxn + axn;
+					    double wy = byn + ayn;
+
+					    // If cross(B, A) < 0 => it's a "right turn" => flip W to keep inside angle
+					    if (crossBA < 0.0) {
+					        wx = -wx;
+					        wy = -wy;
+					    }
+
+					    // If the sum is near zero length, e.g. B and A nearly opposite
+					    double wLen = Math.hypot(wx, wy);
+					    if (wLen < 1e-12) {
+							// This means B and A point in nearly opposite directions (e.g. 180° turn).
+							// The angle-bisector is ill-defined. default to after
+							leftOfClosest = leftAfter;
+						} else {
+							// The site vector from corner = (siteX - xCorner, siteY - yCorner)
+							sx = siteX - xCorner;
+							sy = siteY - yCorner;
+
+							// Cross of W with site vector => which side of the bisector?
+							double cross = cross2D(wx, wy, sx, sy);
+
+							// Example policy:
+							//   If cross < 0 => site is on the "far side" => use after sign
+							//   else => use before sign
+							if (cross < 0.0) {
+//								leftOfClosest = leftAfter;
+								leftOfClosest = leftBefore;
+							} else {
+//								leftOfClosest = leftBefore;
+								leftOfClosest = leftAfter;
+							}
+							
+							// this can be used to debug
+//							leftOfClosest = false;
+//							if (cross < 0d) {
+//								minSegDist = -1d;
+//							} else {
+//								minSegDist = 1d;
+//							}
+						}
+					}
+				}
+			}
+			if (leftOfClosest)
+				return -minSegDist;
+			return minSegDist;
+		}
+	}
+	
+	/**
+	 * Calculate distanceX from a trace extending in a great circle from startLoc in the given direction.
+	 * 
+	 * This is more accurate than using the projected straight line distance
+	 * 
+	 * @param startLoc
+	 * @param siteLoc
+	 * @param azimuthRad
+	 * @param distToEnd
+	 * @param angularDistToEndSq
+	 * @param backwards
+	 * @return
+	 */
+	private static double calcExtendedDistanceX(Location startLoc, Location siteLoc,
+			double azimuthRad, double distToEnd, double angularDistToEndSq, boolean backwards) {
+		double siteAz = LocationUtils.azimuthRad(startLoc, siteLoc);
+
+		// make a straight line approximation of how far away the closest point on this line will be
+		double diff = siteAz - azimuthRad;
+		diff = (diff + Math.PI) % (2 * Math.PI);
+		if (diff < 0)
+			diff += 2 * Math.PI;
+		diff = diff - Math.PI;
+
+		// make sure it's not too small
+		double destDist = Math.max(10d, distToEnd * Math.cos(diff));
+		
+		// now move that distance in the chosen direction
+		double lat1 = startLoc.getLatRad();
+		double lon1 = startLoc.getLonRad();
+		double sinLat1 = Math.sin(lat1);
+		double cosLat1 = Math.cos(lat1);
+		double ad = destDist / EARTH_RADIUS_MEAN; // angular distance
+		double sinD = Math.sin(ad);
+		double cosD = Math.cos(ad);
+
+		// this is that point along the line
+		double lat2 = Math.asin(sinLat1 * cosD + cosLat1 * sinD * Math.cos(azimuthRad));
+		double lon2 = lon1 +
+			Math.atan2(Math.sin(azimuthRad) * sinD * cosLat1,
+				cosD - sinLat1 * Math.sin(lat2));
+
+		// set reference frame, use the average of the site and our guess of the closest location on the line
+		double latRefRad = 0.5*(lat2 + siteLoc.getLatRad());
+		double lonRefRad = 0.5*(lon2 + siteLoc.getLonRad());
+		double lonScale = Math.cos(latRefRad);
+
+		// project into that reference frame
+		double x1 = (lon1 - lonRefRad) * lonScale;
+		double y1 = lat1 - latRefRad;
+
+		double x2 = (lon2 - lonRefRad) * lonScale;
+		double y2 = lat2 - latRefRad;
+
+		double siteX = (siteLoc.getLonRad() - lonRefRad) * lonScale;
+		double siteY = siteLoc.getLatRad() - latRefRad;
+
+		// squared distance to that infinite line
+		double distSq = Line2D.ptLineDistSq(x1, y1, x2, y2, siteX, siteY);
+		// the nearest segment could still be closer
+		double dist;
+		if (distSq < angularDistToEndSq) {
+			// this is closest
+			dist = Math.sqrt(distSq) * EARTH_RADIUS_MEAN;
+		} else {
+			// segment is still closer
+			dist = distToEnd;
+		}
+		// determine sign from cross product with that global line
+		double cross = cross2D(x2-x1, y2-y1, siteX, siteY);
+		if (cross > 0.0)
+			dist = -dist;
+		if (backwards)
+			dist = -dist;
+		return dist;
+	}
+
+    /**
+     * Simple 2D cross-product helper:
+     * cross2D( (ax,ay), (bx,by) ) = ax*by - ay*bx.
+     *
+     * Positive => (bx,by) is "left" of (ax,ay),
+     * Negative => "right",
+     * Zero => collinear.
+     */
+    private static double cross2D(double ax, double ay, double bx, double by) {
+        return ax * by - ay * bx;
+    }
 	
 	/**
 	 * This computes Ry0, the absolute value of Ry

--- a/src/test/java/org/opensha/sha/faultSurface/utils/DistanceXDiagnosticMap.java
+++ b/src/test/java/org/opensha/sha/faultSurface/utils/DistanceXDiagnosticMap.java
@@ -1,0 +1,253 @@
+package org.opensha.sha.faultSurface.utils;
+
+import static org.opensha.commons.geo.GeoTools.EARTH_RADIUS_MEAN;
+
+import java.awt.Color;
+import java.io.File;
+import java.io.IOException;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.jfree.chart.ui.RectangleAnchor;
+import org.jfree.data.Range;
+import org.opensha.commons.data.function.DefaultXY_DataSet;
+import org.opensha.commons.data.function.XY_DataSet;
+import org.opensha.commons.data.xyz.GriddedGeoDataSet;
+import org.opensha.commons.geo.GeoTools;
+import org.opensha.commons.geo.GriddedRegion;
+import org.opensha.commons.geo.Location;
+import org.opensha.commons.geo.LocationUtils;
+import org.opensha.commons.geo.Region;
+import org.opensha.commons.gui.plot.HeadlessGraphPanel;
+import org.opensha.commons.gui.plot.PlotCurveCharacterstics;
+import org.opensha.commons.gui.plot.PlotLineType;
+import org.opensha.commons.gui.plot.PlotSymbol;
+import org.opensha.commons.gui.plot.PlotUtils;
+import org.opensha.commons.gui.plot.jfreechart.xyzPlot.XYZPlotSpec;
+import org.opensha.commons.mapping.gmt.elements.GMT_CPT_Files;
+import org.opensha.commons.util.DataUtils.MinMaxAveTracker;
+import org.opensha.commons.util.cpt.CPT;
+import org.opensha.sha.faultSurface.FaultTrace;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
+
+import net.mahdilamb.colormap.Colors;
+
+public class DistanceXDiagnosticMap {
+	
+	private enum TraceType {
+		RANDOM,
+		STAIRSTEP,
+		SINGLE
+	}
+
+	public static void main(String[] args) throws IOException {
+		double[] strikes = {0d, 30d, 45d, 60d, 90d, 135, 225, 270};
+//		double[] strikes = {270};
+		TraceType[] types = TraceType.values();
+//		TraceType[] types = { TraceType.SINGLE };
+		double[] lats = {0d, 30d, 60d};
+		int numSegs = 10;
+		double maxDeviation = 60d;
+		File outputDir = new File("/tmp/dist_x_tests");
+		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
+		
+//		boolean useOld = false;
+//		String title = "Updated DistanceX Calculation Example";
+		
+		boolean useOld = true;
+		String title = "Previous DistanceX Calculation Example";
+		
+		DecimalFormat oDF = new DecimalFormat("0.##");
+		
+		double refLon = 30;
+//		double zScale = 0.15;
+		double zScale = 1d;
+		
+//		double tick = 0.5;
+//		double bufferMult = 3;
+//		double gridSpacing = 0.02;
+		
+		double tick = 0.5;
+		double bufferMult = 1;
+		double gridSpacing = 0.005;
+		
+		int overallCals = 0;
+		double overallSecs = 0d;
+		
+		for (double strike : strikes) {
+			for (TraceType type : types) {
+				List<Double> segDists = new ArrayList<>(numSegs);
+				List<Double> segAzimuths = new ArrayList<>(numSegs);
+				
+				String strikePrefix = "dist_x_test_strike"+oDF.format(strike);
+				if (useOld)
+					strikePrefix = "old_"+strikePrefix;
+				if (type == TraceType.STAIRSTEP) {
+					strikePrefix += "_stairstep";
+					for (int i=0; i<numSegs; i++) {
+						segDists.add(20d);
+						segAzimuths.add(i % 2 == 0 ? strike-45d : strike+45d);
+					}
+				} else if (type == TraceType.SINGLE) {
+					strikePrefix += "_single";
+					segDists.add(100d);
+					segAzimuths.add(strike);
+				} else {
+					strikePrefix += "_random";
+					long seed = Double.doubleToLongBits(strike+1d);
+					// java rand only uses the lower 48 bits, which might be identical
+					// this scrambles them
+					seed ^= (seed >>> 32);
+					System.out.println("Seed for "+strike+": "+seed);
+					Random rand = new Random(seed);
+					System.out.println("\tFirst rand: "+rand.nextDouble());
+					Location startLoc = new Location(0d, 0d);
+					Location runningLoc = startLoc;
+					for (int i=0; i<numSegs-1; i++) {
+						double dist = 1d+rand.nextDouble()*50d;
+						double az = strike + (rand.nextDouble()-0.5)*2d*maxDeviation;
+						segDists.add(dist);
+						segAzimuths.add(az);
+						runningLoc = LocationUtils.location(runningLoc, Math.toRadians(az), dist);
+					}
+					// now now make it follow the given strike in total
+					double distToRunning = LocationUtils.horzDistanceFast(startLoc, runningLoc);
+					double distToLast = distToRunning + 1d + rand.nextDouble()*50d;
+					Location finalLoc = LocationUtils.location(startLoc, Math.toRadians(strike), distToLast);
+					segDists.add(LocationUtils.horzDistanceFast(runningLoc, finalLoc));
+					segAzimuths.add(LocationUtils.azimuth(runningLoc, finalLoc));
+				}
+				
+				for (double lat : lats) {
+					Location startLoc = new Location(lat, refLon);
+					
+					MinMaxAveTracker latTrack = new MinMaxAveTracker();
+					MinMaxAveTracker lonTrack = new MinMaxAveTracker();
+					
+					FaultTrace trace = new FaultTrace(null);
+					trace.add(startLoc);
+					latTrack.addValue(startLoc.getLatitude());
+					lonTrack.addValue(startLoc.getLongitude());
+					for (int i=0; i<segAzimuths.size(); i++) {
+						Location loc = LocationUtils.location(trace.last(), Math.toRadians(segAzimuths.get(i)), segDists.get(i));
+						trace.add(loc);
+						latTrack.addValue(loc.lat);
+						lonTrack.addValue(loc.lon);
+					}
+					
+					double traceDist = LocationUtils.horzDistanceFast(trace.first(), trace.last());
+					double buffer = traceDist*bufferMult;
+					
+					Location middleLoc = new Location(latTrack.getCenter(), lonTrack.getCenter());
+					Location leftLoc = LocationUtils.location(middleLoc, 3d*Math.PI/2d, buffer);
+					Location rightLoc = LocationUtils.location(middleLoc, Math.PI/2d, buffer);
+					Location upLoc = LocationUtils.location(middleLoc, 0d, buffer);
+					Location downLoc = LocationUtils.location(middleLoc, Math.PI, buffer);
+
+					Location lowerLeft = new Location(downLoc.getLatitude(), leftLoc.getLongitude());
+					Location upperRight = new Location(upLoc.getLatitude(), rightLoc.getLongitude());
+					
+					Region reg = new Region(lowerLeft, upperRight);
+					GriddedRegion gridReg = new GriddedRegion(reg, gridSpacing, GriddedRegion.ANCHOR_0_0);
+					GriddedGeoDataSet xyz = new GriddedGeoDataSet(gridReg);
+					
+					System.out.println("Calculating rX for strike="+(float)strike+", "+type+", for "+xyz.size()+" locations");
+					System.out.println("Trace: "+trace);
+					Stopwatch watch = Stopwatch.createStarted();
+					for (int i=0; i<gridReg.getNodeCount(); i++) {
+						double rx;
+						if (useOld)
+							rx = GriddedSurfaceUtils.getDistanceX_old(trace, gridReg.getLocation(i));
+						else
+							rx = GriddedSurfaceUtils.getDistanceX(trace, gridReg.getLocation(i));
+						xyz.set(i, rx);
+					}
+					watch.stop();
+					double secs = watch.elapsed().toMillis()/1000d;
+					double calcsPerSec = xyz.size()/secs;
+					overallCals += xyz.size();
+					overallSecs += secs;
+					System.out.println("Calculated "+xyz.size()+" rX values in "+(float)secs+" seconds ("+(float)calcsPerSec+" calcs/sec)");
+					
+					double maxZ = Math.max(xyz.getMaxZ(), -xyz.getMinZ());
+					maxZ *= zScale;
+					CPT upperCPT = GMT_CPT_Files.SEQUENTIAL_LAJOLLA_UNIFORM.instance().rescale(0d, 1d).trim(0.15, 1d).rescale(0d, maxZ);
+					CPT lowerCPT = GMT_CPT_Files.SEQUENTIAL_NAVIA_UNIFORM.instance().rescale(0d, 1d).trim(0.05, 1d).reverse().rescale(-maxZ, 0);
+					CPT combCPT = new CPT();
+					combCPT.addAll(lowerCPT);
+					combCPT.addAll(upperCPT);
+					combCPT.setBelowMinColor(lowerCPT.getMinColor());
+					combCPT.setAboveMaxColor(upperCPT.getMaxColor());
+					
+					XY_DataSet traceXY = new DefaultXY_DataSet();
+					traceXY.setName("Trace");
+					for (Location loc : trace)
+						traceXY.set(loc.lon, loc.lat);
+					
+					double az = trace.getStrikeDirection();
+					XY_DataSet startXY = new DefaultXY_DataSet();
+					startXY.setName("Trace Start");
+					startXY.set(trace.first().lon, trace.first().lat);
+					XY_DataSet endXY = new DefaultXY_DataSet();
+					endXY.setName("Trace End");
+					endXY.set(trace.last().lon, trace.last().lat);
+					XY_DataSet extendBeforeXY = extendLine(trace.first(), az+180, reg);
+					extendBeforeXY.setName("Great Circle Extension");
+					XY_DataSet extendAfterXY = extendLine(trace.last(), az, reg);
+					List<XY_DataSet> funcs = List.of(traceXY, extendBeforeXY, extendAfterXY, startXY, endXY);
+					List<PlotCurveCharacterstics> chars = List.of(
+							new PlotCurveCharacterstics(PlotLineType.SOLID, 2f, Color.GRAY),
+							new PlotCurveCharacterstics(PlotLineType.DASHED, 2f, Color.DARK_GRAY),
+							new PlotCurveCharacterstics(PlotLineType.DASHED, 2f, Color.DARK_GRAY),
+							new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, 3f, Colors.tab_red),
+							new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, 3f, Colors.tab_green));
+					
+					XYZPlotSpec plot = new XYZPlotSpec(xyz, funcs, chars, combCPT,
+							title, "Longitude", "Latitude", "DistanceX");
+					plot.setIncludeZlabelInLegend(false);
+					plot.setLegendInset(RectangleAnchor.TOP_LEFT);
+					
+					HeadlessGraphPanel gp = PlotUtils.initHeadless();
+					
+					gp.drawGraphPanel(plot, false, false, new Range(reg.getMinLon(), reg.getMaxLon()),
+							new Range(reg.getMinLat(), reg.getMaxLat()));
+					
+					PlotUtils.setYTick(gp, tick);
+					PlotUtils.setXTick(gp, tick);
+					
+					String prefix = strikePrefix+"_lat"+oDF.format(lat);
+					PlotUtils.writePlots(outputDir, prefix,
+							gp, 1000, true, true, false, false);
+				}
+			}
+		}
+		
+		double calcsPerSec = overallCals/overallSecs;
+		System.out.println("Calculated "+overallCals+" total rX values in "+(float)overallSecs+" seconds ("+(float)calcsPerSec+" calcs/sec)");
+	}
+	
+	private static XY_DataSet extendLine(Location from, double az, Region reg) {
+		XY_DataSet line = new DefaultXY_DataSet();
+		double deltaDist = 5d;
+		double azRad = Math.toRadians(az);
+		
+		line.set(from.lon, from.lat);
+		
+		double dist = deltaDist;
+		while (true) {
+			Location loc = LocationUtils.location(from, azRad, dist);
+			line.set(loc.lon, loc.lat);
+			
+			if (!reg.contains(loc))
+				break;
+			
+			dist += deltaDist;
+		}
+		return line;
+	}
+
+}

--- a/src/test/java/org/opensha/sha/faultSurface/utils/DistanceXDiagnosticMap.java
+++ b/src/test/java/org/opensha/sha/faultSurface/utils/DistanceXDiagnosticMap.java
@@ -55,11 +55,11 @@ public class DistanceXDiagnosticMap {
 		File outputDir = new File("/tmp/dist_x_tests");
 		Preconditions.checkState(outputDir.exists() || outputDir.mkdir());
 		
-//		boolean useOld = false;
-//		String title = "Updated DistanceX Calculation Example";
+		boolean useOld = false;
+		String title = "Updated DistanceX Calculation Example";
 		
-		boolean useOld = true;
-		String title = "Previous DistanceX Calculation Example";
+//		boolean useOld = true;
+//		String title = "Previous DistanceX Calculation Example";
 		
 		DecimalFormat oDF = new DecimalFormat("0.##");
 		


### PR DESCRIPTION
Distance X calculation fix (for #161).

This is ~20x faster than the original OpenSHA DistanceX implementation and more accurate (especially at high latitudes).

Here are some benchmark examples, note that in the prior OpenSHA implementation the +/- cut (where blue turns to red) diverges from the great circle trace extension at high latitudes. The first comparison is at lat=0, so little bias exists in the old calculation; the subsequent test cases are all at high latitude.

| Original | Updated |
|----------|---------|
| ![old_dist_x_test_strike30_random_lat0](https://github.com/user-attachments/assets/31bb2e01-5d4f-4746-b447-d9cf08ef78f8) | ![dist_x_test_strike30_random_lat0](https://github.com/user-attachments/assets/d2968107-1aff-469d-a93c-554f858366fc)|
| ![old_dist_x_test_strike30_random_lat60](https://github.com/user-attachments/assets/0baffce1-4cb7-4517-8186-ccf45fedda45) | ![dist_x_test_strike30_random_lat60](https://github.com/user-attachments/assets/d1dc6276-a1dd-46ba-939b-098f0616af32) |
| ![old_dist_x_test_strike60_stairstep_lat60](https://github.com/user-attachments/assets/ca2827d1-3a6b-4c83-8b6b-452abcb723ec) | ![dist_x_test_strike60_stairstep_lat60](https://github.com/user-attachments/assets/e51e2f54-1532-4c60-aa9a-75bd91106b45) |
| ![old_dist_x_test_strike45_single_lat60](https://github.com/user-attachments/assets/02bc830d-10b5-4849-bbab-fe7c9d061589) | ![dist_x_test_strike45_single_lat60](https://github.com/user-attachments/assets/31206666-ea99-4020-a1cb-3ac571f28396) |
| ![old_dist_x_test_strike135_random_lat60](https://github.com/user-attachments/assets/d3691824-832b-43dc-bf16-e8425564ef34) | ![dist_x_test_strike135_random_lat60](https://github.com/user-attachments/assets/4047727e-27d9-4b85-a15e-6e7e70db46c7) |

The calculation is now done by first projecting the trace and site locations and computing the distance to each trace segment. Then we check to see if the site is off either end of the trace, and calculate the distance to a better extended trace that follows a great circle. Signs are determined analytically using cross products without constructing a `Region`.

A few tricky edge cases were found and dealt with:

* Even if the site is beyond the trace along-strike, it still might be closest to one of the trace segments if they extend toward the site.
* Care must be taken to determine the correct sign if a site is closest to an inflection point on the trace; it might be left of the extension of one segment, and right of the extension of the next.

The old method is preserved for posterity in case we need to reproduce an old calculation as `GriddedSurfaceUtils.getDistanceX_old(FaultTrace, Location)`.

