### PR TITLE
Hotfix - Mean UCERF3 ERF (POISSON ONLY LARGE MEM) Complete Model Runtime Exception

### DIFF
--- a/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
+++ b/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
@@ -503,15 +503,22 @@ public class MeanUCERF3 extends FaultSystemSolutionERF {
 		// Otherwise, download mean sol to build locally.
 		// As such, it won't update client meta.
 		if (!ignoreCache) {
-			CompletableFuture<File> solFileDownloader = checkDownload(solFile.getName());
-			File solutionFile = solFileDownloader.join();
+			File solutionFile;
+			try {
+				CompletableFuture<File> solFileDownloader = checkDownload(solFile.getName());
+				solutionFile = solFileDownloader.join();
+			} catch (NullPointerException e) {
+				if (D) System.err.println(solFile.getName() + " solution doesn't exist on server. Trying cache...");
+				e.printStackTrace();
+				solutionFile = solFile;
+			}
 			try {
 				FaultSystemSolution sol = FaultSystemSolution.load(solutionFile);
 				checkCombineMags(sol);
 				setSolution(sol);
 				return;
 			} catch (Exception e) {
-				ExceptionUtils.throwAsRuntimeException(e);
+				if (D) System.err.println(solutionFile + " not found. Loading mean solution.");
 			}
 		}
 		


### PR DESCRIPTION
Fixes #169

This hotfix resolves the "file" is null runtime exception in HazardCurveApplication v25.4.0.

The complete model preset is the only Mean UCERF3 Preset where the upperDepthTol == 0d, instead of 100d.
In v1.5.2 this requested the resource, "http://opensha.usc.edu/ftp/ucerf3_erf/cached_dep0.0_depShallow_rakeAll.zip". There is no such file. When there is no file on the server and no cached file, the previous behavior was to load the mean solution.
Similarly, there is no such file or metadata entry on CARC for v25.4.0. The default behavior for GetFile is to throw a NullPointerException, which we forgot to catch in MeanUCERF3.

@kevinmilner Should we build and upload a `cached_dep0.0_depShallow_rakeAll`? This won't require any code changes, so can be made independent of this PR.

This hotfix ensures that the mean solution is loaded in this case for v25.4.0. As a hotfix, this PR commit will be tagged with version v25.4.1 (Yes, even though it is May. We consider the month of the major release) and a new hotfix release should be issued. Existing changes in opensha/master will not be merged in at this time. To accomplish this, our hotfix branched off the latest release. After PR approval, the merge plan is as follows:
* opensha-fork/hotfix/mean-ucerf3-complete-model -> opensha/release/25.4
* opensha/release/25.4 -> opensha-fork/release/25.4
* opensha-fork/release/25.4 -> opensha-fork/main
* opensha-fork/main -> opensha/master

This plan may change if we choose to implement a dedicated develop branch in the future, but for now can be taken as reference for our modified forking development flow.

