### PR TITLE
Config for joint rupture merger

### DIFF
--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/RupHistogramPlots.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/reports/plots/RupHistogramPlots.java
@@ -1137,38 +1137,6 @@ public class RupHistogramPlots extends AbstractRupSetPlot {
 	private static double[] example_fractiles_default =  { 0d, 0.5, 0.9, 0.95, 0.975, 0.99, 0.999, 1d };
 	
 	public enum HistScalar {
-		MULTI_PROPORTIONS("Multi Rupture Proportions",
-				"crustal area/subduction area",
-		"Area of crustal component / area of subduction component.") {
-			@Override
-			public HistogramFunction getHistogram(MinMaxAveTracker scalarTrack) {
-				double min = Math.floor(Math.log(scalarTrack.getMin()));
-				double max = Math.ceil(Math.log(scalarTrack.getMax()));
-				int num = (int)Math.max(5, Math.max(20, max - min + 2));
-				return new HistogramFunction(min, max, num);
-			}
-
-			@Override
-			public double getValue(int index, FaultSystemRupSet rupSet, ClusterRupture rup,
-								   SectionDistanceAzimuthCalculator distAzCalc) {
-				List<FaultSection> sections = rup.buildOrderedSectionList();
-				double subduction = sections.stream().filter(s -> s.getSectionName().contains("row:")).mapToDouble(s -> s.getArea(false)).sum();
-				double crustal = sections.stream().filter(s -> !s.getSectionName().contains("row:")).mapToDouble(s -> s.getArea(false)).sum();
-				if(subduction == 0) {
-					return 1;
-				}
-				return crustal/subduction;
-			}
-			public boolean isLogX() {
-				return true;
-			}
-
-
-			@Override
-			public double[] getExampleRupPlotFractiles() {
-				return example_fractiles_default;
-			}
-		},
 		LENGTH("Rupture Length", "Length (km)",
 				"Total length (km) of the rupture, not including jumps or gaps.") {
 			@Override

--- a/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/multiRupture/RuptureMerger.java
+++ b/src/main/java/org/opensha/sha/earthquake/faultSysSolution/ruptures/multiRupture/RuptureMerger.java
@@ -213,15 +213,24 @@ public class RuptureMerger {
         return outPrefix;
     }
 
-    public static void main(String[] args) throws IOException {
+    /**
+     * RuptureMerger configuration with defaults
+     */
+    public static class Config{
+        public File ruptureSet;
+        public File filterFile;
+        public File outputDir = new File("/tmp/");
+        public double maxJumpDist = 15;
+        public int areaSpreadCount = 3;
+        public double areaSpreadDiff = 0.1;
+        public double stiffnessGridSpacing = 2;
+        public File stiffnessCacheDir = new File("/tmp/stiffnessCaches/");
+    }
+
+    public static void merge(Config config) throws IOException {
 
         // load ruptures and split them up into crustal and subduction
-    	// dirty...but this will help us collaborate better...
-    	// Oakley's file:
-    	File inputFile = resolveFile(
-                "C:\\tmp\\nzshm22_merged.zip",
-                "C:\\Users\\user\\GNS\\rupture sets\\nzshm_complete_merged.zip",
-                "/home/kevin/Downloads/rupset-disjointed.zip");
+    	File inputFile = config.ruptureSet;
         FaultSystemRupSet rupSet = FaultSystemRupSet.load(inputFile);
         List<ClusterRupture> nucleationRuptures = new ArrayList<>();
         List<ClusterRupture> targetRuptures = new ArrayList<>();
@@ -232,7 +241,7 @@ public class RuptureMerger {
         }
 
         List<ClusterRupture> ruptures = cRups.getAll();
-        File filterFile = resolveFile("C:\\tmp\\filteredRuptures.txt", "C:\\Users\\user\\GNS\\rupture sets\\filteredRuptures.txt");
+        File filterFile = config.filterFile;
         if (filterFile != null) {
             int oldRupCount = ruptures.size();
             ruptures = new ArrayList<>();
@@ -257,16 +266,15 @@ public class RuptureMerger {
         System.out.println("Loaded " + targetRuptures.size() + " target ruptures");
 
         // set up RuptureMerger
-        double maxJumpDist = 15d;
-        String outPrefix = "mergedRupset_"+oDF.format(maxJumpDist)+"km";
-        RuptureMerger merger = new RuptureMerger(rupSet, maxJumpDist, nucleationRuptures, targetRuptures);
+        String outPrefix = "mergedRupset_"+oDF.format(config.maxJumpDist)+"km";
+        RuptureMerger merger = new RuptureMerger(rupSet, config.maxJumpDist, nucleationRuptures, targetRuptures);
 
-        AreaSpreadSelector targetSelector = new AreaSpreadSelector(merger.getDisAzCalc(), 3, 0.1);
+        AreaSpreadSelector targetSelector = new AreaSpreadSelector(merger.getDisAzCalc(), config.areaSpreadCount, config.areaSpreadDiff);
         merger.setTargetSelector(targetSelector);
 
         System.out.println("possible jumps: "+merger.countPossibleJumps());
 
-        StiffnessCalcModule stiffness = new StiffnessCalcModule(rupSet, 2, new File("C:\\tmp\\stiffnessCaches"));
+        StiffnessCalcModule stiffness = new StiffnessCalcModule(rupSet, config.stiffnessGridSpacing, config.stiffnessCacheDir);
 
         if (stiffness.stiffGridSpacing != 1d)
             outPrefix += "_cffPatch" + oDF.format(stiffness.stiffGridSpacing) + "km";
@@ -318,10 +326,10 @@ public class RuptureMerger {
                         .forScalingRelationship(ScalingRelationships.MEAN_UCERF3)
                         .addModule(stiffness)
                         .build();
-        resultRupSet.write(new File("/tmp/" + outPrefix + ".zip"));
+        resultRupSet.write(new File(config.outputDir, outPrefix + ".zip"));
 
         // quick sanity check
-        RupCartoonGenerator.plotRupture(new File("/tmp/"), outPrefix, mergedRuptures.get(0), "merged rupture", false, true);
+        RupCartoonGenerator.plotRupture(config.outputDir, outPrefix, mergedRuptures.get(0), "merged rupture", false, true);
 
         List<ClusterRupture> sortedRups = new ArrayList<>(mergedRuptures);
         sortedRups.sort(Comparator.comparing((ClusterRupture r) -> r.clusters[0].subSects.size()).thenComparing((ClusterRupture r) -> r.buildOrderedSectionList().size()));
@@ -330,5 +338,15 @@ public class RuptureMerger {
 //        plot.plot(new File("/tmp"), outPrefix + "stiffness", sortedRups.get(sortedRups.size() - 1), "merged rupture " + (sortedRups.size() - 1));
     }
 
+    public static void main(String[] args) throws IOException {
+        Config config = new Config();
+        // dirty...but this will help us collaborate better...
+        config.ruptureSet = resolveFile(
+                "C:\\runs\\run_4\\nzshm22_complete_merged.zip",
+                "C:\\Users\\user\\GNS\\rupture sets\\nzshm_complete_merged.zip",
+                "/home/kevin/Downloads/rupset-disjointed.zip");
+        config.filterFile = resolveFile("C:\\tmp\\filteredRuptures.txt", "C:\\runs\\run_4\\filteredRuptures.txt");
 
+        merge(config);
+    }
 }


### PR DESCRIPTION
This PR makes it possible to configure and run `RuptureMerger` in a more flexible way. This makes it easier for me to integrate it in my workflows.

I removed the `MULTI_PROPORTIONS` histogram as it only works well for rupture sets that are purely joint ruptures. I also had it throw an exception for some normal rupture sets.