### PR TITLE
Ability to have logarithmic scales on colorbars for XYZ plots

### DIFF
--- a/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
+++ b/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
@@ -1768,7 +1768,7 @@ public class GraphPanel extends JSplitPane {
 			// this fixes the overlap issue with the bottom of the plot (not sure if needed here, used for regular plots)
 			logAxis.setVerticalAnchorShift(4);
 			logAxis.setLowerBound(scale.getLowerBound());
-			logAxis.setLowerBound(scale.getUpperBound());
+			logAxis.setUpperBound(scale.getUpperBound());
 			
 			fakeZAxis = logAxis;
 		} else {

--- a/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
+++ b/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
@@ -67,6 +67,7 @@ import org.opensha.commons.data.xyz.XYZ_DataSet;
 import org.opensha.commons.gui.plot.jfreechart.CustomOffsetNumberAxis;
 import org.opensha.commons.gui.plot.jfreechart.DiscretizedFunctionXYDataSet;
 import org.opensha.commons.gui.plot.jfreechart.JFreeLogarithmicAxis;
+import org.opensha.commons.gui.plot.jfreechart.LogPaintScaleLegend;
 import org.opensha.commons.gui.plot.jfreechart.MyTickUnits;
 import org.opensha.commons.gui.plot.jfreechart.xyzPlot.PaintScaleWrapper;
 import org.opensha.commons.gui.plot.jfreechart.xyzPlot.XYIntervalBlockRenderer;
@@ -1784,7 +1785,12 @@ public class GraphPanel extends JSplitPane {
 		fakeZAxis.setLabelFont(new Font(axisLabelFont.getFontName(),axisLabelFont.getStyle(),axisFontSize));
 		Font axisTickFont = fakeZAxis.getTickLabelFont();
 		fakeZAxis.setTickLabelFont(new Font(axisTickFont.getFontName(),axisTickFont.getStyle(),tickFontSize));
-		PaintScaleLegend legend = new PaintScaleLegend(scale, fakeZAxis);
+		PaintScaleLegend legend;
+		if (cpt.isLog10())
+			// this will do the subdivisions correctly in log-space, rather than getting bigger for smaller values
+			legend = new LogPaintScaleLegend(scale, (JFreeLogarithmicAxis)fakeZAxis);
+		else
+			legend = new PaintScaleLegend(scale, fakeZAxis);
 		legend.setSubdivisionCount(500);
 		if (position != null)
 			legend.setPosition(position);

--- a/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
+++ b/src/main/java/org/opensha/commons/gui/plot/GraphPanel.java
@@ -1760,16 +1760,30 @@ public class GraphPanel extends JSplitPane {
 	
 	private static PaintScaleLegend getLegendForCPT(PaintScaleWrapper scale, String zAxisLabel,
 			int axisFontSize, int tickFontSize, double tickUnit, RectangleEdge position) {
-		NumberAxis fakeZAxis = new NumberAxis();
-		fakeZAxis.setLowerBound(scale.getLowerBound());
-		fakeZAxis.setUpperBound(scale.getUpperBound());
-		fakeZAxis.setLabel(zAxisLabel);
+		CPT cpt = scale.getCPT();
+		ValueAxis fakeZAxis;
+		if (cpt.isLog10()) {
+			JFreeLogarithmicAxis logAxis = new JFreeLogarithmicAxis(zAxisLabel);
+			// this fixes the overlap issue with the bottom of the plot (not sure if needed here, used for regular plots)
+			logAxis.setVerticalAnchorShift(4);
+			logAxis.setLowerBound(scale.getLowerBound());
+			logAxis.setLowerBound(scale.getUpperBound());
+			
+			fakeZAxis = logAxis;
+		} else {
+			NumberAxis linearAxis = new NumberAxis();
+			linearAxis.setLowerBound(scale.getLowerBound());
+			linearAxis.setUpperBound(scale.getUpperBound());
+			linearAxis.setLabel(zAxisLabel);
+			if (tickUnit > 0)
+				linearAxis.setTickUnit(new NumberTickUnit(tickUnit));
+			
+			fakeZAxis = linearAxis;
+		}
 		Font axisLabelFont = fakeZAxis.getLabelFont();
 		fakeZAxis.setLabelFont(new Font(axisLabelFont.getFontName(),axisLabelFont.getStyle(),axisFontSize));
 		Font axisTickFont = fakeZAxis.getTickLabelFont();
 		fakeZAxis.setTickLabelFont(new Font(axisTickFont.getFontName(),axisTickFont.getStyle(),tickFontSize));
-		if (tickUnit > 0)
-			fakeZAxis.setTickUnit(new NumberTickUnit(tickUnit));
 		PaintScaleLegend legend = new PaintScaleLegend(scale, fakeZAxis);
 		legend.setSubdivisionCount(500);
 		if (position != null)

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
@@ -118,6 +118,12 @@ import org.jfree.chart.ui.TextAnchor;
 
 /**
  * A numerical axis that uses a logarithmic scale.
+ * 
+ * Note from Kevin in 2025: I don't know where this came from or why we have our own in OpenSHA, it seems to be based
+ * on an ancient JreeChart implementation and is similar to (but differs from) the log axis supplied directly in
+ * JFreeChart. I remember hearing that we contributed some code related to this back to JFreeChart (before I arrived
+ * in 2008), so maybe this is part of that? I also don't know who Michael Duffy is, but the JFreeChart LogAxis
+ * class claims to have been originally contributed by him.
  *
  * @author Michael Duffy
  */

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
@@ -101,6 +101,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.math3.util.Precision;
 import org.jfree.chart.axis.AxisState;
 import org.jfree.chart.axis.LogAxis;
 import org.jfree.chart.axis.NumberTick;
@@ -345,7 +346,8 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 //				System.out.println("\t\tj="+j+", tickVal="+tickVal+", tickLabel="+tickLabel);
 
-				if (tickVal > upperBoundVal) {
+				if (tickVal > upperBoundVal && !Precision.equals(tickVal, upperBoundVal, upperBoundVal*1e-6)) {
+//					System.out.println("We're past it: "+tickVal+" > "+upperBoundVal);
 					return ticks;     //if past highest data value then exit method
 				}
 
@@ -646,7 +648,6 @@ public class JFreeLogarithmicAxis extends LogAxis {
 	protected AxisState drawTickMarksAndLabels(Graphics2D g2, double cursor,
 			Rectangle2D plotArea,
 			Rectangle2D dataArea, RectangleEdge edge) {
-
 		AxisState state = new AxisState(cursor);
 
 		//calls the super class function if user wants to use the "1e#" style of labelling of ticks.
@@ -661,6 +662,12 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 		List ticks = refreshTicks(g2, state, dataArea, edge);
 		state.setTicks(ticks);
+		
+		Font tickFont = this.getTickLabelFont();
+
+		Font majorTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() + (int)(tickFont.getSize() * 0.2));
+		Font minorTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
+		Font powerTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
 
 		g2.setFont(getTickLabelFont());
 		Iterator iterator = ticks.iterator();
@@ -673,9 +680,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 				eIndex =tick.getText().indexOf("E");
 			boolean majorAxis = eIndex >= 0;
 
-			Font tickFont = this.getTickLabelFont();
-			if (majorAxis)
-				g2.setFont(new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize()+(int)(tickFont.getSize()*(0.2))));
+			g2.setFont(majorAxis ? majorTickFont : minorTickFont);
 
 			if (isTickLabelsVisible()) {
 				g2.setPaint(getTickLabelPaint());
@@ -718,7 +723,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 								tick.getRotationAnchor()
 						);
 						// setting the font properties to show the power of 10
-						g2.setFont(new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize()-(int)(tickFont.getSize()*(0.2))));
+						g2.setFont(powerTickFont);
 
 						float horzOffset = (int)(0.3*getTickLabelFont().getSize());
 						if (!tick.getText().startsWith("-") && edge == RectangleEdge.BOTTOM)

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/JFreeLogarithmicAxis.java
@@ -93,6 +93,9 @@ package org.opensha.commons.gui.plot.jfreechart;
 
 import java.awt.Font;
 import java.awt.Graphics2D;
+import java.awt.font.FontRenderContext;
+import java.awt.font.GlyphVector;
+import java.awt.font.TextLayout;
 import java.awt.geom.Line2D;
 import java.awt.geom.Rectangle2D;
 import java.text.DecimalFormat;
@@ -111,6 +114,9 @@ import org.jfree.chart.plot.Plot;
 import org.jfree.chart.plot.ValueAxisPlot;
 import org.jfree.chart.text.TextUtils;
 import org.jfree.data.Range;
+
+import com.google.common.base.Preconditions;
+
 import org.jfree.chart.ui.RectangleEdge;
 import org.jfree.chart.ui.RectangleInsets;
 import org.jfree.chart.ui.TextAnchor;
@@ -119,11 +125,10 @@ import org.jfree.chart.ui.TextAnchor;
 /**
  * A numerical axis that uses a logarithmic scale.
  * 
- * Note from Kevin in 2025: I don't know where this came from or why we have our own in OpenSHA, it seems to be based
- * on an ancient JreeChart implementation and is similar to (but differs from) the log axis supplied directly in
- * JFreeChart. I remember hearing that we contributed some code related to this back to JFreeChart (before I arrived
- * in 2008), so maybe this is part of that? I also don't know who Michael Duffy is, but the JFreeChart LogAxis
- * class claims to have been originally contributed by him.
+ * Note from Kevin in 2025: JFreeChart comes with log axis implementations (including LogAxis which this extends), but
+ * they don't have the major-minor notation we support here. I remember hearing that we contributed some code related
+ * to this back to JFreeChart (before I arrived in 2008), so maybe this is part of that? I also don't know who Michael
+ * Duffy is, but the JFreeChart LogAxis class claims to have been originally contributed by him.
  *
  * @author Michael Duffy
  */
@@ -157,13 +162,13 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 	/** Flag set true to show the  tick labels for minor axis */
 	protected boolean minorAxisTickLabelFlag = true;
-	
+
 	private float verticalAnchorShift = 0f;
 
 	public JFreeLogarithmicAxis(String label) {
 		super(label);
 	}
-	
+
 	/**
 	 * Sets the 'strictValuesFlag' flag; if true;
 	 * then this axis will throw a runtime exception if any of its
@@ -198,7 +203,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		log10TickLabelsInPowerFlag = false;
 		setupNumberFmtObj();             //setup number formatter obj
 	}
-	
+
 	/**
 	 * Sets up the number formatter object according to the
 	 * 'expTickLabelsFlag' flag.
@@ -264,7 +269,169 @@ public class JFreeLogarithmicAxis extends LogAxis {
 	public boolean getMinorAxisTickLabelFlag() {
 		return minorAxisTickLabelFlag;
 	}
+
+	/**
+	 * Tick label bounds. The full bounds will be in index 0. For major ticks in power mode, the major and minor
+	 * bounds will be included in indexes 1 and 2, respectively.
+	 * 
+	 * The bound coordinates will be relative to the given anchor 
+	 * 
+	 * @param g2
+	 * @param label
+	 * @param majorAxis
+	 * @param majorTickFont
+	 * @param minorTickFont
+	 * @param anchor
+	 * @return
+	 */
+	private Rectangle2D[] getTickLabelBounds(Graphics2D g2, String label, boolean majorAxis, boolean verticalAxis,
+			Font majorTickFont, Font minorTickFont, TextAnchor anchor) {
+		return getTickLabelBounds(g2, label, majorAxis, verticalAxis, majorTickFont, minorTickFont, anchor, 0d, 0d);
+	}
+
+
+
+	/**
+	 * Tick label bounds. The full bounds will be in index 0. For major ticks in power mode, the major and minor
+	 * bounds will be included in indexes 1 and 2, respectively.
+	 * 
+	 * The bound coordinates will be relative to the given anchor and the given offsets
+	 * 
+	 * @param g2
+	 * @param label
+	 * @param majorAxis
+	 * @param majorTickFont
+	 * @param minorTickFont
+	 * @param anchor
+	 * @param xOffset
+	 * @param yOffset
+	 * @return
+	 */
+	private Rectangle2D[] getTickLabelBounds(Graphics2D g2, String label, boolean majorAxis, boolean verticalAxis,
+			Font majorTickFont, Font minorTickFont, TextAnchor anchor, double xOffset, double yOffset) {
+		// this part will be aligned to (0, 0)
+		Rectangle2D[] ret;
+		if (label.isEmpty()) {
+			// easy
+			ret = new Rectangle2D[] {getStringBounds(label, minorTickFont, g2)};
+			// re-align to (0, 0)
+			ret[0] = new Rectangle2D.Double(0, 0, ret[0].getWidth(), ret[0].getHeight());
+		} else if (!majorAxis) {
+			// minor axis
+			ret = new Rectangle2D[] {getStringBounds(label, minorTickFont, g2)};
+			double x;
+			if (verticalAxis) {
+				// shift to the leftso that it doesn't line up with the exponent
+				x = -ret[0].getWidth();
+			} else {
+				// re-align to (0, 0)
+				x = 0;
+			}
+			ret[0] = new Rectangle2D.Double(x, 0, ret[0].getWidth(), ret[0].getHeight());
+		} else if (!log10TickLabelsInPowerFlag) {
+			// major axis, but keeping the 1EN notation, also easy
+			ret = new Rectangle2D[] {getStringBounds(label, majorTickFont, g2)};
+			// re-align to (0, 0)
+			ret[0] = new Rectangle2D.Double(0, 0, ret[0].getWidth(), ret[0].getHeight());
+		} else {
+			// we're a major tick, and we're using the 10^n notation, more complicated
+			int eIndex = label.toLowerCase().indexOf("e");
+			Preconditions.checkState(eIndex > 0, "Passed in tick label ('%s') doesn't use E notation?", label);
+			Rectangle2D largeBounds = getStringBounds(label.substring(0, eIndex), majorTickFont, g2);
+			Rectangle2D smallBounds = getStringBounds(label.substring(eIndex+1), minorTickFont, g2);
+			// small bounds here are for the actual string, but we want to make sure everything lines up the same
+			// no matter how many digits in the exponent; we also don't want to consider the negative sign
+			Range range = getRange();
+			int maxExp = (int)Math.max(Math.abs(Math.floor(switchedLog10(range.getLowerBound()))),
+					Math.abs(Math.ceil(switchedLog10(range.getUpperBound()))));
+			Rectangle2D refSmallBounds = getStringBounds(maxExp+"", minorTickFont, g2);
+//			double smallMaxX = Math.max(largeBounds.getWidth()*0.8, largeBounds.getWidth()-2d) + refSmallBounds.getWidth();
+			double smallMaxX = largeBounds.getWidth() + refSmallBounds.getWidth();
+			double smallX = smallMaxX - smallBounds.getWidth();
+//			double smallY = -3-(int)(0.4*this.getTickLabelFont().getSize());
+			double smallY = -(int)(0.4*majorTickFont.getSize());
+			double largeX = 0;
+			double largeY = 0; // small will actually go above the anchor, which is ok
+			largeBounds = new Rectangle2D.Double(largeX, largeY, largeBounds.getWidth(), largeBounds.getHeight());
+			smallBounds = new Rectangle2D.Double(smallX, smallY, smallBounds.getWidth(), smallBounds.getHeight());
+			Rectangle2D combBounds = new Rectangle2D.Double(0d, 0d,
+					Math.max(largeBounds.getWidth(), smallX+smallBounds.getWidth()),
+					largeY+largeBounds.getHeight());
+			ret = new Rectangle2D[] {combBounds, largeBounds, smallBounds};
+		}
+		double totalWidth = ret[0].getWidth();
+		double totalHeight = ret[0].getHeight();
+		//		System.out.println("Plotting label '"+label+"'; original offset was: "+xOffset+", "+yOffset+", anchor is "+anchor);
+		if (anchor.isHorizontalCenter())
+			xOffset -= totalWidth*0.5;
+		else if (anchor.isRight())
+			xOffset -= totalWidth;
+		if (anchor.isVerticalCenter())
+			yOffset -= totalHeight*0.5;
+		else if (anchor.isBottom())
+			yOffset -= totalHeight;
+		if (verticalAxis && ret.length == 1) {
+			// correct for the slight vertical offset of using getStringBounds rather than the actual glyph bounds
+			double offset = calcVerticalStringOffset(label, majorAxis ? majorTickFont : minorTickFont, g2);
+			yOffset -= offset;
+		}
+		// re-align everything
+		for (int i=0; i<ret.length; i++)
+			ret[i] = new Rectangle2D.Double(ret[i].getX()+xOffset, ret[i].getY()+yOffset, ret[i].getWidth(), ret[i].getHeight());
+		//		System.out.print("Returned bounds:");
+		//		for (Rectangle2D rect : ret)
+		//			System.out.println("\t"+rect);
+		return ret;
+	}
+
+	private static Rectangle2D getStringBounds(String text, Font font, Graphics2D g2) {
+		return font.getStringBounds(text, g2.getFontRenderContext());
+		// this can be used to get the actual visual bounds, but that's not very useful because printing it will put it
+		// in the string bounds above anyway
+		//		String origStr = text;
+		//		if (origStr.isEmpty())
+		//			text = " ";
+		//		TextLayout tl = new TextLayout(text, font, g2.getFontRenderContext());
+		//		Rectangle2D visual = tl.getBounds();
+		//		double tightWidth  = visual.getWidth();
+		//		double tightHeight = visual.getHeight();
+		//		if (origStr.isEmpty())
+		//			tightWidth = 0;
+		//		return new Rectangle2D.Double(0d, 0d, tightWidth, tightHeight);
+	}
 	
+	/**
+	 * {@link Font#getStringBounds(String, java.awt.font.FontRenderContext)} returns padded boundaries that usually
+	 * extend above (and, less so, below) the actual visual bounds for a string. This returns how far below the center
+	 * of those regular string bounds the actual printed center lies, in pixels.
+	 * 
+	 * @param text the string to measure
+	 * @param font the font used to draw the string
+	 * @param g2   the Graphics2D (providing the FontRenderContext)
+	 * @return the vertical offset (in pixels) by which the visual center of the text is below the logical center
+	 */
+	private static double calcVerticalStringOffset(String text, Font font, Graphics2D g2) {
+		if (text == null || text.isEmpty()) {
+			return 0d;
+		}
+		FontRenderContext frc = g2.getFontRenderContext();
+
+		// 1) Compute the logical bounds (ascent + descent + leading)
+		Rectangle2D logical = font.getStringBounds(text, frc);
+		double logicalCenter = logical.getY() + logical.getHeight() / 2.0;
+
+		// 2) Compute the visual (pixel‐tight) bounds using a GlyphVector
+		GlyphVector gv = font.createGlyphVector(frc, text);
+		Rectangle2D visual = gv.getVisualBounds();
+		double visualCenter = visual.getY() + visual.getHeight() / 2.0;
+
+		// 3) The offset is how far the actual printed center lies below
+		//    the logical center. Positive → visual center is lower on screen.
+		return visualCenter - logicalCenter;
+	}
+
+	private static double TICK_OVERLAP_BUFFER = 6; // in pixels
+
 	/**
 	 * Calculates the positions of the tick labels for the axis, storing the results in the
 	 * tick label list (ready for drawing).
@@ -278,9 +445,8 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			Rectangle2D dataArea,
 			RectangleEdge edge) {
 
-		List ticks = new ArrayList();
-		double x0 =  0;
-		List ticksXVals = new ArrayList();
+		List<NumberTick> ticks = new ArrayList<>();
+		List<Double> tickEndVals = new ArrayList<>();
 		//get lower bound value:
 		double lowerBoundVal = getRange().getLowerBound();
 		//if small log values and lower bound value too small
@@ -296,8 +462,10 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		//get log10 version of upper bound and round to integer:
 		int iEndCount = (int) StrictMath.ceil(switchedLog10(upperBoundVal));
 		
-//		System.out.println("refreshTicksHoriz: lower="+lowerBoundVal+", upper="+upperBoundVal);
-//		System.out.println("\tiBegCount="+iBegCount+", iEndCount="+iEndCount);
+		boolean showMinor = shouldShowMinor(dataArea, edge);
+
+		//		System.out.println("refreshTicksHoriz: lower="+lowerBoundVal+", upper="+upperBoundVal);
+		//		System.out.println("\tiBegCount="+iBegCount+", iEndCount="+iEndCount);
 
 		double tickVal;
 		String tickLabel="";
@@ -307,13 +475,14 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		if(iBegCount == iEndCount)
 			--iBegCount;
 
-		//Add one major Axis in ther range if there is none in the range.
+		//Add one major Axis in the range if there is none in the range.
 		//The one major Axis added is the one below the lowerBoundVal.
 		//And checks if the upperBound is not a major Axis, then no need to include one major axis
 		if(iEndCount - iBegCount ==1 && (upperBoundVal!=Double.parseDouble("1e"+iEndCount)))
 			setRange(Double.parseDouble("1e"+iBegCount),upperBoundVal);
 
-
+		Font majorTickFont = getMajorTickFont();
+		Font minorTickFont = getMinorTickFont();
 
 		for (int i = iBegCount; i <= iEndCount; i++) {
 			//for each tick with a label to be displayed
@@ -327,6 +496,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 				//small log values in use
 				tickVal = Double.parseDouble("1e"+i) * (1 + j);
+				boolean majorAxis = j == 0;
 				//j=0 means that it is the major Axis with absolute power of 10.
 				if (j == 0) {
 					//checks to if tick Labels to be represented in the form of superscript of 10.
@@ -350,92 +520,107 @@ public class JFreeLogarithmicAxis extends LogAxis {
 						tickLabel = "";
 				}
 
-//				System.out.println("\t\tj="+j+", tickVal="+tickVal+", tickLabel="+tickLabel);
+				//				System.out.println("\t\tj="+j+", tickVal="+tickVal+", tickLabel="+tickLabel);
 
 				if (tickVal > upperBoundVal && !Precision.equals(tickVal, upperBoundVal, upperBoundVal*1e-6)) {
-//					System.out.println("We're past it: "+tickVal+" > "+upperBoundVal);
+					//					System.out.println("We're past it: "+tickVal+" > "+upperBoundVal);
 					return ticks;     //if past highest data value then exit method
 				}
 
 				if (tickVal >= lowerBoundVal - SMALL_LOG_VALUE) {
-					TextAnchor anchor = null;
-					TextAnchor rotationAnchor = null;
-					double angle = 0.0;	
-					//tick value not below lowest data value
-					double xx = valueToJava2D(tickVal, dataArea, edge);
-					Rectangle2D tickLabelBounds = getTickLabelFont().getStringBounds(
-							tickLabel, g2.getFontRenderContext());
-					float x = 0.0f;
-					float y = 0.0f;
-					RectangleInsets tickLabelInsets = getTickLabelInsets();
+					TextAnchor anchor;
+					TextAnchor rotationAnchor;
 					if (isVerticalTickLabels()) {
 						anchor = TextAnchor.CENTER_RIGHT;
 						rotationAnchor = TextAnchor.CENTER_RIGHT;
-						x = (float) (xx + tickLabelBounds.getHeight() / 2);
+					} else if (edge == RectangleEdge.TOP) {
+						anchor = TextAnchor.BOTTOM_CENTER;
+						rotationAnchor = TextAnchor.BOTTOM_CENTER;
+					} else {
+						anchor = TextAnchor.TOP_CENTER;
+						rotationAnchor = TextAnchor.TOP_CENTER;
+					}
+					double angle = 0.0;	
+					Rectangle2D tickLabelBounds = getTickLabelBounds(g2, tickLabel, majorAxis, false,
+							majorTickFont, minorTickFont, TextAnchor.TOP_LEFT)[0];
+					Preconditions.checkState(tickLabelBounds.getX() == 0d);
+					Preconditions.checkState(tickLabelBounds.getY() == 0d);
+					double tickCenter = valueToJava2D(tickVal, dataArea, edge);
+					double tickLabelStart, tickLabelEnd;
+					if (isVerticalTickLabels()) {
+						tickLabelStart = tickCenter - 0.5*tickLabelBounds.getHeight();
+						tickLabelEnd = tickCenter + 0.5*tickLabelBounds.getHeight();
 						if (edge == RectangleEdge.TOP) {
 							angle = Math.PI / 2.0;
-							y = (float) (dataArea.getMinY() - tickLabelInsets.getBottom()
-									- tickLabelBounds.getWidth());
 						}
 						else {
 							angle = -Math.PI / 2.0;
-							y = (float) (dataArea.getMaxY() + tickLabelInsets.getTop()
-									+ tickLabelBounds.getWidth());
 						}
-					}
-					else {
-						x = (float) (xx - tickLabelBounds.getWidth() / 2);
-						if (edge == RectangleEdge.TOP) {
-							anchor = TextAnchor.BOTTOM_CENTER;
-							rotationAnchor = TextAnchor.BOTTOM_CENTER;
-							y = (float) (dataArea.getMinY() - tickLabelInsets.getBottom());
-						}
-						else {
-							anchor = TextAnchor.TOP_CENTER;
-							rotationAnchor = TextAnchor.TOP_CENTER;
-							y = (float) (dataArea.getMaxY() + tickLabelInsets.getTop()
-									+ tickLabelBounds.getHeight());
-						}
+					} else {
+						tickLabelStart = tickCenter - 0.5*tickLabelBounds.getWidth();
+						tickLabelEnd = tickCenter + 0.5*tickLabelBounds.getWidth();
 					}
 					if(this.log10TickLabelsInPowerFlag){
 						//removing the minor labelling, if the ticks overlap.
 						/* also if the difference in the powers of the smallest major axis
 						 * and largest major axis is larger than 3 then don't label the minor axis
 						 **/
-						 if((x<x0 || (iEndCount-iBegCount>3)) && j!=0 && minorAxisTickLabelFlag)
-							 tickLabel="";
-						 else{
-							 //removing the previous minor tickLabels if the major axis overlaps any tickLabels
-							 if(j==0){
-								 int size = ticks.size();
-								 --size;
-								 while(x<=x0 && size>0){
-									 //only remove the previous ticklabel if that has been labelled.
-									 Tick tempTick = ((Tick)ticks.get(size));
-									 if(!tempTick.getText().equals("") && !tempTick.getText().contains("E"))
-										 removePreviousTick(ticks);
-									 x0 =  ((Double)ticksXVals.get(size)).doubleValue()+3;
-									 --size;
-								 }
-							 }
-							 x0 = x + tickLabelBounds.getWidth() +3;
-						 }
+						//						 if((x<x0 || (iEndCount-iBegCount>3)) && j!=0 && minorAxisTickLabelFlag)
+						double prevBufferedEnd = 0d;
+						for (int k=ticks.size(); --k>=0;) {
+							if (!ticks.get(k).getText().isEmpty()) {
+								prevBufferedEnd = tickEndVals.get(k) + TICK_OVERLAP_BUFFER;
+								break;
+							}
+						}
+						if (minorAxisTickLabelFlag) {
+							if (j == 0) {
+								// this is major
+								if (!ticks.isEmpty()) {
+									// remove any previous minor tick labels overlap this major
+									for (int k=tickEndVals.size(); --k>=0;) {
+										double testBufferedEnd = tickEndVals.get(k) + TICK_OVERLAP_BUFFER;
+										if (tickLabelStart < testBufferedEnd) {
+											// we overlap, but see if it has actually been labeled
+											NumberTick tempTick = ticks.get(k);
+											if(!tempTick.getText().equals("") && !tempTick.getText().contains("E")) {
+												// it has a label, clear it
+												double value = tempTick.getValue();
+												ticks.set(k, new NumberTick(value, "",
+														tempTick.getTextAnchor(), tempTick.getRotationAnchor(), tempTick.getAngle()));
+												tickEndVals.set(k, value);
+											}
+										} else {
+											break;
+										}
+									}
+								}
+							} else {
+								// this is minor, see if we overlap the previous one (or have more than max decades)
+								if (tickLabelStart < prevBufferedEnd || !showMinor) {
+									// we do
+									tickLabel = "";
+									tickLabelStart = tickCenter;
+									tickLabelEnd = tickCenter;
+								}
+							}
+						}
 					}
-//					System.out.println("adding tick with val="+tickVal+", label="+tickLabel);
-					Tick tick = new NumberTick(tickVal, tickLabel, anchor, rotationAnchor,angle);
+					//					System.out.println("adding tick with val="+tickVal+", label="+tickLabel);
+					NumberTick tick = new NumberTick(tickVal, tickLabel, anchor, rotationAnchor,angle);
 					ticks.add(tick);
-					ticksXVals.add(Double.valueOf(x));
+					tickEndVals.add(tickLabelEnd);
 				}
 			}
 		}
-//		System.out.println("Returning this tick list:");
-//		for (int i=0; i<ticks.size(); i++) {
-//			ValueTick tick = (ValueTick)ticks.get(i);
-//			System.out.println("\t"+i+". val="+tick.getValue()+", label="+tick.getText());
-//		}
+		//		System.out.println("Returning this tick list:");
+		//		for (int i=0; i<ticks.size(); i++) {
+		//			ValueTick tick = (ValueTick)ticks.get(i);
+		//			System.out.println("\t"+i+". val="+tick.getValue()+", label="+tick.getText());
+		//		}
 		return ticks;
 	}
-	
+
 	/**
 	 * Returns the log10 value, depending on if values between 0 and
 	 * 1 are being plotted.  If negative values are not allowed and
@@ -449,6 +634,23 @@ public class JFreeLogarithmicAxis extends LogAxis {
 	 */
 	protected double switchedLog10(double val) {
 		return StrictMath.log(val) / LOG10_VALUE ;
+	}
+	
+	private static final double MIN_PIXELS_PER_DECADE_FOR_MINOR = 100d;
+	
+	private boolean shouldShowMinor(Rectangle2D dataArea, RectangleEdge edge) {
+		Range range = getRange();
+		double lowerPixel = valueToJava2D(range.getLowerBound(), dataArea, edge);
+		double upperPixel = valueToJava2D(range.getUpperBound(), dataArea, edge);
+		double totPixels = Math.abs(upperPixel - lowerPixel); // abs here because for vertical, upperPixel < lowerPixel
+		if (totPixels < 100)
+			// way too small
+			return false;
+		double decades = switchedLog10(range.getUpperBound()) - switchedLog10(range.getLowerBound());
+
+		// show minor only if we have at least MIN_PIXELS_PER_DECADE_FOR_MINOR for each decade
+		double pixelsPerDecade = totPixels / decades;
+		return pixelsPerDecade >= MIN_PIXELS_PER_DECADE_FOR_MINOR;
 	}
 
 	/**
@@ -464,9 +666,8 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			Rectangle2D dataArea,
 			RectangleEdge edge) {
 
-		List ticks = new ArrayList();
-		List ticksYVals = new ArrayList();
-		double y0 =9999;
+		List<NumberTick> ticks = new ArrayList<>();
+		List<Double> tickEndVals = new ArrayList<>();
 		//get lower bound value:
 		double lowerBoundVal = getRange().getLowerBound();
 		//if small log values and lower bound value too small
@@ -482,7 +683,8 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		int iBegCount = (int) StrictMath.floor(switchedLog10(lowerBoundVal));
 		//get log10 version of upper bound and round to integer:
 		int iEndCount = (int) StrictMath.ceil(switchedLog10(upperBoundVal));
-
+		
+		boolean showMinor = shouldShowMinor(dataArea, edge);
 
 		//if both iBegCount and iEndCount are absolute power of 10 and are equal
 		//reduce the lowerdBound to one major Axis below
@@ -494,6 +696,14 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		//And checks if the upperBound is not a major Axis, then no need to include one major axis
 		if(iEndCount - iBegCount ==1 && (upperBoundVal!=Double.parseDouble("1e"+iEndCount)))
 			setRange(Double.parseDouble("1e"+iBegCount),upperBoundVal);
+
+		Font majorTickFont = getMajorTickFont();
+		Font minorTickFont = getMinorTickFont();
+		
+		// vertical has some extra buffer in the bounding boxes already, subtract that
+//		double TICK_OVERLAP_BUFFER = Math.max(0d, JFreeLogarithmicAxis.TICK_OVERLAP_BUFFER
+//				-calcVerticalStringOffset("1", minorTickFont, g2));
+//		System.out.println("UPDATED TICK_OVERLAP_BUFFER="+(float)JFreeLogarithmicAxis.TICK_OVERLAP_BUFFER+" to "+(float)TICK_OVERLAP_BUFFER);
 
 		double tickVal;
 		String tickLabel="";
@@ -509,6 +719,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 				//for each tick to be displayed
 				tickVal = Double.parseDouble("1e"+i) * (1 + j);
 				//j=0 means that it is the major Axis with absolute power of 10.
+				boolean majorAxis = j == 0;
 				if (j == 0) {
 					//checks to if tick Labels to be represented in the form of superscript of 10.
 					if(log10TickLabelsInPowerFlag){
@@ -526,7 +737,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 				else {   //not first tick to be displayed and it is the minor Axis tick label processing
 					if(log10TickLabelsInPowerFlag && minorAxisTickLabelFlag)
 						tickLabel = ""+(j+1);     //no tick label
-					else
+					else 
 						tickLabel = "";
 				}
 
@@ -536,32 +747,17 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 				if (tickVal >= lowerBoundVal - SMALL_LOG_VALUE) {
 					//tick value not below lowest data value
-					TextAnchor anchor = null;
-					TextAnchor rotationAnchor = null;
-					double angle = 0.0;	
-					//get Y-position for tick:
-					double yy = valueToJava2D(tickVal, dataArea, edge);
-					//get bounds for tick label:
-					Rectangle2D tickLabelBounds
-					= getTickLabelFont().getStringBounds(tickLabel, g2.getFontRenderContext());
-					//get X-position for tick label:
-					float x;
+					TextAnchor anchor;
+					TextAnchor rotationAnchor;
 					if (isVerticalTickLabels()) {
-						x = (float) (dataArea.getX()
-								- tickLabelBounds.getWidth() - getTickLabelInsets().getRight());
 						if (edge == RectangleEdge.LEFT) {
 							anchor = TextAnchor.BOTTOM_CENTER;
 							rotationAnchor = TextAnchor.BOTTOM_CENTER;
-							angle = -Math.PI / 2.0;
-						}
-						else {
+						} else {
 							anchor = TextAnchor.BOTTOM_CENTER;
 							rotationAnchor = TextAnchor.BOTTOM_CENTER;
-							angle = Math.PI / 2.0;
 						}
-					}
-					else {
-						x = (float) (dataArea.getMaxX() + getTickLabelInsets().getLeft());
+					} else {
 						if (edge == RectangleEdge.LEFT) {
 							anchor = TextAnchor.CENTER_RIGHT;
 							rotationAnchor = TextAnchor.CENTER_RIGHT;
@@ -571,37 +767,76 @@ public class JFreeLogarithmicAxis extends LogAxis {
 							rotationAnchor = TextAnchor.CENTER_LEFT;
 						}
 					}
-
-					//get Y-position for tick label:
-						float y = (float) (yy + (tickLabelBounds.getHeight() / 3));
-					if(this.log10TickLabelsInPowerFlag){
-						//removing the minor labelling, if the ticks overlap.
-						/* also if the difference in the powers of the smallest major axis
-						 * and largest major axis is larger than 3 then don't label the minor axis
-						 **/
-						if((y>y0 || (iEndCount-iBegCount>3)) && j!=0 && minorAxisTickLabelFlag)
-							tickLabel="";
-						else{
-							//removing the previous minor axis tickLabels if the major axis overlaps any tickLabels
-							if(j==0){
-								int size = ticks.size();
-								--size;
-								while(y>=y0 && size>0){
-									//only remove the previous ticklabel if that has been labelled.
-									Tick tempTick = ((Tick)ticks.get(size));
-									if(!tempTick.getText().equals("") && !tempTick.getText().contains("E"))
-										//calling the function to remove the previous ticklLabel
-										removePreviousTick(ticks);
-									y0 =  ((Double)ticksYVals.get(size)).doubleValue()-3;
-									--size;
+					double angle = 0.0;	
+					//get bounds for tick label:
+					Rectangle2D tickLabelBounds = getTickLabelBounds(g2, tickLabel, majorAxis, true,
+							majorTickFont, minorTickFont, TextAnchor.TOP_LEFT)[0];
+					// x and y can be non-zero for vertical
+					// y will be non-zero because we're correcting for glyph placing
+					//get X-position for tick label:
+					double tickCenter = valueToJava2D(tickVal, dataArea, edge);
+					double tickLabelStart, tickLabelEnd;
+					if (isVerticalTickLabels()) {
+						// start is at the bottom of the label, which means greater y (y=0 is top)
+						tickLabelStart = tickCenter + 0.5*tickLabelBounds.getWidth();
+						// end is at the top of the label, which means smaller y (y=0 is top)
+						tickLabelEnd = tickCenter - 0.5*tickLabelBounds.getWidth();
+						if (edge == RectangleEdge.LEFT)
+							angle = -Math.PI / 2.0;
+						else
+							angle = Math.PI / 2.0;
+					} else {
+						// tick is padded at the top and we correct for this by offsetting the location in the y direction
+						// but only do the start (bottom), indicating that we're moving the tick up; leave the end (top)
+						// at the original (non-offset) location.
+						double yOffset = tickLabelBounds.getY();
+						tickLabelStart = tickCenter + 0.5*tickLabelBounds.getHeight() - yOffset;
+						tickLabelEnd = tickCenter - 0.5*tickLabelBounds.getHeight();
+					}
+					Preconditions.checkState(tickLabelEnd <= tickLabelStart);
+					double prevBufferedEnd = Double.MAX_VALUE;
+					for (int k=ticks.size(); --k>=0;) {
+						if (!ticks.get(k).getText().isEmpty()) {
+							prevBufferedEnd = tickEndVals.get(k) - TICK_OVERLAP_BUFFER;
+							break;
+						}
+					}
+					if (minorAxisTickLabelFlag) {
+						if (j == 0) {
+							// this is major
+							if (!ticks.isEmpty()) {
+								// remove any previous minor tick labels overlap this major
+								for (int k=tickEndVals.size(); --k>=0;) {
+									double testBufferedEnd = tickEndVals.get(k) - TICK_OVERLAP_BUFFER;
+									if (tickLabelStart > testBufferedEnd) {
+										// we overlap, but see if it has actually been labeled
+										NumberTick tempTick = ticks.get(k);
+										if(!tempTick.getText().equals("") && !tempTick.getText().contains("E")) {
+											// it has a label, clear it
+											double value = tempTick.getValue();
+											ticks.set(k, new NumberTick(value, "",
+													tempTick.getTextAnchor(), tempTick.getRotationAnchor(), tempTick.getAngle()));
+											tickEndVals.set(k, value);
+										}
+									} else {
+										break;
+									}
 								}
 							}
-							y0 = y - tickLabelBounds.getHeight() -3;
+						} else {
+							// this is minor, see if we overlap the previous one (or have more than max decades)
+							if (tickLabelStart > prevBufferedEnd || !showMinor) {
+								// we do
+								tickLabel = "";
+								tickLabelStart = tickCenter;
+								tickLabelEnd = tickCenter;
+							}
 						}
 					}
 					//create tick object and add to list:
 					ticks.add(new NumberTick(tickVal, tickLabel, anchor,rotationAnchor,angle));
-					ticksYVals.add(Double.valueOf(y));
+					//					ticksYVals.add(Double.valueOf(y));
+					tickEndVals.add(tickLabelEnd);
 				}
 			}
 		}
@@ -628,7 +863,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			return;
 		}
 	}
-	
+
 	/**
 	 * This allows you to shift the tick labels vertically to fix some overlap issues (specifically with X axis).
 	 * 
@@ -638,6 +873,22 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		this.verticalAnchorShift = verticalAnchorShift;
 	}
 
+	private Font getMajorTickFont() {
+		Font tickFont = this.getTickLabelFont();
+		return new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() + (int)(tickFont.getSize() * 0.2));
+	}
+
+	private Font getMinorTickFont() {
+		Font tickFont = this.getTickLabelFont();
+		return new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
+	}
+
+	private Font getPowerTickFont() {
+		Font tickFont = this.getTickLabelFont();
+		return new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
+	}
+	
+	private static final boolean DEBUG_PRINT_BOUNDS = false;
 
 	/**
 	 * Draws the axis line, tick marks and tick mark labels.
@@ -663,21 +914,26 @@ public class JFreeLogarithmicAxis extends LogAxis {
 		if (isAxisLineVisible()) {
 			drawAxisLine(g2, cursor, dataArea, edge);
 		}
-		double ol = getTickMarkOutsideLength();
-		double il = getTickMarkInsideLength();
+		//		double ol = getTickMarkOutsideLength();
+		//		double il = getTickMarkInsideLength();
+		float minorOutside = (float) getTickMarkOutsideLength();
+		float minorInside  = (float) getTickMarkInsideLength();
+		// make major tick marks longer
+		float majorOutside = minorOutside * 2.5f;
+		float majorInside  = minorInside  * 2.5f;
+		
+		boolean verticalAxis = edge == RectangleEdge.LEFT || edge == RectangleEdge.RIGHT;
 
 		List ticks = refreshTicks(g2, state, dataArea, edge);
 		state.setTicks(ticks);
-		
-		Font tickFont = this.getTickLabelFont();
 
-		Font majorTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() + (int)(tickFont.getSize() * 0.2));
-		Font minorTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
-		Font powerTickFont = new Font(tickFont.getName(), tickFont.getStyle(), tickFont.getSize() - (int)(tickFont.getSize() * 0.2));
+		Font majorTickFont = getMajorTickFont();
+		Font minorTickFont = getMinorTickFont();
+		Font powerTickFont = getPowerTickFont();
 
 		g2.setFont(getTickLabelFont());
 		Iterator iterator = ticks.iterator();
-//		System.out.println("Plotting log axis labels");
+		//		System.out.println("Plotting log axis labels");
 		while (iterator.hasNext()) {
 			ValueTick tick = (ValueTick)iterator.next();
 
@@ -687,17 +943,18 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			boolean majorAxis = eIndex >= 0;
 
 			g2.setFont(majorAxis ? majorTickFont : minorTickFont);
+			float ol = majorAxis ? majorOutside : minorOutside;
+			float il = majorAxis ? majorInside  : minorInside;
 
 			if (isTickLabelsVisible()) {
 				g2.setPaint(getTickLabelPaint());
 				float[] anchorPoint = calculateAnchorPoint(
-						tick, cursor, dataArea, edge
-				);
-//				if (!tick.getText().isEmpty()) {
-//					System.out.println("tick: value="+tick.getValue()+", label="+tick.getText()+", vertical="+isVerticalTickLabels()+", edge="+edge);
-//					System.out.println("\tcursor="+cursor+", anchor="+anchorPoint[0]+","+anchorPoint[1]);
-//				}
+						tick, cursor, dataArea, edge);
 				anchorPoint[1] += verticalAnchorShift;
+				//				if (!tick.getText().isEmpty()) {
+				//					System.out.println("tick: value="+tick.getValue()+", label="+tick.getText()+", vertical="+isVerticalTickLabels()+", edge="+edge);
+				//					System.out.println("\tcursor="+cursor+", anchor="+anchorPoint[0]+","+anchorPoint[1]);
+				//				}
 
 				if (isVerticalTickLabels()) {
 					TextUtils.drawRotatedString(
@@ -706,49 +963,61 @@ public class JFreeLogarithmicAxis extends LogAxis {
 							tick.getTextAnchor(), 
 							tick.getAngle(),
 							tick.getRotationAnchor()
-					);
+							);
 				}
 				else{
-
+					Rectangle2D[] bounds = getTickLabelBounds(g2, tick.getText(), majorAxis, verticalAxis,
+							majorTickFont, minorTickFont, tick.getTextAnchor(), anchorPoint[0], anchorPoint[1]);
+					// we use bounds x and y below, which is always the top left of the box. the original text anchor
+					// has already been used when determining that location, so don't use tick.getTextAnchor()
+					TextAnchor boundsAnchor = TextAnchor.TOP_LEFT;
+					if (DEBUG_PRINT_BOUNDS) {
+						// debug: draw the anchor point
+						g2.drawRect((int)anchorPoint[0]-1, (int)anchorPoint[1]-1, 2, 2);
+						// draw the bounds
+						for (Rectangle2D b : bounds)
+							g2.drawRect((int)b.getX(), (int)b.getY(), (int)b.getWidth(), (int)b.getHeight());
+					}
 					if (!majorAxis) {
 						// minor axis (smaller font)
 						TextUtils.drawRotatedString(
 								tick.getText(), g2, 
-								anchorPoint[0], anchorPoint[1],
-								tick.getTextAnchor(), 
+								(float)bounds[0].getX(), (float)bounds[0].getY(),
+								boundsAnchor,
 								tick.getAngle(),
 								tick.getRotationAnchor()
-						);
+								);
 					} else {
 						// major axis (10)
 						TextUtils.drawRotatedString(
 								"10", g2, 
-								anchorPoint[0]-7, anchorPoint[1],
-								tick.getTextAnchor(), 
+								(float)bounds[1].getX(), (float)bounds[1].getY(),
+								boundsAnchor,
 								tick.getAngle(),
 								tick.getRotationAnchor()
-						);
+								);
 						// setting the font properties to show the power of 10
 						g2.setFont(powerTickFont);
 
-						float horzOffset = (int)(0.3*getTickLabelFont().getSize());
-						if (!tick.getText().startsWith("-") && edge == RectangleEdge.BOTTOM)
-							horzOffset *= 2;
+						//						float horzOffset = (int)(0.3*getTickLabelFont().getSize());
+						//						if (!tick.getText().startsWith("-") && edge == RectangleEdge.BOTTOM)
+						//							horzOffset *= 2;
 						TextUtils.drawRotatedString(
 								tick.getText().substring(eIndex+1), g2, 
-								anchorPoint[0]+horzOffset,
-								anchorPoint[1]-3-(int)(0.4*this.getTickLabelFont().getSize()),
-								tick.getTextAnchor(), 
+								//								anchorPoint[0]+horzOffset,
+								//								anchorPoint[1]-3-(int)(0.4*this.getTickLabelFont().getSize()),
+								(float)bounds[2].getX(), (float)bounds[2].getY(),
+								boundsAnchor,
 								tick.getAngle(),
 								tick.getRotationAnchor()
-						);
+								);
 					}
 				}
 			}
 			if (isTickMarksVisible()) {
 				float xx = (float) valueToJava2D(
 						tick.getValue(), dataArea, edge
-				);
+						);
 				Line2D mark = null;
 				g2.setStroke(getTickMarkStroke());
 				g2.setPaint(getTickMarkPaint());
@@ -774,25 +1043,25 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			if (edge == RectangleEdge.LEFT) {
 				used += findMaximumTickLabelWidth(
 						ticks, g2, plotArea, isVerticalTickLabels()
-				);  
+						);  
 				state.cursorLeft(used);      
 			}
 			else if (edge == RectangleEdge.RIGHT) {
 				used = findMaximumTickLabelWidth(
 						ticks, g2, plotArea, isVerticalTickLabels()
-				);
+						);
 				state.cursorRight(used);      
 			}
 			else if (edge == RectangleEdge.TOP) {
 				used = findMaximumTickLabelHeight(
 						ticks, g2, plotArea, isVerticalTickLabels()
-				);
+						);
 				state.cursorUp(used);
 			}
 			else if (edge == RectangleEdge.BOTTOM) {
 				used = findMaximumTickLabelHeight(
 						ticks, g2, plotArea, isVerticalTickLabels()
-				);
+						);
 				state.cursorDown(used);
 			}
 		}
@@ -832,7 +1101,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 	protected String makeTickLabel(double val) {
 		return makeTickLabel(val, false);
 	}
-	
+
 	/**
 	 * Returns the largest (closest to positive infinity) double value that is
 	 * not greater than the argument, is equal to a mathematical integer and
@@ -877,7 +1146,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 
 		return logCeil;
 	}
-	
+
 	/**
 	 * Rescales the axis to ensure that all data is visible.
 	 */
@@ -896,7 +1165,7 @@ public class JFreeLogarithmicAxis extends LogAxis {
 			Range r = vap.getDataRange(this);
 			if (r == null) {
 				//no real data present
-//				r = new Range(DEFAULT_LOWER_BOUND, DEFAULT_UPPER_BOUND);
+				//				r = new Range(DEFAULT_LOWER_BOUND, DEFAULT_UPPER_BOUND);
 				r = new Range(0.01, 1.0);
 				lower = r.getLowerBound();    //get lower bound value
 			}

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/LogPaintScaleLegend.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/LogPaintScaleLegend.java
@@ -1,0 +1,167 @@
+package org.opensha.commons.gui.plot.jfreechart;
+
+import java.awt.Graphics2D;
+import java.awt.Paint;
+import java.awt.Stroke;
+import java.awt.geom.Rectangle2D;
+
+import org.jfree.chart.axis.AxisLocation;
+import org.jfree.chart.plot.Plot;
+import org.jfree.chart.plot.PlotOrientation;
+import org.jfree.chart.title.PaintScaleLegend;
+import org.jfree.chart.ui.RectangleEdge;
+import org.opensha.commons.gui.plot.jfreechart.xyzPlot.PaintScaleWrapper;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This fixes a bug in PaintScaleLegend wherein log-spaced colorbars are split into subdivisions in linear space,
+ * resulting in larger blocks for smaller values.
+ */
+public class LogPaintScaleLegend extends PaintScaleLegend {
+
+	private JFreeLogarithmicAxis axis;
+	private PaintScaleWrapper scale;
+
+	public LogPaintScaleLegend(PaintScaleWrapper scale, JFreeLogarithmicAxis axis) {
+		super(scale, axis);
+		Preconditions.checkState(scale.getCPT().isLog10(), "Passed in paint scale CPT isn't log10?");
+		this.scale = scale;
+		this.axis = axis;
+	}
+
+	@Override
+	public Object draw(Graphics2D g2, Rectangle2D area, Object params) {
+		// get values that we can't access directly
+		Paint backgroundPaint = getBackgroundPaint();
+		AxisLocation axisLocation = getAxisLocation();
+		int subdivisions = getSubdivisionCount();
+		double stripWidth = getStripWidth();
+		Paint stripOutlinePaint = getStripOutlinePaint();
+		Stroke stripOutlineStroke = getStripOutlineStroke();
+		double axisOffset = getAxisOffset();
+
+		Rectangle2D target = (Rectangle2D) area.clone();
+		target = trimMargin(target);
+		if (backgroundPaint != null) {
+			g2.setPaint(backgroundPaint);
+			g2.fill(target);
+		}
+		getFrame().draw(g2, target);
+		getFrame().getInsets().trim(target);
+		target = trimPadding(target);
+		
+		double lower   = axis.getLowerBound();          // positive (enforced by JFreeLogarithmicAxis)
+		double upper   = axis.getUpperBound();
+		Preconditions.checkState(lower > 0 && upper > lower,
+				"Log axis bounds must be positive and ordered");
+
+		double logLower = Math.log10(lower);
+		double logUpper = Math.log10(upper);
+		double logInc   = (logUpper - logLower) / subdivisions;
+
+		// helper lambdas for brevity
+		java.util.function.IntFunction<Double> v0 = i ->
+		Math.pow(10, logLower + i       * logInc);          // band start
+		java.util.function.IntFunction<Double> v1 = i ->
+		Math.pow(10, logLower + (i + 1) * logInc);          // band end
+		java.util.function.IntFunction<Double> vMid = i ->
+		Math.pow(10, logLower + (i + 0.5) * logInc);        // band mid (for colour)
+
+		Rectangle2D r = new Rectangle2D.Double();
+
+		// ───────────────────────────────────────────
+		// 3. render: same four cases as the stock draw()
+		// ───────────────────────────────────────────
+		if (RectangleEdge.isTopOrBottom(getPosition())) {
+
+			RectangleEdge axisEdge = Plot.resolveRangeAxisLocation(
+					axisLocation, PlotOrientation.HORIZONTAL);
+
+			if (axisEdge == RectangleEdge.TOP) {
+				for (int i = 0; i < subdivisions; i++) {
+					double vv0 = axis.valueToJava2D(v0.apply(i), target, RectangleEdge.TOP);
+					double vv1 = axis.valueToJava2D(v1.apply(i), target, RectangleEdge.TOP);
+					double ww  = Math.abs(vv1 - vv0) + 1.0;
+
+					r.setRect(Math.min(vv0, vv1), target.getMaxY() - stripWidth, ww, stripWidth);
+					g2.setPaint(scale.getPaint(vMid.apply(i)));
+					g2.fill(r);
+				}
+				if (isStripOutlineVisible()) {
+					g2.setPaint(stripOutlinePaint);
+					g2.setStroke(stripOutlineStroke);
+					g2.draw(new Rectangle2D.Double(target.getMinX(),
+							target.getMaxY() - stripWidth, target.getWidth(), stripWidth));
+				}
+				axis.draw(g2, target.getMaxY() - stripWidth - axisOffset,
+						target, target, RectangleEdge.TOP, null);
+
+			} else { // BOTTOM
+				for (int i = 0; i < subdivisions; i++) {
+					double vv0 = axis.valueToJava2D(v0.apply(i), target, RectangleEdge.BOTTOM);
+					double vv1 = axis.valueToJava2D(v1.apply(i), target, RectangleEdge.BOTTOM);
+					double ww  = Math.abs(vv1 - vv0) + 1.0;
+
+					r.setRect(Math.min(vv0, vv1), target.getMinY(), ww, stripWidth);
+					g2.setPaint(scale.getPaint(vMid.apply(i)));
+					g2.fill(r);
+				}
+				if (isStripOutlineVisible()) {
+					g2.setPaint(stripOutlinePaint);
+					g2.setStroke(stripOutlineStroke);
+					g2.draw(new Rectangle2D.Double(target.getMinX(),
+							target.getMinY(), target.getWidth(), stripWidth));
+				}
+				axis.draw(g2, target.getMinY() + stripWidth + axisOffset,
+						target, target, RectangleEdge.BOTTOM, null);
+			}
+
+		} else { // LEFT / RIGHT (vertical strip)
+
+			RectangleEdge axisEdge = Plot.resolveRangeAxisLocation(
+					axisLocation, PlotOrientation.VERTICAL);
+
+			if (axisEdge == RectangleEdge.LEFT) {
+				for (int i = 0; i < subdivisions; i++) {
+					double vv0 = axis.valueToJava2D(v0.apply(i), target, RectangleEdge.LEFT);
+					double vv1 = axis.valueToJava2D(v1.apply(i), target, RectangleEdge.LEFT);
+					double hh  = Math.abs(vv1 - vv0) + 1.0;
+
+					r.setRect(target.getMaxX() - stripWidth, Math.min(vv0, vv1), stripWidth, hh);
+					g2.setPaint(scale.getPaint(vMid.apply(i)));
+					g2.fill(r);
+				}
+				if (isStripOutlineVisible()) {
+					g2.setPaint(stripOutlinePaint);
+					g2.setStroke(stripOutlineStroke);
+					g2.draw(new Rectangle2D.Double(target.getMaxX() - stripWidth,
+							target.getMinY(), stripWidth, target.getHeight()));
+				}
+				axis.draw(g2, target.getMaxX() - stripWidth - axisOffset,
+						target, target, RectangleEdge.LEFT, null);
+
+			} else { // RIGHT
+				for (int i = 0; i < subdivisions; i++) {
+					double vv0 = axis.valueToJava2D(v0.apply(i), target, RectangleEdge.LEFT);
+					double vv1 = axis.valueToJava2D(v1.apply(i), target, RectangleEdge.LEFT);
+					double hh  = Math.abs(vv1 - vv0) + 1.0;
+
+					r.setRect(target.getMinX(), Math.min(vv0, vv1), stripWidth, hh);
+					g2.setPaint(scale.getPaint(vMid.apply(i)));
+					g2.fill(r);
+				}
+				if (isStripOutlineVisible()) {
+					g2.setPaint(stripOutlinePaint);
+					g2.setStroke(stripOutlineStroke);
+					g2.draw(new Rectangle2D.Double(target.getMinX(),
+							target.getMinY(), stripWidth, target.getHeight()));
+				}
+				axis.draw(g2, target.getMinX() + stripWidth + axisOffset,
+						target, target, RectangleEdge.RIGHT, null);
+			}
+		}
+		return null;   // PaintScaleLegend always returns null
+	}
+
+}

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
@@ -19,22 +19,16 @@ public class PaintScaleWrapper implements PaintScale {
 
 	@Override
 	public double getLowerBound() {
-		if (cpt.isLog10())
-			return Math.pow(10, cpt.getMinValue());
 		return cpt.getMinValue();
 	}
 
 	@Override
 	public Paint getPaint(double value) {
-		if (cpt.isLog10())
-			value = Math.log10(value);
 		return cpt.getColor((float)value);
 	}
 
 	@Override
 	public double getUpperBound() {
-		if (cpt.isLog10())
-			return Math.pow(10, cpt.getMaxValue());
 		return cpt.getMaxValue();
 	}
 	

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
@@ -19,16 +19,22 @@ public class PaintScaleWrapper implements PaintScale {
 
 	@Override
 	public double getLowerBound() {
+		if (cpt.isLog10())
+			return Math.pow(10, cpt.getMinValue());
 		return cpt.getMinValue();
 	}
 
 	@Override
 	public Paint getPaint(double value) {
+		if (cpt.isLog10())
+			value = Math.log10(value);
 		return cpt.getColor((float)value);
 	}
 
 	@Override
 	public double getUpperBound() {
+		if (cpt.isLog10())
+			return Math.pow(10, cpt.getMaxValue());
 		return cpt.getMaxValue();
 	}
 	

--- a/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
+++ b/src/main/java/org/opensha/commons/gui/plot/jfreechart/xyzPlot/PaintScaleWrapper.java
@@ -24,7 +24,7 @@ public class PaintScaleWrapper implements PaintScale {
 
 	@Override
 	public Paint getPaint(double value) {
-		return cpt.getColor((float)value);
+		return cpt.getColor(value);
 	}
 
 	@Override

--- a/src/main/java/org/opensha/commons/mapping/gmt/gui/CPTPanel.java
+++ b/src/main/java/org/opensha/commons/mapping/gmt/gui/CPTPanel.java
@@ -77,8 +77,8 @@ public class CPTPanel extends JPanel
 		} else {
 			labelTable = new HashMap<Float, JLabel>();
 
-			minVal = cpt.getMinValue();
-			maxVal = cpt.getMaxValue();
+			minVal = (float)cpt.getMinValueRaw();
+			maxVal = (float)cpt.getMaxValueRaw();
 
 			cpt.paintGrid(bi);
 
@@ -97,12 +97,12 @@ public class CPTPanel extends JPanel
 				for (int i=0; i<num; i++) {
 					if (i % mod != 0)
 						continue;
-					float tickVal = cpt.get(i).start;
+					float tickVal = (float)cpt.get(i).start;
 					JLabel label = new JLabel(getTickLabel(tickVal));
 					labelTable.put(tickVal, label);
 				}
 				if (num > 0) {
-					float tickVal = cpt.get(num-1).end;
+					float tickVal = (float)cpt.get(num-1).end;
 					JLabel label = new JLabel(getTickLabel(tickVal));
 					labelTable.put(tickVal, label);
 				}

--- a/src/main/java/org/opensha/commons/util/cpt/CPT.java
+++ b/src/main/java/org/opensha/commons/util/cpt/CPT.java
@@ -111,7 +111,11 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 
 	/**
 	 * Set log10 flag, indicating that this CPT is in log10 space and should be plotted using logarithmic axes. This
-	 * does not change the data itself.
+	 * does not change the underlying data itself.
+	 * <br>
+	 * If log10 is set, calls to {{@link #getColor(float)} assume the passed in value is in linear space and will be
+	 * converted internally; similarly, {{@link #getMinValue()} and {{@link #getMaxValue()} will return the bounds in
+	 * linear space. Original values cane accessed via  
 	 * @param isLog10
 	 */
 	public void setLog10(boolean isLog10) {
@@ -254,12 +258,29 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 
 	/**
 	 * This returns a color given a value for this specific CPT file or null if
-	 * the color is undefined
+	 * the color is undefined.
+	 * <br>
+	 * If {@link #isLog10()} is true, the passed in value will be converted to it's log10 equivalent internally;
+	 * use {@link #getColorRaw(float)} to access the color with a value already in log100 space.
 	 *
 	 * @param value
 	 * @return Color corresponding to value
 	 */
 	public Color getColor(float value) {
+		if (isLog10)
+			value = (float)Math.log10(value);
+		return getColorRaw(value);
+	}
+	
+	/**
+	 * This returns a color given a value for this specific CPT file or null if
+	 * the color is undefined. Unlike {@link #getColor(float)}, this ignores the
+	 * {@link #isLog10()} setting.
+	 *
+	 * @param value
+	 * @return Color corresponding to value
+	 */
+	public Color getColorRaw(float value) {
 		CPTVal cpt_val = getCPTVal(value);
 
 		if (cpt_val != null) {
@@ -695,6 +716,20 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	}
 	
 	public float getMinValue() {
+		float min = getMinValueRaw();
+		if (isLog10)
+			min = (float)Math.pow(10, min);
+		return min;
+	}
+	
+	public float getMaxValue() {
+		float max = getMaxValueRaw();
+		if (isLog10)
+			max = (float)Math.pow(10, max);
+		return max;
+	}
+	
+	public float getMinValueRaw() {
 		float min = Float.POSITIVE_INFINITY;
 		for (CPTVal cptVal : this) {
 			if (cptVal.start < min)
@@ -705,7 +740,7 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		return min;
 	}
 	
-	public float getMaxValue() {
+	public float getMaxValueRaw() {
 		float max = Float.NEGATIVE_INFINITY;
 		for (CPTVal cptVal : this) {
 			if (cptVal.start > max)

--- a/src/main/java/org/opensha/commons/util/cpt/CPT.java
+++ b/src/main/java/org/opensha/commons/util/cpt/CPT.java
@@ -44,7 +44,10 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	private static final long serialVersionUID = 1l;
 	public static final String XML_METADATA_NAME = "CPT";
 	private Color nanColor, belowMinColor, aboveMaxColor, gapColor;
-	public Blender blender;
+	private Blender blender;
+	
+	// if true, this CPT is in Log10 space and should be plotted using a logarithmic axis
+	private boolean isLog10;
 	
 	private double preferredTickInterval = Double.NaN;
 	
@@ -97,6 +100,22 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		
 		setBelowMinColor(colors[0]);
 		setAboveMaxColor(colors[colors.length-1]);
+	}
+
+	/**
+	 * @return true if this CPT is in log10 space
+	 */
+	public boolean isLog10() {
+		return isLog10;
+	}
+
+	/**
+	 * Set log10 flag, indicating that this CPT is in log10 space and should be plotted using logarithmic axes. This
+	 * does not change the data itself.
+	 * @param isLog10
+	 */
+	public void setLog10(boolean isLog10) {
+		this.isLog10 = isLog10;
 	}
 
 	/**

--- a/src/main/java/org/opensha/commons/util/cpt/CPT.java
+++ b/src/main/java/org/opensha/commons/util/cpt/CPT.java
@@ -93,8 +93,8 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		
 		double delta = (maxVal - minVal)/(colors.length - 1);
 		for (int i=0; i<colors.length-1; i++) {
-			float start = (float)(minVal + delta*i);
-			float end = (float)(minVal + delta*(i+1));
+			double start = (minVal + delta*i);
+			double end = (minVal + delta*(i+1));
 			add(new CPTVal(start, colors[i], end, colors[i+1]));
 		}
 		
@@ -266,6 +266,20 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	 * @param value
 	 * @return Color corresponding to value
 	 */
+	public Color getColor(double value) {
+		return getColor((float)value);
+	}
+
+	/**
+	 * This returns a color given a value for this specific CPT file or null if
+	 * the color is undefined.
+	 * <br>
+	 * If {@link #isLog10()} is true, the passed in value will be converted to it's log10 equivalent internally;
+	 * use {@link #getColorRaw(float)} to access the color with a value already in log100 space.
+	 *
+	 * @param value
+	 * @return Color corresponding to value
+	 */
 	public Color getColor(float value) {
 		if (isLog10)
 			value = (float)Math.log10(value);
@@ -284,13 +298,13 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		CPTVal cpt_val = getCPTVal(value);
 
 		if (cpt_val != null) {
-			if (value == cpt_val.start) {
+			if (value == (float)cpt_val.start) {
 				return cpt_val.minColor;
-			} else if (value == cpt_val.end) {
+			} else if (value == (float)cpt_val.end) {
 				return cpt_val.maxColor;
-			} else if (value > cpt_val.start && value < cpt_val.end) {
-				float adjVal = (value - cpt_val.start)
-						/ (cpt_val.end - cpt_val.start);
+			} else if (value > (float)cpt_val.start && value < (float)cpt_val.end) {
+				float adjVal = (value - (float)cpt_val.start)
+						/ ((float)cpt_val.end - (float)cpt_val.start);
 				return blendColors(cpt_val.minColor, cpt_val.maxColor, adjVal);
 			}
 		}
@@ -371,6 +385,11 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 				switch (firstChar) {
 				case '#':
 					// comment
+					line = line.substring(1).trim();
+					line = line.replace(" ", "");
+					line = line.toLowerCase();
+					if (line.startsWith("log10=true"))
+						cpt.setLog10(true);
 					continue;
 				case 'N':
 					tok.nextToken();
@@ -438,6 +457,7 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		
 		if (name != null && !name.isEmpty())
 			xml.addAttribute("name", name);
+		xml.addAttribute("log10", isLog10+"");
 		
 		return root;
 	}
@@ -449,6 +469,9 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 			cpt = new CPT(nameAtt.getStringValue());
 		else
 			cpt = new CPT();
+		Attribute logAtt = cptElem.attribute("log10");
+		if (logAtt != null)
+			cpt.setLog10(Boolean.valueOf(logAtt.getStringValue()));
 		
 		Iterator<Element> it = cptElem.elementIterator(CPTVal.XML_METADATA_NAME);
 		while (it.hasNext())
@@ -638,19 +661,19 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		if (size() > 0) {
 
 			// Establish the increase in value for each change in pixel
-			float minStart = this.get(0).start;
-			float maxEnd = this.get(size() - 1).end;
-			float valsPerPixel = (maxEnd - minStart) / width; //To ensure that the last value is included
+			double minStart = this.get(0).start;
+			double maxEnd = this.get(size() - 1).end;
+			double valsPerPixel = (maxEnd - minStart) / width; //To ensure that the last value is included
 
 			// If we've lit pixel +1 pixels the next pixel is lit with the color
 			// from valsPerPixel*x + minStart
 			int pixel = 0;
-			float val = 0;
+			double val = 0;
 
 			for( CPTVal cptval: this ) {
 				// Get the CPTVals in order and get then paint the associated lines with colors corresponding to the range of values of that CPTVal
-				float start = cptval.start;
-				float end = cptval.end;
+				double start = cptval.start;
+				double end = cptval.end;
 				Color startC = cptval.minColor;
 				Color endC = cptval.maxColor;
 
@@ -675,8 +698,8 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 				//Start filling in the gradient
 				while (pixel < width && start <= val && val <= end ) {
 					//Calculate color of line
-					float bias = (val - start) / (end - start);
-					Color blend = blender.blend(startC, endC, bias);
+					double bias = (val - start) / (end - start);
+					Color blend = blender.blend(startC, endC, (float)bias);
 
 					//Draw line and go to next pixel
 					g.setColor(blend);
@@ -701,7 +724,9 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		} catch (IOException e) {}
 		out += "http://www.opensha.org)";
 		out += ": " + this.getClass().getName() + "\n";
-		out += 			"# Date: " + (new Date()) + "\n";
+		out += "# Date: " + (new Date()) + "\n";
+		if (isLog10)
+			out += "# LOG10 = true\n";
 		for(CPTVal v: this){
 			out += v.toString() + "\n";
 		}
@@ -715,22 +740,22 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		return out;
 	}
 	
-	public float getMinValue() {
-		float min = getMinValueRaw();
+	public double getMinValue() {
+		double min = getMinValueRaw();
 		if (isLog10)
-			min = (float)Math.pow(10, min);
+			min = Math.pow(10, min);
 		return min;
 	}
 	
-	public float getMaxValue() {
-		float max = getMaxValueRaw();
+	public double getMaxValue() {
+		double max = getMaxValueRaw();
 		if (isLog10)
-			max = (float)Math.pow(10, max);
+			max = Math.pow(10, max);
 		return max;
 	}
 	
-	public float getMinValueRaw() {
-		float min = Float.POSITIVE_INFINITY;
+	public double getMinValueRaw() {
+		double min = Float.POSITIVE_INFINITY;
 		for (CPTVal cptVal : this) {
 			if (cptVal.start < min)
 				min = cptVal.start;
@@ -740,8 +765,8 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		return min;
 	}
 	
-	public float getMaxValueRaw() {
-		float max = Float.NEGATIVE_INFINITY;
+	public double getMaxValueRaw() {
+		double max = Float.NEGATIVE_INFINITY;
 		for (CPTVal cptVal : this) {
 			if (cptVal.start > max)
 				max = cptVal.start;
@@ -774,6 +799,7 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		cpt.setGapColor(getGapColor());
 		cpt.setNanColor(getNanColor());
 		cpt.setBlender(getBlender());
+		cpt.setLog10(isLog10());
 		
 		for (CPTVal val : this)
 			cpt.add((CPTVal)val.clone());
@@ -784,19 +810,23 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	}
 
 	public CPT asLog10() {
-		Preconditions.checkState(getMinValue() > 0, "can only get log10 representation when min > 0");
-		return rescale(Math.log10(getMinValue()), Math.log10(getMaxValue()));
+		Preconditions.checkState(getMinValueRaw() > 0, "can only get log10 representation when min > 0");
+		CPT cpt = rescale(Math.log10(getMinValueRaw()), Math.log10(getMaxValueRaw()));
+		cpt.setLog10(true);
+		return cpt;
 	}
 	
 	public CPT asPow10() {
-		return rescale(Math.pow(10, getMinValue()), Math.pow(10, getMaxValue()));
+		CPT cpt = rescale(Math.pow(10, getMinValueRaw()), Math.pow(10, getMaxValueRaw()));
+		cpt.setLog10(false);
+		return cpt;
 	}
 	
 	public CPT asDiscrete(int num, boolean preserveEdges) {
 		CPT cpt = (CPT)clone();
 		CPT orig = this;
-		double min = this.getMinValue();
-		double max = this.getMaxValue();
+		double min = this.getMinValueRaw();
+		double max = this.getMaxValueRaw();
 		double delta = (max - min)/num;
 		if (preserveEdges) {
 			orig = (CPT)clone();
@@ -805,8 +835,8 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 		cpt.clear();
 		
 		for (int i=0; i<num; i++) {
-			float start = (float)(min + i*delta);
-			float end = (float)(min + (i+1)*delta);
+			double start = (min + i*delta);
+			double end = (min + (i+1)*delta);
 			Color color;
 			if (preserveEdges && i == 0)
 				color = getMinColor();
@@ -823,8 +853,8 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	public CPT asDiscrete(double delta, boolean preserveEdges) {
 		CPT cpt = (CPT)clone();
 		CPT orig = this;
-		double min = this.getMinValue();
-		double max = this.getMaxValue();
+		double min = this.getMinValueRaw();
+		double max = this.getMaxValueRaw();
 		if (preserveEdges) {
 			orig = (CPT)clone();
 			double lastBinStart = 0d;
@@ -843,7 +873,7 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 				color = getMaxColor();
 			else
 				color = orig.getColor((float)(0.5*(end + start)));
-			cpt.add(new CPTVal((float)start, color, (float)end, color));
+			cpt.add(new CPTVal(start, color, end, color));
 		}
 		
 		return cpt;
@@ -853,14 +883,14 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	 * @return rescaled version of this CPT
 	 */
 	public CPT rescale(double min, double max) {
-		Preconditions.checkState(getMaxValue() > getMinValue(), "in order to rescale, current max must be > min");
+		Preconditions.checkState(getMaxValueRaw() > getMinValueRaw(), "in order to rescale, current max must be > min");
 		Preconditions.checkArgument(max > min, "new max must be > min: %s !> %s", max, min);
 		CPT cpt = (CPT)clone();
 		cpt.clear();
 		
 		for (CPTVal val : this) {
-			float start = (float)rescaleValue(val.start, min, max);
-			float end = (float)rescaleValue(val.end, min, max);
+			double start = rescaleValue(val.start, min, max);
+			double end = rescaleValue(val.end, min, max);
 			CPTVal newVal = new CPTVal(start, val.minColor, end, val.maxColor);
 			cpt.add(newVal);
 		}
@@ -869,37 +899,37 @@ public class CPT extends ArrayList<CPTVal> implements Named, Serializable, Clone
 	}
 	
 	private double rescaleValue(double oldVal, double newMin, double newMax) {
-		double oldDelta = getMaxValue() - getMinValue();
+		double oldDelta = getMaxValueRaw() - getMinValueRaw();
 		double newDelta = newMax - newMin;
 		
-		return newMin + ((oldVal - getMinValue()) / oldDelta) * newDelta;
+		return newMin + ((oldVal - getMinValueRaw()) / oldDelta) * newDelta;
 	}
 	
 	public CPT trim(double newMin, double newMax) {
-		Preconditions.checkState(newMin >= getMinValue(), "new minimum is lower than original minimum");
-		Preconditions.checkState(newMax <= getMaxValue(), "new maximum is greater than original maximum");
+		Preconditions.checkState(newMin >= getMinValueRaw(), "new minimum is lower than original minimum");
+		Preconditions.checkState(newMax <= getMaxValueRaw(), "new maximum is greater than original maximum");
 		Preconditions.checkState(newMax > newMin, "new max must be greater than new max");
 		CPT cpt = (CPT)clone();
 		cpt.clear();
 		
 		for (CPTVal val : this) {
-			if (val.end < (float)newMin)
+			if ((float)val.end < (float)newMin)
 				// completely before the start
 				continue;
-			if (val.start > (float)newMax)
+			if ((float)val.start > (float)newMax)
 				// completely after the end
 				break;
 			// if we're here, we are inside or at least overlap a new bound
 			CPTVal newVal = val;
-			if (val.start < (float)newMin) {
+			if ((float)val.start < (float)newMin) {
 				// we started before the new minimum, truncate the lower bound
-				Color minColor = getColor((float)newMin);
-				newVal = new CPTVal((float)newMin, minColor, newVal.end, newVal.maxColor);
+				Color minColor = getColor(newMin);
+				newVal = new CPTVal(newMin, minColor, newVal.end, newVal.maxColor);
 			}
-			if (val.end > (float)newMax) {
+			if ((float)val.end > (float)newMax) {
 				// we end after the new maximum, truncate the upper bound
-				Color maxColor = getColor((float)newMax);
-				newVal = new CPTVal(newVal.start, newVal.minColor, (float)newMax, maxColor);
+				Color maxColor = getColor(newMax);
+				newVal = new CPTVal(newVal.start, newVal.minColor, newMax, maxColor);
 			}
 			cpt.add(newVal);
 		}

--- a/src/main/java/org/opensha/commons/util/cpt/CPTVal.java
+++ b/src/main/java/org/opensha/commons/util/cpt/CPTVal.java
@@ -11,18 +11,18 @@ import org.opensha.commons.util.XMLUtils;
 public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLSaveable {
 	public static final String XML_METADATA_NAME = "CPTVal";
 	
-	/**
+	/*
 	 * In general this information determines the indicator color associated
 	 * with a value with a certain range.
 	 *
 	 * This class correspond to a row in a CPT file
+	 * 
+	 * TODO: make these final
 	 */
 	public Color minColor;
 	public Color maxColor;
-	public float start;
-	public float end;
-
-	public CPTVal() {}
+	public double start;
+	public double end;
 	
 	/**
 	 *
@@ -38,7 +38,7 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 	 *            end
 	 *
 	 */
-	public CPTVal(float start, int minR, int minG, int minB, float end,
+	public CPTVal(double start, int minR, int minG, int minB, double end,
 			int maxR, int maxG, int maxB) {
 		minColor = new Color(minR, minG, minB);
 		maxColor = new Color(maxR, maxG, maxB);
@@ -52,7 +52,7 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 		// System.out.println("Max: " + maxColor);
 	}
 	
-	public CPTVal(float start, Color minColor, float end, Color maxColor) {
+	public CPTVal(double start, Color minColor, double end, Color maxColor) {
 		this.minColor = minColor;
 		this.maxColor = maxColor;
 		this.start = start;
@@ -83,11 +83,11 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 	public static CPTVal fromXMLMetadata(Element valElem) {
 		Element startEl = valElem.element("Start");
 		Color startColor = XMLUtils.colorFromXML(startEl.element("Color"));
-		float minVal = Float.parseFloat(startEl.attributeValue("value"));
+		double minVal = Double.parseDouble(startEl.attributeValue("value"));
 		
 		Element endEl = valElem.element("End");
 		Color endColor = XMLUtils.colorFromXML(endEl.element("Color"));
-		float maxVal = Float.parseFloat(endEl.attributeValue("value"));
+		double maxVal = Double.parseDouble(endEl.attributeValue("value"));
 		
 		return new CPTVal(minVal, startColor, maxVal, endColor);
 	}
@@ -99,11 +99,11 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 	public int compareTo(CPTVal other) {
 		// If this range is less than other range or only contains the start
 		// point of the other range
-		if (this.end <= other.start) {
+		if ((float)this.end <= (float)other.start) {
 			return -1;// (Float.valueOf(this.end - other.start )).intValue();
 		}// If this range is greater than other range or only contains the
 			// end point of the other range
-		else if (this.start >= other.end) {
+		else if ((float)this.start >= (float)other.end) {
 			return +1;// (Float.valueOf(this.start - other.end)).intValue();
 		} else {
 			// There is overlap
@@ -115,10 +115,10 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + Float.floatToIntBits(end);
+		result = prime * result + Float.floatToIntBits((float)end);
 		result = prime * result + ((maxColor == null) ? 0 : maxColor.hashCode());
 		result = prime * result + ((minColor == null) ? 0 : minColor.hashCode());
-		result = prime * result + Float.floatToIntBits(start);
+		result = prime * result + Float.floatToIntBits((float)start);
 		return result;
 	}
 
@@ -131,7 +131,7 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 		if (getClass() != obj.getClass())
 			return false;
 		CPTVal other = (CPTVal) obj;
-		if (Float.floatToIntBits(end) != Float.floatToIntBits(other.end))
+		if (Double.doubleToLongBits(end) != Double.doubleToLongBits(other.end))
 			return false;
 		if (maxColor == null) {
 			if (other.maxColor != null)
@@ -143,7 +143,7 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 				return false;
 		} else if (!minColor.equals(other.minColor))
 			return false;
-		if (Float.floatToIntBits(start) != Float.floatToIntBits(other.start))
+		if (Double.doubleToLongBits(start) != Double.doubleToLongBits(other.start))
 			return false;
 		return true;
 	}
@@ -154,7 +154,7 @@ public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLS
 	 * @return true if value is greater than or equal to the start value and less than the end value
 	 */
 	public boolean contains(float value) {
-		return this.start <= value && value < this.end;
+		return (float)this.start <= value && value < (float)this.end;
 	}
 
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/util/SegmentationCalculator.java
@@ -1254,7 +1254,7 @@ public class SegmentationCalculator {
 				fakeXY.set(0d, -1d);
 				fakeXY.setName("Connection");
 				funcs.add(fakeXY);
-				float half = rateCPT.getMinValue() + 0.5f*(rateCPT.getMaxValue()-rateCPT.getMinValue());
+				double half = rateCPT.getMinValue() + 0.5f*(rateCPT.getMaxValue()-rateCPT.getMinValue());
 				chars.add(new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, scatterWidth, rateCPT.getColor(half)));
 				
 				DefaultXY_DataSet zerosScatter = new DefaultXY_DataSet();
@@ -1733,7 +1733,7 @@ public class SegmentationCalculator {
 				fakeXY.set(0d, -1d);
 				fakeXY.setName("Connection");
 				funcs.add(fakeXY);
-				float half = rateCPT.getMinValue() + 0.5f*(rateCPT.getMaxValue()-rateCPT.getMinValue());
+				double half = rateCPT.getMinValue() + 0.5*(rateCPT.getMaxValue()-rateCPT.getMinValue());
 				chars.add(new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, scatterWidth, rateCPT.getColor(half)));
 				
 				DefaultXY_DataSet zerosScatter = new DefaultXY_DataSet();
@@ -1962,7 +1962,7 @@ public class SegmentationCalculator {
 			fakeXY.set(0d, -1d);
 			fakeXY.setName("Connection");
 			funcs.add(fakeXY);
-			float half = rateCPT.getMinValue() + 0.5f*(rateCPT.getMaxValue()-rateCPT.getMinValue());
+			double half = rateCPT.getMinValue() + 0.5*(rateCPT.getMaxValue()-rateCPT.getMinValue());
 			chars.add(new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, scatterWidth, rateCPT.getColor(half)));
 			targetRatioFuncs.add(fakeXY);
 			targetRatioChars.add(new PlotCurveCharacterstics(PlotSymbol.FILLED_CIRCLE, scatterWidth, rateCPT.getMaxColor()));

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SubSectionPolygonBuilder.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/SubSectionPolygonBuilder.java
@@ -143,9 +143,9 @@ public class SubSectionPolygonBuilder {
 					} else {
 						angle = 0d;
 					}
-					System.out.println(sect.getSectionName()+" shear iter "+iter+"; leftFractWidth="
-							+(float)(leftWidth/sectLen)+", rightFractWidth="+(float)(rightWidth/sectLen)
-							+", shearAngle="+(float)angle);
+//					System.out.println(sect.getSectionName()+" shear iter "+iter+"; leftFractWidth="
+//							+(float)(leftWidth/sectLen)+", rightFractWidth="+(float)(rightWidth/sectLen)
+//							+", shearAngle="+(float)angle);
 					if (first)
 						firstAngle = angle;
 					else
@@ -159,7 +159,7 @@ public class SubSectionPolygonBuilder {
 					if (sect instanceof GeoJSONFaultSection)
 						((GeoJSONFaultSection) sect).getProperties().set(SECT_POLY_DIRECTION_PROP_NAME, sect.getDipDirection()+shearAngles[i]);
 				}
-				System.out.println("Shear angles for "+subSects.get(0).getParentSectionName()+": "+Doubles.asList(shearAngles));
+//				System.out.println("Shear angles for "+subSects.get(0).getParentSectionName()+": "+Doubles.asList(shearAngles));
 			}
 			
 			for (int i=0; i<subSects.size(); i++) {


### PR DESCRIPTION
This resolves #141, adding support for Log10 colorbars in XYZ plots. I did the implementation slightly differently than proposed in the original issue

The `CPT` class now has `void setLog10(boolean isLog10)` and `boolean isLog10()` methods. Setting the Log10 flag doesn't change any of the interval CPT values, it's just a flag that it is in Log10 space. It does, however, change the behavior of the following methods:

* `Color getColor(double value)`: assumes the passed in value is in linear space, and will be converted to log space before finding the corresponding value
* `double getMinValue()` and `double getMaxValue()`: return the value in linear space, e.g., taking `10^min` if in Log10 mode.

I added new methods to get the raw values without any linear <--> log conversion:

* `Color getColorRaw(double value)`: assumes the passed is in whatever units the underlying `CPTVal`'s use, ignores the Log10 flag.
* `double getMinValueRaw()` and `double getMaxValueRaw()`: return the min and max values of the underlying `CPTVal`'s

Doing so this way makes it easy for classes that build plots to work with log or linear CPTs without any code changes; because they use getMin/getMax/getColor, they don't need to know if the CPT is in log or linear space.Any code that accesses the underlying `CPTVal` instances directly should be aware that they are unaffected by the Log10 flag.

Here's an example plot showing the nice new Log10 colorscale:

![crustal_m5](https://github.com/user-attachments/assets/58ac7eeb-4864-4b84-b0f4-266bf698561f)

A few other implementation details:

* I had to create a new `LogPaintScaleLegend` class that builds subdivisions in Log10 space
  * Subdivisions are units of contiguous colors in the drawn colorscale, usually very tiny, e.g., 500 color increments per drawn colorbar, each hopefully no more than a few pixels wide
  * When using the default `PaintScaleLegend` in Log10 space, values on the left of the color bar might have noticeably large blocks, e.g., a small value might draw the same color for 10 pixels, but large values 1 pixel.
  * That's because the subdivision placement (left and right bounds) were determined by linear value +/- 0.5*nSubdivisions. I now do this in log space.
* I cleaned up the `JFreeLogarithmicAxis` class a bit:
  * I determined that we have our own implementation because the default implementations in JFreeChart don't do the nice minor tick labeling
  * The logic for detecting collisions between minor labels was bad, I simplified and improved it
  * It used to only show minor ticks for scales spanning 3 decades or less. That choice is now dependent on the size of the plot, requiring at least `MIN_PIXELS_PER_DECADE_FOR_MINOR = 100` pixels in the drawn axis per decade. TBD if things get weird here on high resolution displays with scaling.