### PR TITLE
ERF tectonic regime improvements

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/AbstractERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/AbstractERF.java
@@ -3,10 +3,12 @@ package org.opensha.sha.earthquake;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.EventObject;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.dom4j.Element;
 import org.opensha.commons.data.Site;
@@ -304,12 +306,10 @@ public abstract class AbstractERF implements
 	 * This specifies what types of Tectonic Regions are included in the ERF.
 	 * This default implementation includes only ACTIVE_SHALLOW, so it should 
 	 * be overridden in subclasses if other types are used
-	 * @return : ArrayList<TectonicRegionType>
+	 * @return : Set<TectonicRegionType>
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes(){
-		ArrayList<TectonicRegionType> list = new ArrayList<TectonicRegionType>();
-		list.add(TectonicRegionType.ACTIVE_SHALLOW);
-		return list;
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes(){
+		return EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW);
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/AbstractEpistemicListERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/AbstractEpistemicListERF.java
@@ -3,8 +3,10 @@ package org.opensha.sha.earthquake;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.EventObject;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.dom4j.Attribute;
 import org.dom4j.Element;
@@ -227,10 +229,8 @@ TimeSpanChangeListener,ParameterChangeListener, XMLSaveable {
 	 * be overridden in subclasses if other types are used
 	 * @return : ArrayList<TectonicRegionType>
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes(){
-		ArrayList<TectonicRegionType> list = new ArrayList<TectonicRegionType>();
-		list.add(TectonicRegionType.ACTIVE_SHALLOW);
-		return list;
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes(){
+		return EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW); 
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/BaseERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/BaseERF.java
@@ -4,6 +4,7 @@ package org.opensha.sha.earthquake;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.opensha.commons.data.Named;
 import org.opensha.commons.data.TimeSpan;
@@ -80,7 +81,7 @@ public interface BaseERF extends Named, Serializable, Comparable<BaseERF> {
 
 	/**
 	 * This specifies what types of Tectonic Regions are included in the ERF
-	 * @return : ArrayList<TectonicRegionType>
+	 * @return : Set<TectonicRegionType>
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes();
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes();
 }

--- a/src/main/java/org/opensha/sha/earthquake/ERFSubset.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERFSubset.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.opensha.commons.data.Site;
 import org.opensha.commons.data.TimeSpan;
@@ -48,7 +49,7 @@ public class ERFSubset implements ERF {
 	}
 
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		return baseERF.getIncludedTectonicRegionTypes();
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/erf/BaseFaultSystemSolutionERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/erf/BaseFaultSystemSolutionERF.java
@@ -5,9 +5,11 @@ import static org.opensha.sha.earthquake.param.IncludeBackgroundOption.ONLY;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.EventObject;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.UnaryOperator;
 
 import javax.swing.event.ChangeEvent;
@@ -113,6 +115,8 @@ public class BaseFaultSystemSolutionERF extends AbstractNthRupERF {
 	protected FaultSystemSolution faultSysSolution;		// the FFS for the ERF
 	protected Optional<RupMFDsModule> mfdsModuleOptional; // rupture MFDs (if available); null until first load is tried
 	protected Optional<ProxyFaultSectionInstances> proxySectsModuleOptional;					// proxy sects (if available); null until first load is tried
+	protected Optional<RupSetTectonicRegimes> trtsModuleOptional;		// rupture-specific TRTs module
+	protected Set<TectonicRegionType> erfTRTs;			// TRTs from the rupture set and gridded seismicity
 	protected boolean cacheGridSources = false;			// if true, grid sources are cached instead of built on the fly
 	protected ProbEqkSource[] gridSourceCache = null;
 	protected int numNonZeroFaultSystemSources;			// this is the number of faultSystemRups with non-zero rates (each is a source here)
@@ -512,6 +516,8 @@ public class BaseFaultSystemSolutionERF extends AbstractNthRupERF {
 		// clear out any cached values
 		mfdsModuleOptional = null;
 		proxySectsModuleOptional = null;
+		trtsModuleOptional = null;
+		erfTRTs = null;
 		gridSourceCache = null;
 		
 		// set flags
@@ -656,6 +662,20 @@ public class BaseFaultSystemSolutionERF extends AbstractNthRupERF {
 			// no MFD for this rupture, or it only has 1 value
 			return null;
 		return rupMFD;
+	}
+	
+	protected RupSetTectonicRegimes getRupSetTectonicRegimes() {
+		if (trtsModuleOptional == null) {
+			synchronized (this) {
+				if (trtsModuleOptional == null) {
+					trtsModuleOptional = faultSysSolution.getRupSet().getOptionalModule(RupSetTectonicRegimes.class);
+				}
+			}
+		}
+		if (trtsModuleOptional.isEmpty())
+			// don't have TRTs
+			return null;
+		return trtsModuleOptional.get();
 	}
 	
 	/**
@@ -981,6 +1001,31 @@ public class BaseFaultSystemSolutionERF extends AbstractNthRupERF {
 		if (disaggSourceConsolidator == null)
 			disaggSourceConsolidator = new SolutionDisaggConsolidator(this);
 		return disaggSourceConsolidator;
+	}
+
+	@Override
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
+		if (erfTRTs == null) {
+			if (faultSysSolution == null)
+				return EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW);
+			synchronized (this) {
+				if (erfTRTs == null) {
+					EnumSet<TectonicRegionType> trts = EnumSet.noneOf(TectonicRegionType.class);
+					
+					// add in those from the rupture set
+					RupSetTectonicRegimes rupSetTRTs = getRupSetTectonicRegimes();
+					if (rupSetTRTs != null)
+						trts.addAll(rupSetTRTs.getSet());
+					
+					// add in those from the gridded seismicity
+					GridSourceProvider gridProv = getGridSourceProvider();
+					if (gridProv != null)
+						trts.addAll(gridProv.getTectonicRegionTypes());
+					erfTRTs = trts;
+				}
+			}
+		}
+		return erfTRTs;
 	}
 	
 }

--- a/src/main/java/org/opensha/sha/earthquake/griddedForecast/GriddedHypoMagFreqDistForecast.java
+++ b/src/main/java/org/opensha/sha/earthquake/griddedForecast/GriddedHypoMagFreqDistForecast.java
@@ -1,8 +1,10 @@
 package org.opensha.sha.earthquake.griddedForecast;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.EventObject;
 import java.util.ListIterator;
+import java.util.Set;
 
 import org.opensha.commons.data.TimeSpan;
 import org.opensha.commons.geo.GriddedRegion;
@@ -183,10 +185,8 @@ ParameterChangeListener {
 	 * be overridden in subclasses if other types are used
 	 * @return : ArrayList<TectonicRegionType>
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes(){
-		ArrayList<TectonicRegionType> list = new ArrayList<TectonicRegionType>();
-		list.add(TectonicRegionType.ACTIVE_SHALLOW);
-		return list;
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes(){
+		return EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW);
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2010.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2010.java
@@ -2,7 +2,9 @@ package org.opensha.sha.earthquake.rupForecastImpl.NewZealand;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 import org.opensha.commons.calc.magScalingRelations.magScalingRelImpl.HanksBakun2002_MagAreaRel;
@@ -151,7 +153,7 @@ public class NewZealandERF2010 extends AbstractERF{
 	private ArrayList<Double> sourceMedianAnnualRates = new ArrayList<Double>();
 	
 	//Tectonic types
-	private ArrayList<TectonicRegionType> tectonicRegionTypes;
+	private Set<TectonicRegionType> tectonicRegionTypes;
 	private final static String ACTIVE_SHALLOW = "ACTIVE_SHALLOW";
 	private final static String SUBDUCTION_INTERFACE = "SUBDUCTION_INTERFACE";
 	private final static String SUBDUCTION_SLAB = "SUBDUCTION_SLAB";
@@ -720,7 +722,7 @@ public class NewZealandERF2010 extends AbstractERF{
 	 * This method makes the tectonic regions list
 	 */
 	public void makeTectonicRegionList() {
-		tectonicRegionTypes = new ArrayList<TectonicRegionType>();
+		tectonicRegionTypes = EnumSet.noneOf(TectonicRegionType.class);
 		if(numActiveShallow>0) tectonicRegionTypes.add(TectonicRegionType.ACTIVE_SHALLOW);
 		if(numVolcanic>0) tectonicRegionTypes.add(TectonicRegionType.VOLCANIC);
 		if(numSubSlab>0) tectonicRegionTypes.add(TectonicRegionType.SUBDUCTION_SLAB);
@@ -730,7 +732,7 @@ public class NewZealandERF2010 extends AbstractERF{
 	/**
 	 * This method copies the tectonicRegionTypes for using in the epistemic uncertainty version
 	 */
-	public ArrayList<TectonicRegionType> getTectonicRegionTypes() {
+	public Set<TectonicRegionType> getTectonicRegionTypes() {
 		return tectonicRegionTypes;
 	}
 	
@@ -815,7 +817,7 @@ public class NewZealandERF2010 extends AbstractERF{
 	}
 	
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		return tectonicRegionTypes;
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2010_Epistemic.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2010_Epistemic.java
@@ -6,6 +6,7 @@ package org.opensha.sha.earthquake.rupForecastImpl.NewZealand;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.StringTokenizer;
 import org.opensha.commons.data.TimeSpan;
 import org.opensha.commons.data.estimate.DiscreteValueEstimate;
@@ -182,7 +183,7 @@ public class NewZealandERF2010_Epistemic  extends AbstractEpistemicListERF{
 	}
 	
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 
 		return newZealand2010ERF.getTectonicRegionTypes();
 	}

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2015_ChchAftershock.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/NewZealand/NewZealandERF2015_ChchAftershock.java
@@ -2,7 +2,9 @@ package org.opensha.sha.earthquake.rupForecastImpl.NewZealand;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 import org.opensha.commons.calc.magScalingRelations.magScalingRelImpl.HanksBakun2002_MagAreaRel;
@@ -154,7 +156,7 @@ public class NewZealandERF2015_ChchAftershock extends AbstractERF{
 	private ArrayList<Double> sourceMedianAnnualRates = new ArrayList<Double>();
 	
 	//Tectonic types
-	private ArrayList<TectonicRegionType> tectonicRegionTypes;
+	private Set<TectonicRegionType> tectonicRegionTypes;
 	private final static String ACTIVE_SHALLOW = "ACTIVE_SHALLOW";
 	private final static String SUBDUCTION_INTERFACE = "SUBDUCTION_INTERFACE";
 	private final static String SUBDUCTION_SLAB = "SUBDUCTION_SLAB";
@@ -723,7 +725,7 @@ public class NewZealandERF2015_ChchAftershock extends AbstractERF{
 	 * This method makes the tectonic regions list
 	 */
 	public void makeTectonicRegionList() {
-		tectonicRegionTypes = new ArrayList<TectonicRegionType>();
+		tectonicRegionTypes = EnumSet.noneOf(TectonicRegionType.class);
 		if(numActiveShallow>0) tectonicRegionTypes.add(TectonicRegionType.ACTIVE_SHALLOW);
 		if(numVolcanic>0) tectonicRegionTypes.add(TectonicRegionType.VOLCANIC);
 		if(numSubSlab>0) tectonicRegionTypes.add(TectonicRegionType.SUBDUCTION_SLAB);
@@ -733,7 +735,7 @@ public class NewZealandERF2015_ChchAftershock extends AbstractERF{
 	/**
 	 * This method copies the tectonicRegionTypes for using in the epistemic uncertainty version
 	 */
-	public ArrayList<TectonicRegionType> getTectonicRegionTypes() {
+	public Set<TectonicRegionType> getTectonicRegionTypes() {
 		return tectonicRegionTypes;
 	}
 	
@@ -818,7 +820,7 @@ public class NewZealandERF2015_ChchAftershock extends AbstractERF{
 	}
 	
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		return tectonicRegionTypes;
 	}
 	

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
@@ -4,10 +4,12 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.opensha.sha.earthquake.faultSysSolution.FaultSystemSolution;
 import org.opensha.sha.earthquake.faultSysSolution.erf.BaseFaultSystemSolutionERF;
 import org.opensha.sha.earthquake.rupForecastImpl.prvi25.util.NSHM25_Downloader;
+import org.opensha.sha.util.TectonicRegionType;
 
 import javax.swing.*;
 import java.io.File;
 import java.io.IOException;
+import java.util.Set;
 
 /**
  * USGS 2025 NSHM ERF, Puerto Rico and Virgin Islands, Branch Averaged ERF
@@ -71,7 +73,7 @@ public class NSHM25_PRVI_BranchAveragedERF extends BaseFaultSystemSolutionERF {
         }).join();
     }
 
-    /**
+	/**
      * Ensure our solution is fetched and loaded and then update the forecast.
      * Only checks for newer models if not already loaded in this session.
      */
@@ -85,6 +87,9 @@ public class NSHM25_PRVI_BranchAveragedERF extends BaseFaultSystemSolutionERF {
     }
 
     public static void main(String[] args) {
-        new NSHM25_PRVI_BranchAveragedERF().updateForecast();
+    	NSHM25_PRVI_BranchAveragedERF erf = new NSHM25_PRVI_BranchAveragedERF();
+    	erf.updateForecast();
+    	
+    	System.out.println("TRTs:\n"+erf.getIncludedTectonicRegionTypes());
     }
 }

--- a/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
+++ b/src/main/java/org/opensha/sha/gcim/ui/GcimControlPanel.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.swing.BoxLayout;
@@ -738,7 +739,7 @@ implements ParameterChangeFailListener, ParameterChangeListener,
 	/** 
 	 * This method gets the included tectonic region type, which is needed by the GcimEditIMi panel
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		return parent.getIncludedTectonicRegionTypes();
 	}
 	

--- a/src/main/java/org/opensha/sha/gcim/ui/IMCorrRel_MultiGuiBean.java
+++ b/src/main/java/org/opensha/sha/gcim/ui/IMCorrRel_MultiGuiBean.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -65,7 +66,8 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 	private ArrayList<ImCorrelationRelationship> imCorrRels;
 	private ArrayList<Boolean> imCorrRelEnables;
 
-	private ArrayList<TectonicRegionType> regions = null;
+	private Set<TectonicRegionType> regions = null;
+	private List<TectonicRegionType> regionsList = null;
 	
 	private IMCorrRel_ParamEditor paramEdit = null;
 	private int chooserForEditor = 0;
@@ -149,9 +151,9 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 			// this is for multiple IMCorrRels
 			if (!refreshOnly)
 				showHideButtons = new ArrayList<ShowHideButton>();
-			for (int i=0; i<regions.size(); i++) {
+			for (int i=0; i<regionsList.size(); i++) {
 				// create label for tectonic region
-				TectonicRegionType region = regions.get(i);
+				TectonicRegionType region = regionsList.get(i);
 				JLabel label = new JLabel(region.toString());
 				label.setFont(trtFont);
 				this.add(wrapInPanel(label));
@@ -232,10 +234,11 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 	 * 
 	 * @param regions
 	 */
-	public void setTectonicRegions(ArrayList<TectonicRegionType> regions) {
+	public void setTectonicRegions(Set<TectonicRegionType> regions) {
 		// we can refresh only if there are none or < 2 regions, and the check box isn't showing
 		boolean refreshOnly = (regions == null || regions.size() < 2) && !isCheckBoxVisible();
 		this.regions = regions;
+		this.regionsList = regions == null ? null : new ArrayList<>(regions);
 		boolean prevSingle = !isMultipleIMCorrRels();
 		this.rebuildGUI(refreshOnly);
 		boolean newSingle = !isMultipleIMCorrRels();
@@ -250,7 +253,7 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 	 * 
 	 * @return the list Tectonic Regions from the GUI
 	 */
-	public ArrayList<TectonicRegionType> getTectonicRegions() {
+	public Set<TectonicRegionType> getTectonicRegions() {
 		return regions;
 	}
 
@@ -392,7 +395,7 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 
 			TectonicRegionType trt = null;
 			if (isMultipleIMCorrRels())
-				trt = regions.get(index);
+				trt = regionsList.get(index);
 			this.setRenderer(new EnableableCellRenderer(trt));
 			
 			this.comboBoxIndex = index;
@@ -408,8 +411,8 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 	protected ChooserComboBox getChooser(TectonicRegionType trt) {
 		if (!isMultipleIMCorrRels())
 			return chooserBoxes.get(0);
-		for (int i=0; i<regions.size(); i++) {
-			if (regions.get(i).toString().equals(trt.toString()))
+		for (int i=0; i<regionsList.size(); i++) {
+			if (regionsList.get(i).toString().equals(trt.toString()))
 				return chooserBoxes.get(i);
 		}
 		return null;
@@ -548,8 +551,8 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 	public void showParamEditor(TectonicRegionType trt) {
 		if (!isMultipleIMCorrRels())
 			throw new RuntimeException("Cannot show param editor for TRT in single IMCorrRel mode!");
-		for (int i=0; i<regions.size(); i++) {
-			if (regions.get(i).toString().equals(trt.toString())) {
+		for (int i=0; i<regionsList.size(); i++) {
+			if (regionsList.get(i) == trt) {
 				ShowHideButton button = showHideButtons.get(i);
 				if (button.isShowing())
 					button.doClick();
@@ -597,7 +600,7 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 			map.put(TectonicRegionType.ACTIVE_SHALLOW, imCorrRel);
 		} else {
 			for (int i=0; i<regions.size(); i++) {
-				TectonicRegionType region = regions.get(i);
+				TectonicRegionType region = regionsList.get(i);
 				map.put(region, getIMCorrRelForChooser(i));
 			}
 		}
@@ -678,7 +681,7 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 		if (trt == null)
 			throw new IllegalArgumentException("Tectonic Region Type cannot be null!");
 		for (int i=0; i<regions.size(); i++) {
-			if (trt.toString().equals(regions.get(i).toString())) {
+			if (trt == regionsList.get(i)) {
 				int index = ListUtils.getIndexByName(imCorrRels, imCorrRelName);
 				if (index < 0)
 					throw new NoSuchElementException("IMCorrRel '" + imCorrRelName + "' not found");
@@ -706,8 +709,8 @@ public class IMCorrRel_MultiGuiBean extends LabeledBoxPanel implements ActionLis
 			ImCorrelationRelationship imCorrRel = imikCorrRel; //Hard coded
 			map.put(TectonicRegionType.ACTIVE_SHALLOW, imCorrRel);
 		} else {
-			for (int i=0; i<regions.size(); i++) {
-				TectonicRegionType region = regions.get(i);
+			for (int i=0; i<regionsList.size(); i++) {
+				TectonicRegionType region = regionsList.get(i);
 				map.put(region, imikCorrRel);  //Hard coded
 			}
 		}

--- a/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
+++ b/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
@@ -19,6 +19,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import javax.swing.BorderFactory;
@@ -2703,9 +2704,12 @@ ActionListener, ScalarIMRChangeListener, IMTChangeListener {
 	/** 
 	 * This method gets the included tectonic region types, which is needed by some control panels
 	 */
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		try {
-			ArrayList<TectonicRegionType> includedTectonicRegionTypes =  erfGuiBean.getSelectedERF_Instance().getIncludedTectonicRegionTypes();
+			BaseERF selectedERF = erfGuiBean.getSelectedERF();
+//			System.out.println("Getting TRTs for "+selectedERF.getName());
+			Set<TectonicRegionType> includedTectonicRegionTypes =  selectedERF.getIncludedTectonicRegionTypes();
+//			System.out.println("Returning TRTs: "+includedTectonicRegionTypes);
 			return includedTectonicRegionTypes;
 		} catch (InvocationTargetException e) {
 			e.printStackTrace();

--- a/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
@@ -62,7 +62,10 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	private List<? extends ScalarIMR> imrs;
 	private ArrayList<Boolean> imrEnables;
 
-	private ArrayList<TectonicRegionType> regions = null;
+	// set from the ERF
+	private Set<TectonicRegionType> regions = null;
+	// list for fixed iteration order
+	private List<TectonicRegionType> regionsList = null;
 	
 	private IMR_ParamEditor paramEdit = null;
 	private int chooserForEditor = 0;
@@ -168,9 +171,10 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 			// this is for multiple IMRs
 			if (!refreshOnly)
 				showHideButtons = new ArrayList<ShowHideButton>();
-			for (int i=0; i<regions.size(); i++) {
+			
+			for (int i=0; i<regionsList.size(); i++) {
+				TectonicRegionType region = regionsList.get(i);
 				// create label for tectonic region
-				TectonicRegionType region = regions.get(i);
 				JLabel label = new JLabel(region.toString());
 				label.setFont(trtFont);
 				this.add(wrapInPanel(label));
@@ -252,10 +256,12 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	 * 
 	 * @param regions
 	 */
-	public void setTectonicRegions(ArrayList<TectonicRegionType> regions) {
+	public void setTectonicRegions(Set<TectonicRegionType> regions) {
+//		System.out.println("IMR_MultiGuiBean.setTectonicRegions("+regions+")");
 		// we can refresh only if there are none or < 2 regions, and the check box isn't showing
 		boolean refreshOnly = (regions == null || regions.size() < 2) && !isCheckBoxVisible();
 		this.regions = regions;
+		this.regionsList = regions == null ? null : new ArrayList<>(regions);
 		boolean prevSingle = !isMultipleIMRs();
 		this.rebuildGUI(refreshOnly);
 		boolean newSingle = !isMultipleIMRs();
@@ -270,7 +276,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	 * 
 	 * @return the list Tectonic Regions from the GUI
 	 */
-	public ArrayList<TectonicRegionType> getTectonicRegions() {
+	public Set<TectonicRegionType> getTectonicRegions() {
 		return regions;
 	}
 
@@ -341,13 +347,13 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	 */
 	public class EnableableCellRenderer extends BasicComboBoxRenderer {
 		
-		protected ArrayList<Boolean> trtSupported = null;
+		protected List<Boolean> trtSupported = null;
 		
 		public EnableableCellRenderer(TectonicRegionType trt) {
 			this(wrapInList(trt));
 		}
 		
-		public EnableableCellRenderer(ArrayList<TectonicRegionType> trts) {
+		public EnableableCellRenderer(List<TectonicRegionType> trts) {
 			if (trts != null) {
 				trtSupported = new ArrayList<Boolean>();
 				for (ScalarIMR imr : imrs) {
@@ -442,12 +448,12 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		public void resetRenderer() {
 			EnableableCellRenderer renderer;
 			if (isMultipleIMRs()) {
-				TectonicRegionType trt = regions.get(comboBoxIndex);
+				TectonicRegionType trt = regionsList.get(comboBoxIndex);
 //				System.out.println("Resetting renderer for single: " + trt);
 				renderer = new EnableableCellRenderer(trt);
 			} else {
 //				System.out.println("Resetting renderer for multiple: " + regions);
-				renderer = new EnableableCellRenderer(regions);
+				renderer = new EnableableCellRenderer(regionsList);
 			}
 			this.setRenderer(renderer);
 		}
@@ -461,7 +467,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		if (!isMultipleIMRs())
 			return chooserBoxes.get(0);
 		for (int i=0; i<regions.size(); i++) {
-			if (regions.get(i).toString().equals(trt.toString()))
+			if (regionsList.get(i) == trt)
 				return chooserBoxes.get(i);
 		}
 		return null;
@@ -601,7 +607,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		if (!isMultipleIMRs())
 			throw new RuntimeException("Cannot show param editor for TRT in single IMR mode!");
 		for (int i=0; i<regions.size(); i++) {
-			if (regions.get(i).toString().equals(trt.toString())) {
+			if (regionsList.get(i) == trt) {
 				ShowHideButton button = showHideButtons.get(i);
 				if (button.isShowing())
 					button.doClick();
@@ -637,7 +643,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 			map.put(TectonicRegionType.ACTIVE_SHALLOW, imr);
 		} else {
 			for (int i=0; i<regions.size(); i++) {
-				TectonicRegionType region = regions.get(i);
+				TectonicRegionType region = regionsList.get(i);
 				map.put(region, getIMRForChooser(i));
 			}
 		}
@@ -692,7 +698,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		if (trt == null)
 			throw new IllegalArgumentException("Tectonic Region Type cannot be null!");
 		for (int i=0; i<regions.size(); i++) {
-			if (trt.toString().equals(regions.get(i).toString())) {
+			if (trt == regionsList.get(i)) {
 				int index = ListUtils.getIndexByName(imrs, imrName);
 				if (index < 0)
 					throw new NoSuchElementException("IMR '" + imrName + "' not found");

--- a/src/main/java/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
+++ b/src/main/java/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -258,10 +259,8 @@ public class UCERF3EpistemicListERF implements EpistemicListERF, ParameterChange
 	}
 
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
-		ArrayList<TectonicRegionType> list = new ArrayList<TectonicRegionType>();
-		list.add(TectonicRegionType.ACTIVE_SHALLOW);
-		return list;
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
+		return EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW);
 	}
 
 	@Override

--- a/src/test/java/org/opensha/sha/gui/beans/MultiERFDummy.java
+++ b/src/test/java/org/opensha/sha/gui/beans/MultiERFDummy.java
@@ -1,6 +1,8 @@
 package org.opensha.sha.gui.beans;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Set;
 
 import org.opensha.sha.earthquake.AbstractERF;
 import org.opensha.sha.earthquake.ProbEqkSource;
@@ -8,13 +10,11 @@ import org.opensha.sha.util.TectonicRegionType;
 
 public class MultiERFDummy extends AbstractERF {
 	
-	ArrayList<TectonicRegionType> regions;
+	Set<TectonicRegionType> regions;
 	
 	public MultiERFDummy() {
-		regions = new ArrayList<TectonicRegionType>();
-		regions.add(TectonicRegionType.ACTIVE_SHALLOW);
-		regions.add(TectonicRegionType.STABLE_SHALLOW);
-		regions.add(TectonicRegionType.SUBDUCTION_SLAB);
+		regions = EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW,
+				TectonicRegionType.STABLE_SHALLOW, TectonicRegionType.SUBDUCTION_SLAB);
 	}
 
 	@Override
@@ -48,7 +48,7 @@ public class MultiERFDummy extends AbstractERF {
 	}
 
 	@Override
-	public ArrayList<TectonicRegionType> getIncludedTectonicRegionTypes() {
+	public Set<TectonicRegionType> getIncludedTectonicRegionTypes() {
 		return regions;
 	}
 

--- a/src/test/java/org/opensha/sha/gui/beans/TestIMR_MultiGuiBean.java
+++ b/src/test/java/org/opensha/sha/gui/beans/TestIMR_MultiGuiBean.java
@@ -3,12 +3,14 @@ package org.opensha.sha.gui.beans;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.Stack;
 
 import javax.swing.JCheckBox;
@@ -42,9 +44,9 @@ import org.opensha.sha.util.TectonicRegionType;
 public class TestIMR_MultiGuiBean implements ScalarIMRChangeListener {
 	
 	static List<? extends ScalarIMR> imrs;
-	static ArrayList<TectonicRegionType> demoTRTs;
-	static ArrayList<TectonicRegionType> demoTRTsNoSub;
-	static ArrayList<TectonicRegionType> demoSingleTRT;
+	static Set<TectonicRegionType> demoTRTs;
+	static Set<TectonicRegionType> demoTRTsNoSub;
+	static Set<TectonicRegionType> demoSingleTRT;
 	
 	IMR_MultiGuiBean gui;
 	
@@ -66,18 +68,12 @@ public class TestIMR_MultiGuiBean implements ScalarIMRChangeListener {
 	@BeforeClass
 	public static void setUpBeforeClass() {
 		imrs = getBuildIMRs();
-		demoTRTs = new ArrayList<TectonicRegionType>();
-		demoTRTs.add(TectonicRegionType.ACTIVE_SHALLOW);
-		demoTRTs.add(TectonicRegionType.STABLE_SHALLOW);
-		demoTRTs.add(TectonicRegionType.SUBDUCTION_INTERFACE);
-		demoTRTs.add(TectonicRegionType.SUBDUCTION_SLAB);
+		demoTRTs = EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW, TectonicRegionType.STABLE_SHALLOW,
+				TectonicRegionType.SUBDUCTION_SLAB, TectonicRegionType.SUBDUCTION_INTERFACE);
 		
-		demoTRTsNoSub = new ArrayList<TectonicRegionType>();
-		demoTRTsNoSub.add(TectonicRegionType.ACTIVE_SHALLOW);
-		demoTRTsNoSub.add(TectonicRegionType.STABLE_SHALLOW);
+		demoTRTsNoSub = EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW, TectonicRegionType.STABLE_SHALLOW);
 		
-		demoSingleTRT = new ArrayList<TectonicRegionType>();
-		demoSingleTRT.add(TectonicRegionType.ACTIVE_SHALLOW);
+		demoSingleTRT = EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW);
 	}
 	
 	@Before
@@ -249,19 +245,19 @@ public class TestIMR_MultiGuiBean implements ScalarIMRChangeListener {
 		gui.setTectonicRegions(demoTRTs);
 		
 		try {
-			gui.setIMR(ShakeMap_2003_AttenRel.NAME, demoTRTs.get(0));
+			gui.setIMR(ShakeMap_2003_AttenRel.NAME, demoTRTs.iterator().next());
 			fail("Should throw exception when setIMR called in single IMR mode");
 		} catch (RuntimeException e) {}
 		
 		gui.setMultipleIMRs(true);
 		
 		try {
-			gui.setIMR(null, demoTRTs.get(0));
+			gui.setIMR(null, demoTRTs.iterator().next());
 			fail("Should throw exception when setIMR called with null name");
 		} catch (NoSuchElementException e) {}
 		
 		try {
-			gui.setIMR(null, demoTRTs.get(0));
+			gui.setIMR(null, demoTRTs.iterator().next());
 			fail("Should throw exception when setIMR called with null name");
 		} catch (NoSuchElementException e) {}
 		
@@ -271,16 +267,16 @@ public class TestIMR_MultiGuiBean implements ScalarIMRChangeListener {
 		} catch (RuntimeException e) {}
 		
 		try {
-			gui.setIMR(BA_2008_AttenRel.NAME, demoTRTs.get(0));
+			gui.setIMR(BA_2008_AttenRel.NAME, demoTRTs.iterator().next());
 			fail("Setting IMR should fail if IMR doesn't support current IMT!");
 		} catch (Exception e) {}
 		
 		gui.setIMT(pgaIMR);
 		
-		gui.setIMR(CY_2008_AttenRel.NAME, demoTRTs.get(0));
+		gui.setIMR(CY_2008_AttenRel.NAME, demoTRTs.iterator().next());
 		
 		assertEquals("Set IMR for TRT 0 didn't work!",
-				CY_2008_AttenRel.NAME, gui.getIMRMap().get(demoTRTs.get(0)).getName());
+				CY_2008_AttenRel.NAME, gui.getIMRMap().get(demoTRTs.iterator().next()).getName());
 		
 		gui.setTectonicRegions(demoTRTsNoSub);
 		

--- a/src/test/java/org/opensha/sha/gui/beans/TestIMT_IMR_Interactions.java
+++ b/src/test/java/org/opensha/sha/gui/beans/TestIMT_IMR_Interactions.java
@@ -3,7 +3,9 @@ package org.opensha.sha.gui.beans;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -26,7 +28,7 @@ import org.opensha.sha.util.TectonicRegionType;
 public class TestIMT_IMR_Interactions {
 
 	static List<? extends ScalarIMR> imrs;
-	static ArrayList<TectonicRegionType> demoTRTs;
+	static Set<TectonicRegionType> demoTRTs;
 
 	IMR_MultiGuiBean imrGui;
 	IMT_NewGuiBean imtGui;
@@ -37,11 +39,8 @@ public class TestIMT_IMR_Interactions {
 		imrs =  AttenRelRef.instanceList(null, true);
 		for (ScalarIMR imr : imrs)
 			imr.setParamDefaults();
-		demoTRTs = new ArrayList<TectonicRegionType>();
-		demoTRTs.add(TectonicRegionType.ACTIVE_SHALLOW);
-		demoTRTs.add(TectonicRegionType.STABLE_SHALLOW);
-		demoTRTs.add(TectonicRegionType.SUBDUCTION_INTERFACE);
-		demoTRTs.add(TectonicRegionType.SUBDUCTION_SLAB);
+		demoTRTs = EnumSet.of(TectonicRegionType.ACTIVE_SHALLOW, TectonicRegionType.STABLE_SHALLOW,
+				TectonicRegionType.SUBDUCTION_SLAB, TectonicRegionType.SUBDUCTION_INTERFACE);
 	}
 
 	@Before


### PR DESCRIPTION
This updates the ERF `getIncludedTectonicRegionTypes()` method to return `Set<TectonicRegionType>` rather than an `ArrayList`, and updates `BaseFaultSystemSolutionERF` to properly populate that set. Previously, `BaseFaultSystemSolutionERF` set the TRT correctly in each source but didn't advertise the set of TRTs to the applications. Now, the apps correctly show the multi-TRT IMR view for NSHM23 and NSHM25.

This should be good to go, but I'll wait until after the impending release to merge it in.