### PR TITLE
Fix bug merging pager images in ComcatReportPageGen

### DIFF
--- a/src/main/java/org/opensha/commons/data/comcat/plot/ComcatReportPageGen.java
+++ b/src/main/java/org/opensha/commons/data/comcat/plot/ComcatReportPageGen.java
@@ -766,16 +766,15 @@ public class ComcatReportPageGen {
 	private static void combinePager(File top, File bottom, File output) throws IOException {
 		BufferedImage topIMG = ImageIO.read(top);
 		BufferedImage botIMG = ImageIO.read(bottom);
-		
+
 		int width = Integer.max(topIMG.getWidth(), botIMG.getWidth());
 		int height = topIMG.getHeight()+botIMG.getHeight();
-		
-		BufferedImage comb = new BufferedImage(width, height, topIMG.getType());
+		BufferedImage comb = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
 		for (int y=0; y<topIMG.getHeight(); y++)
 			for (int x=0; x<topIMG.getWidth(); x++)
 				comb.setRGB(x, y, topIMG.getRGB(x, y));
-		for (int y=0; y<topIMG.getHeight(); y++)
-			for (int x=0; x<topIMG.getWidth(); x++)
+		for (int y=0; y<botIMG.getHeight(); y++)
+			for (int x=0; x<botIMG.getWidth(); x++)
 				comb.setRGB(x, y+topIMG.getHeight(), botIMG.getRGB(x, y));
 		
 		ImageIO.write(comb, "png", output);


### PR DESCRIPTION
Resolves failure to build the event page for recent event [M 4.6 - 1 km SE of Boulder Creek, CA](https://earthquake.usgs.gov/earthquakes/eventpage/nc75337442/executive?utm_medium=email&utm_source=ENS&utm_campaign=realtime).

Previously the combinePager function assumed that the top and bottom images to merge would have the same dimensions. This event retrieved images with different widths which resulted in an ArrayIndexOutOfBoundsException. This PR resolves the issue by updating the bounds for the bottom image loop. We also changed the output image type to TYPE_INT_ARGB instead of assuming the top image is always compatible (e.g., TYPE_4BYTE_ABGR).
