### PR TITLE
Hotfix - Resolve NullPointerException in GCIM Module

### DIFF
--- a/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
+++ b/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
@@ -683,7 +683,7 @@ implements ParameterChangeFailListener, ParameterChangeListener,
 			//update the off-diagonal ImikjCorrRel terms in the array list
 			//Get the number of IMik|j CorrRels that SHOULD be in the HashMap
 			int numIMikCorrRels = (i+1)*(i+1-1)/2 - (i)*(i-1)/2;
-			ArrayList<? extends Map<TectonicRegionType, ImCorrelationRelationship>> IMikCorrRels = null;
+			ArrayList<? extends Map<TectonicRegionType, ImCorrelationRelationship>> IMikCorrRels = new ArrayList<>();
 			if (numIMikCorrRels>0) {
 				IMikCorrRels = gcimEditIMiControlPanel.getSelectedIMikjCorrRelMap();
 			}


### PR DESCRIPTION
Fixes #174 

In updateIMiDetailsInArrayLists, a new IMikCorrRels is initiated as null, when it should be initiated as a new ArrayList.

Doing so ensures that we don't place null values in the IMikjCorrRelMap in the event that there is a change in the GCIM Calculator while also having zero IMikCorrRels. When trying to flatten the contents of the map into an array, this fails when encountering null instead of a list.

After approval, this hotfix will be merged directly into the latest stable release, backported into our development branch, and new assets will be released for minor release v25.4.2.
