### PR TITLE
Removed remaining old Thread.stop() references

### DIFF
--- a/src/main/java/org/opensha/sra/gui/BCR_Application.java
+++ b/src/main/java/org/opensha/sra/gui/BCR_Application.java
@@ -380,7 +380,7 @@ IMR_GuiBeanAPI{
 		buttonPanel.add(riskAgoraImgLabel,7);
 
 
-		//making the cancel button not visible until user has started to do the calculation
+		// Cancellation is not supported for this legacy GUI.
 		cancelCalcButton.setVisible(false);
 
 		topSplitPane.add(chartSplit, JSplitPane.TOP);
@@ -443,7 +443,6 @@ IMR_GuiBeanAPI{
 	 * @param e
 	 */
 	void addButton_actionPerformed(ActionEvent e) {
-		cancelCalcButton.setVisible(true);
 		addButton();
 	}
 
@@ -1045,18 +1044,11 @@ IMR_GuiBeanAPI{
 
 
 	/**
-	 * This function stops the hazard curve calculation if started, so that user does not
-	 * have to wait for the calculation to finish.
-	 * Note: This function has one advantage , it starts over the calculation again, but
-	 * if user has not changed any other parameter for the forecast, that won't
-	 * be updated, so saves time and memory for not updating the forecast everytime,
-	 * cancel is pressed.
+	 * Cancellation is not supported for this legacy GUI, but leave this handler to
+	 * clean up the old cancel UI if it is invoked.
 	 * @param e
 	 */
 	void cancelCalcButton_actionPerformed(ActionEvent e) {
-		//stopping the Hazard Curve calculation thread
-		calcThread.stop();
-		calcThread = null;
 		//close the progress bar for the ERF GuiBean that displays "Updating Forecast".
 		erfGuiBean.closeProgressBar();
 		//stoping the timer thread that updates the progress bar

--- a/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
+++ b/src/main/java/org/opensha/sra/gui/LossEstimationApplication.java
@@ -519,7 +519,7 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 		buttonPanel.add(usgsImgLabel, 6);
 		buttonPanel.add(openshaImgLabel, 7);
 		buttonPanel.add(riskAgoraImgLabel,8);
-		//making the cancel button not visible until user has started to do the calculation
+		// Cancellation is not supported for this legacy GUI.
 		cancelCalcButton.setVisible(false);
 
 		topSplitPane.add(chartSplit, JSplitPane.TOP);
@@ -1372,18 +1372,11 @@ implements Runnable, ParameterChangeListener, CurveDisplayAppAPI, IMR_GuiBeanAPI
 
 
 	/**
-	 * This function stops the hazard curve calculation if started, so that user does not
-	 * have to wait for the calculation to finish.
-	 * Note: This function has one advantage , it starts over the calculation again, but
-	 * if user has not changed any other parameter for the forecast, that won't
-	 * be updated, so saves time and memory for not updating the forecast everytime,
-	 * cancel is pressed.
+	 * Cancellation is not supported for this legacy GUI, but leave this handler to
+	 * clean up the old cancel UI if it is invoked.
 	 * @param e
 	 */
 	void cancelCalcButton_actionPerformed(ActionEvent e) {
-		//stopping the Hazard Curve calculation thread
-		calcThread.stop();
-		calcThread = null;
 		//close the progress bar for the ERF GuiBean that displays "Updating Forecast".
 		erfGuiBean.closeProgressBar();
 		//stoping the timer thread that updates the progress bar

--- a/src/main/java/org/opensha/sra/gui/portfolioeal/PortfolioEALCalculatorController.java
+++ b/src/main/java/org/opensha/sra/gui/portfolioeal/PortfolioEALCalculatorController.java
@@ -213,12 +213,11 @@ public class PortfolioEALCalculatorController implements ActionListener, ItemLis
 	}
 	
 	/**
-	 * This is called when the "Cancel" button is pressed.  It resets the buttons to
-	 * their original state, and stops the current calculation.
+	 * This is called if the hidden "Cancel" button is pressed. It resets the buttons
+	 * to their original state; cancellation is not supported for this legacy GUI.
 	 */
 	private void cancelButtonPressed() {
 		view.setButtonsOnCancel();
-		calcThread.stop();
 	}
 	
 	/**
@@ -250,7 +249,7 @@ public class PortfolioEALCalculatorController implements ActionListener, ItemLis
 	 *	<b>"Compute"</b> starts up a new thread that calls computeEAL(), which computes the EAL for a portfolio.><br>
 	 *	<b>"Clear Results"</b> goes to clearResults(), which clears the I/O text area.<br>
 	 *  <b>"Open Portfolio"</b> opens up a new dialog that allows you to open a portfolio file.<br>
-	 *  <b>"Cancel"</b> stops the thread running the calculations and resets the buttons.
+	 *  <b>"Cancel"</b> resets the buttons; cancellation is not supported.
 	 *  <b>JComboBox: "comboBoxSelection"</b> Calls a method in view based on the selection
 	 *  
 	 *  
@@ -328,6 +327,5 @@ public class PortfolioEALCalculatorController implements ActionListener, ItemLis
 	public void calculationException( String errorMessage ) {
 		JOptionPane.showMessageDialog(view, errorMessage, "Error", JOptionPane.ERROR_MESSAGE );
 		view.setButtonsOnCancel();
-		calcThread.stop();
 	}
 }

--- a/src/main/java/org/opensha/sra/gui/portfolioeal/gui/PortfolioEALCalculatorView.java
+++ b/src/main/java/org/opensha/sra/gui/portfolioeal/gui/PortfolioEALCalculatorView.java
@@ -205,8 +205,7 @@ public class PortfolioEALCalculatorView extends JFrame {
 		JComboBox controlPanels = new JComboBox(array);
 		// The compute EAL button
 		computeButton = new JButton("Compute");
-		// The cancel button to stop computations
-		// It starts not visible, but becomes visible when the "Compute" button is hit
+		// Cancellation is not supported for this legacy GUI.
 		cancelButton = new JButton("Cancel");
 		cancelButton.setVisible(false);
 		// The clear I/O screen button
@@ -326,12 +325,12 @@ public class PortfolioEALCalculatorView extends JFrame {
 	
 	/**
 	 * Set the buttons up when the "Compute" button is hit.<br>
-	 * "Cancel": set visible<br>
+	 * "Cancel": keep hidden<br>
 	 * "Compute": set disabled<br>
 	 * "Clear": set disabled<br>
 	 */
 	public void setButtonsOnCompute() {
-		cancelButton.setVisible(true);
+		cancelButton.setVisible(false);
 		computeButton.setEnabled(false);
 		clearButton.setEnabled(false);
 	}


### PR DESCRIPTION
Related to #109 and #141. Removes remaining `Thread.stop()` deprecation warnings in old/released apps. Those apps still work (at least as well as they did before, which is unknown), they just don't display the cancel button anymore.

Builds no longer display the warning in Java 21+ (see #238).