### PR TITLE
Dip and GMM hypocentral depth updates for multifault ruptures (CompoundSurface)

### DIFF
--- a/src/main/java/org/opensha/sha/faultSurface/CompoundSurface.java
+++ b/src/main/java/org/opensha/sha/faultSurface/CompoundSurface.java
@@ -792,7 +792,10 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 			for (int s=0; s<surfaceAreas.length; s++)
 				avgDip += surfaces.get(s).getAveDip()*surfaceAreas[s];
 			avgDip /= totArea;
-			this.avgDip = avgDip;
+			Preconditions.checkState(avgDip < 90.0001 && avgDip > 0d, "Bad avgDip=%s", avgDip);
+			// can end up as barely over 90 due to floating point math, e.g., 90.00000000000001; clamp it to 90 after
+			// the check above
+			this.avgDip = Math.min(avgDip, 90d);
 		}
 		return avgDip;
 	}

--- a/src/main/java/org/opensha/sha/faultSurface/CompoundSurface.java
+++ b/src/main/java/org/opensha/sha/faultSurface/CompoundSurface.java
@@ -71,6 +71,7 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 	private double horzWidth = Double.NaN;
 	private double topDepth = Double.NaN;
 	private double bottomDepth = Double.NaN;
+	private double avgDip = Double.NaN;
 	
 	private SurfaceDistanceCache cache = SurfaceCachingPolicy.build(this);
 	
@@ -123,7 +124,7 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 	 */
 	public static class Simple extends CompoundSurface {
 		
-		private final double avgDip;
+		private final double avgOrientedDip;
 		private final BitSet reversed;
 		private final boolean wholeRupReversed;
 		private final ContiguousIntList indexes;
@@ -369,23 +370,23 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 				// flip the direction of each surface
 				reversed.flip(0, numSurfaces);
 			}
-			this.avgDip = avgDip;
+			this.avgOrientedDip = avgDip;
 			this.indexes = new ContiguousIntList();
 		}
 
 		private Simple(List<? extends RuptureSurface> surfaces, List<? extends FaultSection> sects,
-				double[] surfaceAreas, double totArea, double avgDip, BitSet reversed,
+				double[] surfaceAreas, double totArea, double avgOrientedDip, BitSet reversed,
 				boolean wholeRupReversed, ContiguousIntList indexes) {
 			super(surfaces, sects, surfaceAreas, totArea);
-			this.avgDip = avgDip;
+			this.avgOrientedDip = avgOrientedDip;
 			this.reversed = reversed;
 			this.wholeRupReversed = wholeRupReversed;
 			this.indexes = indexes;
 		}
 
 		@Override
-		public double getAveDip() {
-			return avgDip;
+		public double getAveOrientedDip() {
+			return avgOrientedDip;
 		}
 
 		@Override
@@ -425,7 +426,7 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 
 		@Override
 		public Simple copyShallow() {
-			return new Simple(surfaces, sections, surfaceAreas, totArea, avgDip, reversed, wholeRupReversed, indexes);
+			return new Simple(surfaces, sections, surfaceAreas, totArea, avgOrientedDip, reversed, wholeRupReversed, indexes);
 		}
 		
 		private class ContiguousIntList extends AbstractList<Integer> {
@@ -457,7 +458,7 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 		private final List<Integer> bottomIndexes;
 		private final List<Integer> leftIndexes;
 		private final List<Integer> rightIndexes;
-		private final double avgDip;
+		private final double avgOrientedDip;
 		
 		public DownDip(List<? extends RuptureSurface> surfaces, List<? extends FaultSection> sections) {
 			super(surfaces, sections);
@@ -685,6 +686,7 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 				leftIndexes = rightIndexes;
 				rightIndexes = tmp;
 				reversed.flip(0, numSurfaces);
+				avgDip = 180d-avgDip;
 			}
 			
 			tops = new BitSet(numSurfaces);
@@ -704,15 +706,15 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 				this.leftIndexes = new IntListWrapper(leftIndexes);
 				this.rightIndexes = new IntListWrapper(rightIndexes);
 			}
-			this.avgDip = avgDip;
+			this.avgOrientedDip = avgDip;
 		}
 
 		private DownDip(List<? extends RuptureSurface> surfaces, List<? extends FaultSection> sections,
 				double[] surfaceAreas, double totArea,
-				double avgDip, BitSet reversed, BitSet tops, List<Integer> topIndexes, List<Integer> bottomIndexes,
+				double avgOrientedDip, BitSet reversed, BitSet tops, List<Integer> topIndexes, List<Integer> bottomIndexes,
 				List<Integer> leftIndexes, List<Integer> rightIndexes) {
 			super(surfaces, sections, surfaceAreas, totArea);
-			this.avgDip = avgDip;
+			this.avgOrientedDip = avgOrientedDip;
 			this.reversed = reversed;
 			this.tops = tops;
 			this.topIndexes = topIndexes;
@@ -722,8 +724,8 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 		}
 
 		@Override
-		public double getAveDip() {
-			return avgDip;
+		public double getAveOrientedDip() {
+			return avgOrientedDip;
 		}
 
 		@Override
@@ -763,10 +765,36 @@ public abstract class CompoundSurface implements CacheEnabledSurface {
 
 		@Override
 		public DownDip copyShallow() {
-			return new DownDip(surfaces, sections, surfaceAreas, totArea, avgDip, reversed, tops,
+			return new DownDip(surfaces, sections, surfaceAreas, totArea, avgOrientedDip, reversed, tops,
 					topIndexes, bottomIndexes, leftIndexes, rightIndexes);
 		}
 		
+	}
+
+	/**
+	 * Unlike {@link #getAveDip()} which returns a simple area-weighted average dip, this returns the overall average
+	 * sense of dip along the direction of the rupture following the AKi & Richards convention, and surfaces that dip
+	 * opposite each other will cancel out.
+	 * @return
+	 */
+	public abstract double getAveOrientedDip();
+
+	/**
+	 * This returns an area-weighted dip across all surfaces that compose this compound surface. This is better if you
+	 * care about a typical dip across the surface. Use {@link CompoundSurface#getAveOrientedDip()} instead if you
+	 * care about an overall directional sense of dip following the Aki & Richards convention.
+	 * @return area-weighted dip
+	 */
+	@Override
+	public double getAveDip() {
+		if (Double.isNaN(avgDip)) {
+			double avgDip = 0d;
+			for (int s=0; s<surfaceAreas.length; s++)
+				avgDip += surfaces.get(s).getAveDip()*surfaceAreas[s];
+			avgDip /= totArea;
+			this.avgDip = avgDip;
+		}
+		return avgDip;
 	}
 	
 	private static double distForReversalCheck(Location loc1, Location loc2) {

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/ZhaoEtAl_2006_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/ZhaoEtAl_2006_AttenRel.java
@@ -708,7 +708,8 @@ public class ZhaoEtAl_2006_AttenRel extends AttenuationRelationship implements
 			// ---------------------------------------------------------------------- MARCO 2010.03.15
 		}
 		if (hypo == null)
-			hypodepth = surf.getAveRupTopDepth() + 0.5*surf.getAveWidth()*Math.sin(Math.toRadians(surf.getAveDip()));
+//			hypodepth = surf.getAveRupTopDepth() + 0.5*surf.getAveWidth()*Math.sin(Math.toRadians(surf.getAveDip()));
+			hypodepth = 0.5 * (surf.getAveRupTopDepth() + surf.getAveRupBottomDepth());
 		else
 			hypodepth = hypo.getDepth();
 		

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_WrapperFullParam.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_WrapperFullParam.java
@@ -181,8 +181,7 @@ public class NGAW2_WrapperFullParam extends AttenuationRelationship implements P
 			if (eqkRupture.getHypocenterLocation() != null) {
 				zHyp = eqkRupture.getHypocenterLocation().getDepth();
 			} else {
-				zHyp = surf.getAveRupTopDepth() +
-						Math.sin(surf.getAveDip() * TO_RAD) * width/2.0;
+				zHyp = 0.5 * (surf.getAveRupTopDepth() + surf.getAveRupBottomDepth());
 			}
 			focalDepthParam.setValueIgnoreWarning(zHyp);
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/nshmp/NSHMP_GMM_Wrapper.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/nshmp/NSHMP_GMM_Wrapper.java
@@ -1138,8 +1138,7 @@ public abstract class NSHMP_GMM_Wrapper extends AttenuationRelationship implemen
 				if (eqkRupture.getHypocenterLocation() != null) {
 					zHyp = eqkRupture.getHypocenterLocation().getDepth();
 				} else {
-					zHyp = surf.getAveRupTopDepth() +
-						Math.sin(surf.getAveDip() * TO_RAD) * surf.getAveWidth()/2.0;
+					zHyp = 0.5*(surf.getAveRupTopDepth() + surf.getAveRupBottomDepth());
 				}
 				valueManager.setParameterValue(Field.ZHYP, zHyp);
 			}

--- a/src/test/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_WrapperTest.java
+++ b/src/test/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_WrapperTest.java
@@ -181,8 +181,7 @@ public class NGAW2_WrapperTest {
 				if (gmpe_rup.getHypocenterLocation() != null) {
 					gmpe.set_zHyp(gmpe_rup.getHypocenterLocation().getDepth());
 				} else {
-					gmpe.set_zHyp(surf.getAveRupTopDepth() +
-							Math.sin(surf.getAveDip() * TO_RAD) * surf.getAveWidth() / 2.0);
+					gmpe.set_zHyp(0.5 * (surf.getAveRupTopDepth() + surf.getAveRupBottomDepth()));
 				}
 
 				gmpe.set_vs30(vs30);


### PR DESCRIPTION
## CompoundSurface dip (for multifault ruptures)

Traditionally, OpenSHA's `CompoundSurface` class has computed an orientation-aware average dip that represents the area-averaged overall sense of dip following the Aki & Richards convention.

For example, consider a 2-fault rupture where the two faults dip in opposite directions. If the areas and dips are equal, then the oriented dip cancels out to vertical and the Aki & Richards direction is undefined:

<img width="800" height="253" alt="compound_dip_example" src="https://github.com/user-attachments/assets/a522d1ef-de32-4a6f-a7f6-5ad895626193" />

If one has a larger dip, then the oriented dip is <90 and the  Aki & Richards convention assures that the average overall dip direction is to the right:

<img width="800" height="278" alt="compound_dip_example" src="https://github.com/user-attachments/assets/47687906-61b0-44be-86f1-db7d2e325217" />

The question becomes: which dip should we  use when parameterizing a GMM? We have previously used the oriented dip (including with the original `CompoundSurface` before PR #215), but this PR changes that to use the pure area-weighted dip. The latter is a better representation of the typical dip of the rupture than the oriented dip. It is also what `NSHMP-Haz` and `OpenQuake` do, and can meaningful affect hazard near complex multifault ruptures with mixed dips because some GMMs explicitly use scalar dip values in their hanging-wall terms.

The oriented dip is still available via:

`CompoundSurface.getAveOrientedDip()`

...but `CompoundSurface.getAveDip()` now returns the average dip.

## Hypocentral depth (zHyp) update

This PR also updates the hypocentral depth calculation used to parameterize GMMs when a rupture's hypocenter is unknown. We now use an average middle depth rather than projecting down-dip from the upper depth. This is facilitated by the new `RuptureSurface.getAveRupBottomDepth()` method added in #215:

Previous `zHyp` calculation (this is what `NSHMP-Haz` still does):

`zHyp = zTor + 0.5 * DDW * sin(dip)`

Updated `zHyp` calculation:

`zHyp = 0.5 * (zTor + zBot)`

Those quantities are equivalent for single-fault ruptures, but the latter is more accurate for multifault ruptures with varying dips because it gives a true average depth.

Here's an example with 2 sections, let's assume they're equal-area for simplicity, both with the same 10 km vertical extent:

 - Section A: `dip=30`, `width=20`, `zTor=0`, `zBot=10`, `DDW=15`
 - Section B: `dip=90`, `width=10`, `zTor=0`, `zBot=10`, `DDW=10`
 - `avgDip = 0.5 * (30 + 60) = 60`
 - `avgDDW = 0.5 * (20 + 10) = 15`

The simpler depth midpoint method gives `zHyp=5`, which is the true middle depth (and the middle of each surface individually).

The old formula gives: `zHyp = zTor + 0.5 * avgDDW * sin(avgDip) = 0 + 0.5 * 15 * sin(60) = 6.5`, which is 1.5 km too deep.

I looked at `OpenQuake` and found that they use a different approach; they find the section nearest to the centroid of the rupture and return the middle depth of that section. They do that because they return a location, treated as the hypocenter, which is guaranteed to be on the rupture surface. Since we're just setting the `zHyp` parameter, I think the midpoint approach is most defensible.

CC: @pmpowers-usgs