### PR TITLE
Add message to disaggregation plot viewer for consolidated source list

### DIFF
--- a/src/main/java/org/opensha/sha/gui/infoTools/DisaggregationPlotViewerWindow.java
+++ b/src/main/java/org/opensha/sha/gui/infoTools/DisaggregationPlotViewerWindow.java
@@ -195,12 +195,15 @@ public class DisaggregationPlotViewerWindow extends JFrame implements HyperlinkL
 				consolidatedSourceListDataScrollPane.getViewport().add(consolidatedSourceListDataPane, null);
 //				consolidatedSourceListDataPane.setForeground(Color.blue);
 
-                String contributeExceedMsg = "The consolidated source list gives the total contribution across all ruptures "
-                        + "that include a specific source (fault). Because a single source can be involved in multiple "
-                        + "ruptures, including multi-fault ruptures, it may be counted more than once, resulting in a "
-                        + "total percent contribution of all consolidated sources greater than 100%.\n\n";
+               String contributeExceedMsg = "NOTE: Consolidated entries represent summed contributions across sources that share a common " +
+                           "underlying feature (as defined by the ERF). A single source from the Source List Data tab may " +
+                           "contribute to multiple entries in this list, and the sum of contribution percentages across all consolidated " +
+                           "entries may exceed 100%.\n" +
+                           "\n" +
+                           "A common example is an ERF with multi-fault ruptures, where individual sources represent different combinations of " +
+                           "faults rupturing together. In that case, the consolidated list reports the summed contribution of each individual " +
+                           "fault across all ruptures in which it participates.\n\n";
                 consolidatedSourceDataText = contributeExceedMsg.concat(consolidatedSourceDataText);
-
 
 				consolidatedSourceListDataPane.setText(consolidatedSourceDataText);
 				consolidatedSourceListDataPane.setEditable(false);


### PR DESCRIPTION
<img width="942" height="1112" alt="image" src="https://github.com/user-attachments/assets/20c49084-0ab7-49e0-a839-bb87706914e1" />


Added a message for the Consolidated Source List panel in the disaggregation plot viewer. This message explains why the sum of percentages here can exceed 100%, unlike in the "Source List Data" panel, where the message is not present.

I believe keeping it in the same scroll pane is best as it results in a consistent UI without dynamically shifting the height of the window. It also is only relevant to that panel so the message should only be shown there.

The output seen in the attached image was achieved using the Hazard Curve Application using "Mean UCERF3" ERF, CY2014 IMR, SA IMT, and enabling Probability disaggregation from the Disaggregation Control Panel, and checking "Show Source Disaggregation List".


Disaggregation consolidated source list message:

_The consolidated source list gives the total contribution across all ruptures that include a specific source (fault). Because a single source can be involved in multiple ruptures, including multi-fault ruptures, it may be counted more than once, resulting in a total percent contribution of all consolidated sources greater than 100%._