### PR TITLE
Hotfix minor release - v25.4.1

### DIFF
--- a/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
+++ b/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
@@ -503,15 +503,22 @@ public class MeanUCERF3 extends FaultSystemSolutionERF {
 		// Otherwise, download mean sol to build locally.
 		// As such, it won't update client meta.
 		if (!ignoreCache) {
-			CompletableFuture<File> solFileDownloader = checkDownload(solFile.getName());
-			File solutionFile = solFileDownloader.join();
+			File solutionFile;
+			try {
+				CompletableFuture<File> solFileDownloader = checkDownload(solFile.getName());
+				solutionFile = solFileDownloader.join();
+			} catch (NullPointerException e) {
+				if (D) System.err.println(solFile.getName() + " solution doesn't exist on server. Trying cache...");
+				e.printStackTrace();
+				solutionFile = solFile;
+			}
 			try {
 				FaultSystemSolution sol = FaultSystemSolution.load(solutionFile);
 				checkCombineMags(sol);
 				setSolution(sol);
 				return;
 			} catch (Exception e) {
-				ExceptionUtils.throwAsRuntimeException(e);
+				if (D) System.err.println(solutionFile + " not found. Loading mean solution.");
 			}
 		}
 		


### PR DESCRIPTION
Fixes #169 

Mean UCERF3 ERF Complete Model Preset in HazardCurveApplication used to create a NullPointerException in v25.4.0. This hotfix marks a minor release v25.4.1, which restores the behavior as found in v1.5.2. The model computes successfully now.
