### PR TITLE
Correct simulation endtime written into ETAS result binaries

### DIFF
--- a/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_CatalogIO.java
+++ b/src/main/java/scratch/UCERF3/erf/ETAS/ETAS_CatalogIO.java
@@ -515,7 +515,7 @@ public class ETAS_CatalogIO {
 				out.writeInt(meta.rangeTriggerRupIDs.upperEndpoint());
 			}
 			out.writeLong(meta.simulationStartTime);
-			out.writeLong(meta.simulationStartTime);
+			out.writeLong(meta.simulationEndTime);
 			out.writeInt(meta.numSpontaneousRuptures);
 			out.writeInt(meta.numSupraSeis);
 			out.writeDouble(meta.minMag);


### PR DESCRIPTION
Write simulation end time into binaries.
Note that this bug fix won't impact current ETAS results binaries until we merge it into etas-launcher-stable.

Tested locally via Docker
* Custom opensha-jup image ran UCERF3-ETAS n=100 for Ridgecrest
* Wrote out binary results via ETAS_CatalogIO
* Used modified ETAS Binary Analysis Tool to confirm the binary could be read
* Confirmed via the report that the endtime and starttime for individual catalogs differ and are as expected.