### PR TITLE
[186] fix legend cut-off

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SectBySectDetailPlots.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/SectBySectDetailPlots.java
@@ -2331,7 +2331,7 @@ public class SectBySectDetailPlots extends AbstractRupSetPlot {
 			maxMag = Math.max(maxMag, rupSet.getMaxMagForSection(sect.getSectionId()));
 		}
 		
-		double legendRelX = latX ? 0.975 : 0.025;
+        double legendRelX = 0.025;
 		
 		Map<Integer, List<FaultSection>> parentsMap = faultSects.stream().collect(Collectors.groupingBy(s->s.getParentSectionId()));
 


### PR DESCRIPTION
closes #186 

For `SectBySectDetailsPlots`, the legend was anchored at 0.975 (i.e. 97.5%) of the X axis whenever Latitude was mapped to X, and 0.025 whenever Longitude was mapped to X. This change always anchors the legend at 0.025, i.e. the legend begins at the left-hand side of the chart rather than the right-hand side of the chart.

Going through the code, I do not believe that my change breaks anything. It is not obvious why the legend's origin was set to the far right of the chart. It's possible that this was done because the X axis is inverted when Latitude is mapped to X, and the hope was that the anchor would then be equivalent to 0.025. Another theory is that the legend was supposed to run vertically on the righ-hand side of the chart, but I cannot see any code to rotate the legend.

Before and after:

<img width="1000" height="2300" alt="sect_along_strike" src="https://github.com/user-attachments/assets/a2cd4bfa-b748-4f28-886e-6bfe9aebaeb7" />


<img width="1000" height="2300" alt="sect_along_strike" src="https://github.com/user-attachments/assets/6b748b23-8ff0-4182-8cf0-75bb1bdd0bdb" />




