### PR TITLE
Make GeoJSONFaultSection not final

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ProxyFaultSectionInstances.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/modules/ProxyFaultSectionInstances.java
@@ -445,7 +445,7 @@ public class ProxyFaultSectionInstances implements ArchivableModule, BranchAvera
 			int numProxySectsPerPoly = numProxySectsPerPolys.get(sectID);
 			
 			Preconditions.checkState(proxyTraces.size() == numProxySectsPerPoly);
-			GeoJSONFaultSection geoSect = sect instanceof GeoJSONFaultSection ? (GeoJSONFaultSection)sect : new GeoJSONFaultSection(sect);
+			GeoJSONFaultSection geoSect = sect instanceof GeoJSONFaultSection ? (GeoJSONFaultSection)sect : GeoJSONFaultSection.fromFaultSection(sect);
 			Feature origFeature = geoSect.toFeature();
 			FeatureProperties proxyProps = new FeatureProperties(origFeature.properties);
 			proxyProps.remove(GeoJSONFaultSection.FAULT_ID);

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSectionBranchAverager.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/util/FaultSectionBranchAverager.java
@@ -106,7 +106,7 @@ public class FaultSectionBranchAverager {
 			avgSectSlipRateStdDevs[s] /= totWeight;
 			double avgRake = FaultUtils.getInRakeRange(avgSectRakes.get(s).getAverage());
 			
-			GeoJSONFaultSection avgSect = new GeoJSONFaultSection(new AvgFaultSection(refSect, avgSectAseis[s],
+			GeoJSONFaultSection avgSect = GeoJSONFaultSection.fromFaultSection(new AvgFaultSection(refSect, avgSectAseis[s],
 					avgSectCoupling[s], avgRake, avgSectSlipRates[s], avgSectSlipRateStdDevs[s]));
 			if (avgSectCreep != null && sectAnyCreeps[s]) {
 				avgSectCreep[s] /= totWeight;

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/NSHM23_InvConfigFactory.java
@@ -2002,7 +2002,7 @@ public class NSHM23_InvConfigFactory implements ClusterSpecificInversionConfigur
 				if (sect instanceof GeoJSONFaultSection)
 					geoSect = (GeoJSONFaultSection)sect;
 				else
-					geoSect = new GeoJSONFaultSection(sect);
+					geoSect = GeoJSONFaultSection.fromFaultSection(sect);
 				Feature feature = geoSect.toFeature();
 				FeatureProperties props = feature.properties;
 				double curLowDepth = props.getDouble(GeoJSONFaultSection.LOW_DEPTH, Double.NaN);
@@ -2411,7 +2411,7 @@ public class NSHM23_InvConfigFactory implements ClusterSpecificInversionConfigur
 					double newLower = 7d + (origLower - origUpper);
 					
 					GeoJSONFaultSection origSect = (sect instanceof GeoJSONFaultSection) ?
-							(GeoJSONFaultSection)sect : new GeoJSONFaultSection(sect);
+							(GeoJSONFaultSection)sect : GeoJSONFaultSection.fromFaultSection(sect);
 					Feature feature = origSect.toFeature();
 					feature.properties.set(GeoJSONFaultSection.UPPER_DEPTH, newUpper);
 					feature.properties.set(GeoJSONFaultSection.LOW_DEPTH, newLower);

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23_DeformationModels.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/logicTree/NSHM23_DeformationModels.java
@@ -445,7 +445,7 @@ public enum NSHM23_DeformationModels implements RupSetDeformationModel {
 			if (sect instanceof GeoJSONFaultSection)
 				geoSects.add((GeoJSONFaultSection)sect);
 			else
-				geoSects.add(new GeoJSONFaultSection(sect));
+				geoSects.add(GeoJSONFaultSection.fromFaultSection(sect));
 		}
 		GeoJSONFaultReader.attachGeoDefModel(geoSects, defModel);
 		

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/prior2018/NSHM18_DeformationModels.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/prior2018/NSHM18_DeformationModels.java
@@ -290,7 +290,7 @@ public enum NSHM18_DeformationModels implements RupSetDeformationModel, RupSetSu
 		List<GeoJSONFaultSection> modSects = new ArrayList<>();
 		int numNonZero = 0;
 		for (FaultSection sect : origSects) {
-			GeoJSONFaultSection modSect = new GeoJSONFaultSection(sect);
+			GeoJSONFaultSection modSect = GeoJSONFaultSection.fromFaultSection(sect);
 			DefModelRecord rec = recordMap.get(sect.getSectionId());
 			if (rec == null) {
 				System.err.println("WARNING: no matching deformation model record for id="

--- a/src/main/java/org/opensha/sha/faultSurface/GeoJSONFaultSection.java
+++ b/src/main/java/org/opensha/sha/faultSurface/GeoJSONFaultSection.java
@@ -389,7 +389,12 @@ public class GeoJSONFaultSection implements FaultSection {
 		Preconditions.checkState(Double.isFinite(value), "FaultSections must have the '%s' GeoJSON property", propName);
 	}
 
-	public GeoJSONFaultSection(FaultSection sect) {
+	private GeoJSONFaultSection(){
+		// Private default constructor to prevent inheritance.
+		// GeoJSONFaultSection does not have the final keyword so that it can be mocked.
+	}
+
+	private GeoJSONFaultSection(FaultSection sect) {
 		this.id = sect.getSectionId();
 		this.name = sect.getSectionName();
 		this.dip = sect.getAveDip();
@@ -442,7 +447,11 @@ public class GeoJSONFaultSection implements FaultSection {
 		this.properties = properties;
 		cacheCommonValues();
 	}
-	
+
+	public static GeoJSONFaultSection fromFaultSection(FaultSection section){
+		return new GeoJSONFaultSection(section);
+	}
+
 	public static GeoJSONFaultSection fromFeature(Feature feature) {
 		return new GeoJSONFaultSection(feature);
 	}

--- a/src/main/java/scratch/UCERF3/inversion/U3InversionConfigFactory.java
+++ b/src/main/java/scratch/UCERF3/inversion/U3InversionConfigFactory.java
@@ -657,7 +657,7 @@ public class U3InversionConfigFactory implements InversionConfigurationFactory {
 				if (sect instanceof GeoJSONFaultSection)
 					geoSect = (GeoJSONFaultSection)sect;
 				else
-					geoSect = new GeoJSONFaultSection(sect);
+					geoSect = GeoJSONFaultSection.fromFaultSection(sect);
 				Feature feature = geoSect.toFeature();
 				FeatureProperties props = feature.properties;
 				double curLowDepth = props.getDouble(GeoJSONFaultSection.LOW_DEPTH, Double.NaN);

--- a/src/test/java/org/opensha/sha/faultSurface/GeoJSONFaultSectionTest.java
+++ b/src/test/java/org/opensha/sha/faultSurface/GeoJSONFaultSectionTest.java
@@ -47,7 +47,7 @@ public class GeoJSONFaultSectionTest {
 		if (sect instanceof GeoJSONFaultSection)
 			jsonSect = (GeoJSONFaultSection)sect;
 		else
-			jsonSect = new GeoJSONFaultSection(sect);
+			jsonSect = GeoJSONFaultSection.fromFaultSection(sect);
 		
 		return gson.toJson(jsonSect.toFeature());
 	}
@@ -200,7 +200,7 @@ public class GeoJSONFaultSectionTest {
 		String stringPropName = "StringProp";
 		String boolPropName = "BooleanProp";
 		for (FaultSection sect : faultModel) {
-			GeoJSONFaultSection jsonSect = new GeoJSONFaultSection(sect);
+			GeoJSONFaultSection jsonSect = GeoJSONFaultSection.fromFaultSection(sect);
 			
 			int intVal = r.nextInt();
 			long longVal = r.nextLong();
@@ -241,7 +241,7 @@ public class GeoJSONFaultSectionTest {
 		String singleQuoteBoolPropName = "SingleQuoteBoolProp";
 		String doubleQuoteBoolPropName = "DoubleQuoteBoolProp";
 		for (FaultSection sect : faultModel) {
-			GeoJSONFaultSection jsonSect = new GeoJSONFaultSection(sect);
+			GeoJSONFaultSection jsonSect = GeoJSONFaultSection.fromFaultSection(sect);
 			
 			long longVal = r.nextLong();
 			double doubleVal = r.nextDouble();


### PR DESCRIPTION
`GeoJSONFaultSection` can currently not be mocked for tests as it is `final`. Removing that keyword enables us to write more concise tests.

```
org.mockito.exceptions.base.MockitoException: 
Cannot mock/spy class org.opensha.sha.faultSurface.GeoJSONFaultSection
Mockito cannot mock/spy because :
 - final class
``` 