### PR TITLE
Hotfix minor release - v25.4.2

### DIFF
--- a/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
+++ b/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
@@ -683,7 +683,7 @@ implements ParameterChangeFailListener, ParameterChangeListener,
 			//update the off-diagonal ImikjCorrRel terms in the array list
 			//Get the number of IMik|j CorrRels that SHOULD be in the HashMap
 			int numIMikCorrRels = (i+1)*(i+1-1)/2 - (i)*(i-1)/2;
-			ArrayList<? extends Map<TectonicRegionType, ImCorrelationRelationship>> IMikCorrRels = null;
+			ArrayList<? extends Map<TectonicRegionType, ImCorrelationRelationship>> IMikCorrRels = new ArrayList<>();
 			if (numIMikCorrRels>0) {
 				IMikCorrRels = gcimEditIMiControlPanel.getSelectedIMikjCorrRelMap();
 			}


### PR DESCRIPTION
Backport hotfix for v25.4.2 into main. This fixes a NullPointerException found in the GCIM module when setting the IMR.

