### PR TITLE
Fix CPTVal serialization

### DIFF
--- a/build.version
+++ b/build.version
@@ -1,7 +1,7 @@
 # OpenSHA version file.
-# Mon May  5 15:53:05 PDT 2025
+# Mon Mar 23 17:18:54 PDT 2026
 
-build.number=0
+build.number=1
 major.version=26
 minor.version=1
 

--- a/build.version
+++ b/build.version
@@ -1,7 +1,7 @@
 # OpenSHA version file.
 # Mon May  5 15:53:05 PDT 2025
 
-build.number=0
+build.number=1
 major.version=26
 minor.version=1
 

--- a/src/main/java/org/opensha/commons/util/cpt/CPTVal.java
+++ b/src/main/java/org/opensha/commons/util/cpt/CPTVal.java
@@ -10,6 +10,7 @@ import org.opensha.commons.util.XMLUtils;
 
 public class CPTVal implements Comparable<CPTVal>, Serializable, Cloneable, XMLSaveable {
 	public static final String XML_METADATA_NAME = "CPTVal";
+    private static final long serialVersionUID = -5043502130615306253L;
 	
 	/*
 	 * In general this information determines the indicator color associated


### PR DESCRIPTION
Hotfix release for v26.1.1.

- Fix CPTVal serialization to support GMTMap in prod
- Increment build version to 26.1.1
- opensha-dev @ 4bb3085
- opensha-cybershake @ 701bf68
- Still supports Java 11