### PR TITLE
Update SimpleVulnerability DEM

### DIFF
--- a/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
+++ b/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
@@ -96,6 +96,7 @@ import org.opensha.sra.vulnerability.models.curee.caltech.CCSmallHouseTypical;
 import org.opensha.sra.vulnerability.models.curee.caltech.CCTownhouseLimitedDrift;
 import org.opensha.sra.vulnerability.models.curee.caltech.CCTownhouseTypical;
 import org.opensha.sra.vulnerability.models.servlet.VulnerabilityServletAccessor;
+import org.opensha.sra.vulnerability.models.servlet.VulnerabilityLocalAccessor;
 import org.opensha.sra.gui.components.GuiBeanAPI;
 import org.opensha.sra.gui.components.VulnerabilityBean;
 
@@ -289,7 +290,8 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 	}
 	
 	public static List<AbstractVulnerability> fetchVulns() throws IOException {
-		VulnerabilityServletAccessor access = new VulnerabilityServletAccessor();
+//		VulnerabilityServletAccessor access = new VulnerabilityServletAccessor();
+		VulnerabilityLocalAccessor access = new VulnerabilityLocalAccessor();
 		ArrayList<AbstractVulnerability> vms = new ArrayList<AbstractVulnerability>();
 		for (Vulnerability vuln : access.getVulnMap().values()) {
 			if (vuln instanceof AbstractVulnerability)

--- a/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
+++ b/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Arrays;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -899,6 +900,15 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 					forecast.getTimeSpan().getDuration());
 		getAnnualizedPE(currentAnnualizedRates);
 	}*/
+		
+		System.out.println("IMT=" + currentIMT +
+                ", Period=" + currentPeriod +
+                ", IMLs=" + Arrays.toString(currentIMLs));
+		System.out.println("Hazard curve:\n" + currentHazardCurve);		System.out.println("IMT=" + currentIMT +
+                ", Period=" + currentPeriod +
+                ", IMLs=" + Arrays.toString(currentIMLs));
+		System.out.println("Hazard curve:\n" + currentHazardCurve);
+		
 		AbstractVulnerability vuln = vulnBean.getCurrentModel();
 		Preconditions.checkNotNull(vuln, "Vulnerability model is null");
 		System.out.println("Vuln model: "+vuln.getName()+" ("+vuln.getClass()+")");

--- a/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
+++ b/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Arrays;
 
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -291,8 +290,8 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 	}
 	
 	public static List<AbstractVulnerability> fetchVulns() throws IOException {
-//		VulnerabilityServletAccessor access = new VulnerabilityServletAccessor();
-		VulnerabilityLocalAccessor access = new VulnerabilityLocalAccessor();
+		VulnerabilityServletAccessor access = new VulnerabilityServletAccessor();
+//		VulnerabilityLocalAccessor access = new VulnerabilityLocalAccessor();
 		ArrayList<AbstractVulnerability> vms = new ArrayList<AbstractVulnerability>();
 		for (Vulnerability vuln : access.getVulnMap().values()) {
 			if (vuln instanceof AbstractVulnerability)
@@ -899,16 +898,7 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 			(ArbitrarilyDiscretizedFunc)calc.getAnnualizedRates(currentHazardCurve, 
 					forecast.getTimeSpan().getDuration());
 		getAnnualizedPE(currentAnnualizedRates);
-	}*/
-		
-		System.out.println("IMT=" + currentIMT +
-                ", Period=" + currentPeriod +
-                ", IMLs=" + Arrays.toString(currentIMLs));
-		System.out.println("Hazard curve:\n" + currentHazardCurve);		System.out.println("IMT=" + currentIMT +
-                ", Period=" + currentPeriod +
-                ", IMLs=" + Arrays.toString(currentIMLs));
-		System.out.println("Hazard curve:\n" + currentHazardCurve);
-		
+	}*/	
 		AbstractVulnerability vuln = vulnBean.getCurrentModel();
 		Preconditions.checkNotNull(vuln, "Vulnerability model is null");
 		System.out.println("Vuln model: "+vuln.getName()+" ("+vuln.getClass()+")");

--- a/src/main/java/org/opensha/sra/vulnerability/AbstractVulnerability.java
+++ b/src/main/java/org/opensha/sra/vulnerability/AbstractVulnerability.java
@@ -218,7 +218,7 @@ public abstract class AbstractVulnerability implements Vulnerability, Serializab
 	}
 
 	/**
-	 * @return The return period for the implementing model.
+	 * @return The period for the SA im_type.
 	 */
 	public double getPeriod() {
 		return period;
@@ -226,7 +226,7 @@ public abstract class AbstractVulnerability implements Vulnerability, Serializab
 
 	/**
 	 * Sets the return period to <code>period</code>
-	 * @param period The new return period (in years).
+	 * @param period The new period for the SA im_type.
 	 */
 	public void setPeriod(double period) {
 		this.period = period;

--- a/src/main/java/org/opensha/sra/vulnerability/models/SimpleVulnerability.java
+++ b/src/main/java/org/opensha/sra/vulnerability/models/SimpleVulnerability.java
@@ -22,7 +22,7 @@ public class SimpleVulnerability extends AbstractVulnerability implements Serial
 	/**
 	 * 
 	 */
-	private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 2L;
 	
 	private ArrayList<Double> mdfVals;
 	private ArrayList<Double> covVals;

--- a/src/main/java/org/opensha/sra/vulnerability/models/SimpleVulnerability.java
+++ b/src/main/java/org/opensha/sra/vulnerability/models/SimpleVulnerability.java
@@ -2,9 +2,11 @@ package org.opensha.sra.vulnerability.models;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.opensha.commons.data.function.ArbitrarilyDiscretizedFunc;
 import org.opensha.commons.data.function.AbstractDiscretizedFunc;
+import org.apache.commons.math3.distribution.LogNormalDistribution;
 import org.opensha.commons.util.StatUtil;
 import org.opensha.sra.vulnerability.AbstractVulnerability;
 
@@ -29,7 +31,10 @@ public class SimpleVulnerability extends AbstractVulnerability implements Serial
 	private AbstractDiscretizedFunc vulnFunc;
 	private AbstractDiscretizedFunc covFunc;
 	
-	private static double[] toPrimDoubleArray(ArrayList<Double> vals) {
+    private double[][] DEM;
+    private double[] DEM_DF_vals;
+	
+	private static double[] toPrimDoubleArray(List<Double> vals) {
 		double dvals[] = new double[vals.size()];
 		
 		for (int i=0; i<vals.size(); i++) {
@@ -48,6 +53,12 @@ public class SimpleVulnerability extends AbstractVulnerability implements Serial
 		if (im_levels.size() != covVals.size())
 			throw new IllegalArgumentException("im_levels must be the same size as covVals");
 		
+		// damage factors for damage exceedance matrix
+	    this.DEM_DF_vals = getDamageFactorsForDEM();
+	    
+	    // building the damage exceedance matrix
+	    this.DEM = buildDEMMatrix(toPrimDoubleArray(im_levels), toPrimDoubleArray(mdfVals), toPrimDoubleArray(covVals), this.DEM_DF_vals);
+		
 		this.im_levels = im_levels;
 		this.mdfVals = mdfVals;
 		this.covVals = covVals;
@@ -63,16 +74,139 @@ public class SimpleVulnerability extends AbstractVulnerability implements Serial
 		vulnFunc.setName(funcName);
 	}
 
+    /**
+     * Internal helper class that wraps Apache Commons Math's LogNormalDistribution.
+     *
+     * This class converts a mean value (MDF) and a coefficient of variation (COV)
+     * into parameters of the underlying lognormal distribution:
+     *
+     *     sigma = sqrt( ln(1 + COV^2) )
+     *     mu = ln(mean) - (sigma^2)/2
+     *
+     */
+    private static class LogNormalHelper {
+
+        /** LogNormalDistribution instance from Apache Commons Math. */
+        private final LogNormalDistribution dist;
+
+        /**
+         * Constructs a lognormal distribution from the specified mean and COV.
+         *
+         * @param mean  mean damage factor (DF[i]) at a given IML
+         * @param cov   coefficient of variation of damage factor (COV[i])
+         */
+        private LogNormalHelper(double mean, double cov) {
+            // Convert mean & COV into lognormal parameters
+            double sigma = Math.sqrt(Math.log(1.0 + cov * cov));
+            double mu = Math.log(mean) - 0.5 * sigma * sigma;
+
+            // Construct a numerically stable lognormal distribution
+            this.dist = new LogNormalDistribution(mu, sigma);
+        }
+
+        /**
+         * Computes the cumulative distribution function (CDF) value for the
+         * lognormal distribution at the specified damage factor.
+         *
+         * @param x damage factor threshold
+         * @return P(Damage <= x) for the underlying lognormal
+         */
+        public double cdf(double x) {
+            return dist.cumulativeProbability(x);
+        }
+    }
+    
+    /**
+     * Generates a geometrically spaced array of values from start to end.
+     *
+     * @param start the starting value
+     * @param end the maximum value
+     * @param ratio the geometric ratio between consecutive values
+     * @return array of values
+     */
+    private static double[] generateDamageFactorsForDEM(double start, double end, double ratio) {
+    	List<Double> values = new ArrayList<>();
+        for (double x = start; x <= end; x *= ratio) {
+            // Add values spaced geometrically by ratio
+            values.add(x);
+        }
+        return toPrimDoubleArray(values);
+    }
+    
+    
+    /**
+     * Generates an array of damage factor thresholds for building the DEM matrix.
+     * 
+     * The start, increment, and end points (1e-6, 1.0, 1.2) are consistent with those
+     * hardcoded in the Curee vulnerabilities
+     *
+     * @return array of damage factors
+     */
+    public static double[] getDamageFactorsForDEM() {
+        return generateDamageFactorsForDEM(1e-6, 1.0, 1.2);
+    }
+    
+    /**
+     * Builds the Damage Exceedance Matrix (DEM) for a vulnerability.
+     *
+     * Each column corresponds to an intensity measure level (IML).
+     * Each row corresponds to a damage-factor threshold (DEM_DF).
+     *
+     * Element DEM[j][i] = P(Damage > DEM_DFs[j] | IML = imls[i])
+     *
+     * The damage factor at each intensity measure level is assumed to follow a lognormal
+     * distribution defined by DF[i] (mean) and COVDF[i] (coefficient of variation).
+     *
+     * Special case:
+     * - If COVDF[i] == 0, the damage is treated as deterministic (delta function).
+     *   In this case, DEM[j][i] = 1.0 if DF[i] >= DEM_DFs[j], else 0.0.
+     *
+     * @param imls    array of intensity measure levels (length = nIML)
+     * @param DF      array of mean damage factor values at each IML (length = nIML)
+     * @param COVDF   array of coefficient of variation of DF at each IML (length = nIML)
+     * @param DEM_DFs array of damage-factor thresholds (length = nThresholds)
+     * @return        DEM matrix [nThresholds][nIML] where DEM[j][i] = P(Damage > DEM_DFs[j] | IML[i])
+     */
+    private static double[][] buildDEMMatrix(double[] imls,
+                                             double[] DF,
+                                             double[] COVDF,
+                                             double[] DEM_DFs) {
+
+        double[][] DEM = new double[DEM_DFs.length][imls.length];
+
+        // Loop over intensity measure levels (columns)
+        for (int i = 0; i < imls.length; i++) {
+
+            // Handle deterministic case (COV = 0)
+            if (COVDF[i] == 0) {
+                for (int j = 0; j < DEM_DFs.length; j++) {
+                    // Step function: 1 if DF >= threshold, 0 if DF < threshold
+                    DEM[j][i] = (DF[i] >= DEM_DFs[j] ? 1.0 : 0.0);
+                }
+                continue; // Skip lognormal calculation
+            }
+
+            // Lognormal distribution for probabilistic damage
+            LogNormalHelper logNorm = new LogNormalHelper(DF[i], COVDF[i]);
+
+            // Compute exceedance probabilities for each damage threshold
+            for (int j = 0; j < DEM_DFs.length; j++) {
+                DEM[j][i] = 1.0 - logNorm.cdf(DEM_DFs[j]);
+            }
+        }
+
+        return DEM;
+    }
+    
+
 	@Override
 	public double[] getDEMDFVals() {
-		// TODO Auto-generated method stub
-		return null;
+		return DEM_DF_vals;
 	}
 
 	@Override
 	public double[][] getDEMMatrix() {
-		// TODO Auto-generated method stub
-		return null;
+		return DEM;
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sra/vulnerability/models/servlet/VulnerabilityLocalAccessor.java
+++ b/src/main/java/org/opensha/sra/vulnerability/models/servlet/VulnerabilityLocalAccessor.java
@@ -31,7 +31,7 @@ public class VulnerabilityLocalAccessor
         FileInputStream in = new FileInputStream(
             "C:/Users/ahulsey/OneDrive - DOI/Desktop/Research/vulnerabilities/" +
             "borrowed_vulnerabilities/Porter_Hazus-and-Curee/from Kevin/" +
-            "porter_portfolios_and_vulns/2014_05_16b_VUL06_SHORT.txt"
+            "porter_portfolios_and_vulns/2014_05_16b_VUL06.txt"
         );
 
         localVulns = new HashMap<>();

--- a/src/main/java/org/opensha/sra/vulnerability/models/servlet/VulnerabilityLocalAccessor.java
+++ b/src/main/java/org/opensha/sra/vulnerability/models/servlet/VulnerabilityLocalAccessor.java
@@ -1,0 +1,68 @@
+package org.opensha.sra.vulnerability.models.servlet;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Set;
+
+import org.opensha.sra.vulnerability.Vulnerability;
+import org.opensha.sra.vulnerability.models.VulnFileReader;
+import org.opensha.sra.vulnerability.models.SimpleVulnerability;
+
+/**
+ * This provides a way to use a local file to retrieve vulnerabilities instead 
+ * the servlet. 
+ * Maintains the same class structure as VulnerabilityServletAccessor.
+ * Useful for local testing.
+ * 
+ * @author anne
+ *
+ */
+public class VulnerabilityLocalAccessor
+        extends VulnerabilityServletAccessor {
+
+    private HashMap<String, Vulnerability> localVulns;
+
+    public VulnerabilityLocalAccessor() throws IOException {
+        load();
+    }
+
+    private void load() throws IOException {
+        FileInputStream in = new FileInputStream(
+            "C:/Users/ahulsey/OneDrive - DOI/Desktop/Research/vulnerabilities/" +
+            "borrowed_vulnerabilities/Porter_Hazus-and-Curee/from Kevin/" +
+            "porter_portfolios_and_vulns/2014_05_16b_VUL06_SHORT.txt"
+        );
+
+        localVulns = new HashMap<>();
+
+        for (SimpleVulnerability v :
+                VulnFileReader.readVUL06File(in)) {
+            localVulns.put(v.getName(), v);
+        }
+    }
+
+    @Override
+    public HashMap<String, Vulnerability> getVulnMap() {
+        return localVulns;
+    }
+
+    @Override
+    public Vulnerability getVuln(String name) {
+        return localVulns.get(name);
+    }
+
+    @Override
+    public Set<String> getNames() {
+        return localVulns.keySet();
+    }
+    
+	public static void main(String args[]) throws IOException {
+		VulnerabilityServletAccessor vulns = new VulnerabilityLocalAccessor();
+		
+		Vulnerability vuln = vulns.getVuln("C1H-h-AGR1-DF");
+		System.out.println("Got vuln:");
+		System.out.println(vuln);
+		
+	}
+}


### PR DESCRIPTION
Updates the SimpleVulnerability class to create the damage exceedance matrix needed for the LossEstimationApplication.

Reads Keith's vulnerability files and assumes a lognormal distribution for the mean and cov values.

Creates a new VulnerabilityLocalAccessor to use during troubleshooting. (The current state uses the servlet. This can be switched by commenting either line 294 or 295 in LossEstimationApplication.)