### PR TITLE
v25.4.3: ERF Download Hotfix

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/NSHM23_Downloader.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/util/NSHM23_Downloader.java
@@ -13,7 +13,7 @@ import org.scec.getfile.GetFile;
  * GetFile wrapper for downloading NSHM 2023 ERFs.
  */
 public class NSHM23_Downloader extends GetFile {
-	private static final String DOWNLOAD_URL = "https://g-c662a6.a78b8.36fe.data.globus.org/getfile/nshm23/nshm23.json";
+	private static final String DOWNLOAD_URL = "https://g-3a9041.a78b8.36fe.data.globus.org/getfile/nshm23/nshm23.json";
 	
 	/**
 	 * Create a GetFile instance for downloading NSHM23 models.

--- a/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
+++ b/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
@@ -65,7 +65,7 @@ public class MeanUCERF3 extends FaultSystemSolutionERF {
 	
 	public static final String NAME = "Mean UCERF3";
 	
-	private static final String DOWNLOAD_URL = "https://g-c662a6.a78b8.36fe.data.globus.org/getfile/ucerf3/ucerf3.json";
+	private static final String DOWNLOAD_URL = "https://g-3a9041.a78b8.36fe.data.globus.org/getfile/ucerf3/ucerf3.json";
 	// static final String DOWNLOAD_URL = "https://"+ServerPrefUtils.SERVER_PREFS.getHostName()+"/ftp/ucerf3_erf_modular/";
 	
 	static final String RAKE_BASIS_FILE_NAME = "rake_basis.zip";


### PR DESCRIPTION
Updates the ERF data download URLs to use the new Globus URLs for project2 instead of project, which are no longer available on CARC after the maintenance completed yesterday.

Confirmed downloads work with the HazardCurveApplication and the GetFile Operational tests pass.

This will be a hotfix release and a new OpenSHA release and announcement will be issued accordingly. The upcoming major release resolves this in a more robust way using a new version of GetFile and supports multiple server fallback.
