### PR TITLE
ERF GUI name updates and sorting

### DIFF
--- a/src/main/java/org/opensha/commons/param/editor/impl/EnumParameterEditor.java
+++ b/src/main/java/org/opensha/commons/param/editor/impl/EnumParameterEditor.java
@@ -4,7 +4,10 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Vector;
 
 import javax.swing.BorderFactory;
@@ -38,6 +41,7 @@ public class EnumParameterEditor<E extends Enum<E>> extends
 
 	private JComboBox widget;
 	private Class<E> clazz;
+	private Comparator<E> comparator;
 
 	/**
 	 * Constructs a new editor for the supplied <code>Parameter</code>.
@@ -45,8 +49,27 @@ public class EnumParameterEditor<E extends Enum<E>> extends
 	 * @param clazz the class of the supplied <code>Parameter</code>
 	 */
 	public EnumParameterEditor(EnumParameter<E> model, Class<E> clazz) {
+		this(model, clazz, null);
+	}
+
+	/**
+	 * Constructs a new editor for the supplied <code>Parameter</code>.
+	 * @param model for editor
+	 * @param clazz the class of the supplied <code>Parameter</code>
+	 * @param comparator comparator to sort the enum list
+	 */
+	public EnumParameterEditor(EnumParameter<E> model, Class<E> clazz, Comparator<E> comparator) {
 		super(model);
 		this.clazz = clazz;
+		if (comparator != null) {
+			// this will also update the widget, which will have been already built via the super constructor
+			setComparator(comparator);
+		}
+	}
+	
+	public void setComparator(Comparator<E> comparator) {
+		this.comparator = comparator;
+		updateWidget();
 	}
 
 	@Override
@@ -105,7 +128,12 @@ public class EnumParameterEditor<E extends Enum<E>> extends
 		Vector<Object> v = new Vector<Object>();
 		String nullOption = ((EnumParameter<E>) getParameter()).getNullOption();
 		if (nullOption != null) v.add(nullOption);
-		v.addAll(con.getAllowedValues());
+		List<E> vals = con.getAllowedValues();
+		if (comparator != null) {
+			vals = new ArrayList<>(vals);
+			vals.sort(comparator);
+		}
+		v.addAll(vals);
 		return v;
 	}
 

--- a/src/main/java/org/opensha/commons/param/impl/EnumParameter.java
+++ b/src/main/java/org/opensha/commons/param/impl/EnumParameter.java
@@ -1,5 +1,6 @@
 package org.opensha.commons.param.impl;
 
+import java.util.Comparator;
 import java.util.EnumSet;
 
 import org.dom4j.Element;
@@ -32,6 +33,8 @@ public class EnumParameter<E extends Enum<E>> extends AbstractParameter<E> {
 	private String nullOption;
 	private Class<E> clazz;
 	private EnumSet<E> choices;
+	
+	private Comparator<E> comparator;
 
 	// private; for internal cloning use only
 	private EnumParameter() {};
@@ -70,7 +73,7 @@ public class EnumParameter<E extends Enum<E>> extends AbstractParameter<E> {
 	@Override
 	public ParameterEditor<E> getEditor() {
 		if (editor == null) {
-			editor = new EnumParameterEditor<E>(this, clazz);
+			editor = new EnumParameterEditor<E>(this, clazz, comparator);
 		}
 		return editor;
 	}
@@ -119,6 +122,13 @@ public class EnumParameter<E extends Enum<E>> extends AbstractParameter<E> {
 	@Override
 	public EnumConstraint<E> getConstraint() {
 		return (EnumConstraint<E>) super.getConstraint();
+	}
+	
+	public void setComparator(Comparator<E> comparator) {
+		this.comparator = comparator;
+		if (editor != null) {
+			editor.setComparator(comparator);
+		}
 	}
 
 }

--- a/src/main/java/org/opensha/sha/calc/IM_EventSet/README.txt
+++ b/src/main/java/org/opensha/sha/calc/IM_EventSet/README.txt
@@ -84,33 +84,28 @@ Each line of the input file that starts with "#" is a comment that gets ignored 
 The first choice is which of the following Earthquake Rupture Forecasts to use:
 
     WGCEP (2007) UCERF2 - Single Branch
-    WGCEP Eqk Rate Model 2 ERF
-    USGS NSHM23 Branch Averaged ERF
+    WGCEP (2007) UCERF2 - Adjustable ERF
+    USGS NSHM23 - Branch Averaged ERF
     USGS/CGS 2002 Adj. Cal. ERF
-    UCERF3 Single Branch ERF
     USGS/CGS 1996 Cal. ERF
-    WGCEP (2007) UCERF2 - Single Branch, Modified, Fault Model 2.1 only
-    WGCEP UCERF 1.0 (2005)
-    Fault System Solution ERF
+    WGCEP (2007) UCERF2 - Single Branch (Mod: FM 2.1 only)
+    WGCEP (2005) UCERF1
     USGS/CGS 1996 Adj. Cal. ERF
-    Mean UCERF3
+    WGCEP (2014) UCERF3 - Mean/Branch Averaged
 
 You could alternatively specify their corresponding short names as follows:
     MeanUCERF2
     UCERF2
     NSHM23_BranchAveragedERF
     Frankel02_AdjustableEqkRupForecast
-    UCERF3_CompoundSol_ERF
     Frankel96_EqkRupForecast
     ModMeanUCERF2_FM2pt1
     WGCEP_UCERF1_EqkRupForecast
-    FaultSystemSolutionERF
     Frankel96_AdjustableEqkRupForecast
     MeanUCERF3
 
-
 For example, you could pass either
-Mean UCERF3
+WGCEP (2014) UCERF3 - Mean/Branch Averaged
 or
 MeanUCERF3
 as the first choice. Either long or short name formats will result in the same choice.

--- a/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
@@ -7,6 +7,7 @@ import static org.opensha.commons.util.DevStatus.PRODUCTION;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
@@ -139,23 +140,22 @@ public enum ERF_Ref {
 	/** WGCEP Single Branch UCERF 3 */
 	UCERF3_COMPOUND(UCERF3_CompoundSol_ERF.class, UCERF3_CompoundSol_ERF.NAME, PRODUCTION, false),
 
+	/** WGCEP UCERF3List */
+	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, PRODUCTION, false),
+
 	/** Yucca Mountain ERF */
 	YUCCA_MOUNTAIN(YuccaMountainERF.class, YuccaMountainERF.NAME, PRODUCTION, false),
 
 	/** Yucca Mountain ERF List */
 	YUCCA_MOUNTAIN_LIST(YuccaMountainERF_List.class, YuccaMountainERF_List.NAME, PRODUCTION, false),
 
-	/** WGCEP UCERF3List */
-	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, PRODUCTION, false),
-
 	/** National Seismic Hazard Model 2023 Western US ERF */
 	NSHM23_WUS_BRANCH_AVG(NSHM23_BranchAveragedERF.class, NSHM23_BranchAveragedERF.NAME, PRODUCTION, false),
+	
+	/** National Seismic Hazard Model 2025 Puerto Rico and Virgin Islands ERF */
+	NHSM25_PRVI_BRANCH_AVG(NSHM25_PRVI_BranchAveragedERF.class, NSHM25_PRVI_BranchAveragedERF.NAME, PRODUCTION, false),
 
 	// DEVELOPMENT
-
-	/** National Seismic Hazard Model 2025 Puerto Rico and Virgin Islands ERF */
-	NHSM25_PRVI_BRANCH_AVG(NSHM25_PRVI_BranchAveragedERF.class, NSHM25_PRVI_BranchAveragedERF.NAME, DEVELOPMENT, false),
-
 
 	/** STEP Alaska Forecast */
 	STEP_ALASKA(STEP_AlaskanPipeForecast.class, STEP_AlaskanPipeForecast.NAME, DEVELOPMENT, false),
@@ -168,7 +168,12 @@ public enum ERF_Ref {
 	//	TEST_ETAS1_ERF(TestModel1_ERF.class, TestModel1_ERF.NAME, EXPERIMENTAL, false),
 
 	;
-
+	
+	/**
+	 * The ERF that should be selected by default in the applications. This one loads/calculates instantly so it's a
+	 * good default.
+	 */
+	public static ERF_Ref APP_DEFAULT_ERF = FRANKEL_ADJUSTABLE_96;
 
 	private Class<? extends BaseERF> clazz;
 	private String name;
@@ -352,18 +357,38 @@ public enum ERF_Ref {
 			DevStatus... stati) {
 		return get(includeListERFs, true, stati);
 	}
-
-	/**
-	 * This returns a sorted view of the given ERF Refs, sorted first by DevStatus and then by name
-	 */
-	public static List<ERF_Ref> getSorted(Set<ERF_Ref> erfs) {
-		List<ERF_Ref> refs = new ArrayList<>(erfs);
-		Collections.sort(refs, (R1,R2) -> {
-			if (R1.status != R2.status)
-				return Integer.compare(R1.status.priority(), R2.status.priority());
-			return R1.name.compareTo(R2.name);
-		});
-		return refs;
+	
+	public static Comparator<ERF_Ref> PRIORITY_NAME_COMPARATOR = (R1,R2) -> {
+		if (R1.status != R2.status)
+			return Integer.compare(R1.status.priority(), R2.status.priority());
+		return R1.name.compareTo(R2.name);
+	};
+	
+	public static void main(String[] args) {
+		// in list order
+		System.out.println("In class list order:");
+		DevStatus prevStatus = null;
+		List<ERF_Ref> list = new ArrayList<>();
+		for (ERF_Ref ref : values()) {
+			if (ref.status != prevStatus) {
+				System.out.println(ref.status);
+				prevStatus = ref.status;
+			}
+			System.out.println("\t"+ref.name+"\t\t\t\t("+(ref.name())+")");
+			list.add(ref);
+		}
+		System.out.println();
+		
+		list.sort(PRIORITY_NAME_COMPARATOR);
+		System.out.println("In sorted order:");
+		prevStatus = null;
+		for (ERF_Ref ref : list) {
+			if (ref.status != prevStatus) {
+				System.out.println(ref.status);
+				prevStatus = ref.status;
+			}
+			System.out.println("\t"+ref.name+"\t\t\t\t("+(ref.name())+")");
+		}
 	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
@@ -56,6 +56,10 @@ public enum ERF_Ref {
 	 */
 
 	// PRODUCTION
+	
+	/*
+	 * Old USGS models
+	 */
 
 	/** Frankel/USGS 1996 Adjustable ERF */
 	FRANKEL_ADJUSTABLE_96(Frankel96_AdjustableEqkRupForecast.class,
@@ -78,13 +82,14 @@ public enum ERF_Ref {
 
 	/** WGCEP 2002 ERF Epistemic List */
 	WGCEP_02_LIST(WG02_ERF_Epistemic_List.class, WG02_ERF_Epistemic_List.NAME, PRODUCTION, false),
+	
+	/*
+	 * Generic interactive/build-on-the-fly models
+	 */
 
 	/** WGCEP 2002 Fortran Wrapped ERF */
 	//WGCEP_02_WRAPPED_LIST(WG02_FortranWrappedERF_EpistemicList.class,
 	//		WG02_FortranWrappedERF_EpistemicList.NAME, PRODUCTION, true),
-
-	/** WGCEP UCERF 1 */
-	WGCEP_UCERF_1(WGCEP_UCERF1_EqkRupForecast.class, WGCEP_UCERF1_EqkRupForecast.NAME, PRODUCTION, false),
 
 	/** PEER Area Forecast */
 	PEER_AREA(PEER_AreaForecast.class, PEER_AreaForecast.NAME, PRODUCTION, true),
@@ -116,6 +121,25 @@ public enum ERF_Ref {
 	/**  Point Source Multi Vert ERF */
 	POINT_SOURCE_MULTI_VERT_LIST(Point2MultVertSS_FaultERF_List.class,
 			Point2MultVertSS_FaultERF_List.NAME, PRODUCTION, false),
+	
+	/*
+	 * Generic FSS base ERFs
+	 */
+	
+	/** Fault System Solution ERF */
+	INVERSION_SOLUTION_ERF(FaultSystemSolutionERF.class, FaultSystemSolutionERF.NAME,
+			PRODUCTION, true),
+	
+	/*
+	 * UCERF1
+	 */
+
+	/** WGCEP UCERF 1 */
+	WGCEP_UCERF_1(WGCEP_UCERF1_EqkRupForecast.class, WGCEP_UCERF1_EqkRupForecast.NAME, PRODUCTION, false),
+	
+	/*
+	 * UCERF2
+	 */
 
 	/** WGCEP UCERF 2 ERF */
 	UCERF_2(UCERF2.class, UCERF2.NAME, PRODUCTION, false),
@@ -129,10 +153,10 @@ public enum ERF_Ref {
 
 	/** WGCEP Mean2 */
 	MEAN_UCERF_2_Mod(ModMeanUCERF2_FM2pt1.class, ModMeanUCERF2_FM2pt1.NAME, PRODUCTION, false),
-
-	/** Fault System Solution ERF */
-	INVERSION_SOLUTION_ERF(FaultSystemSolutionERF.class, FaultSystemSolutionERF.NAME,
-			PRODUCTION, true),
+	
+	/*
+	 * UCERF3
+	 */
 
 	/** WGCEP Mean UCERF 3 */
 	MEAN_UCERF3(MeanUCERF3.class, MeanUCERF3.NAME, PRODUCTION, false),
@@ -142,18 +166,26 @@ public enum ERF_Ref {
 
 	/** WGCEP UCERF3List */
 	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, PRODUCTION, false),
-
-	/** Yucca Mountain ERF */
-	YUCCA_MOUNTAIN(YuccaMountainERF.class, YuccaMountainERF.NAME, PRODUCTION, false),
-
-	/** Yucca Mountain ERF List */
-	YUCCA_MOUNTAIN_LIST(YuccaMountainERF_List.class, YuccaMountainERF_List.NAME, PRODUCTION, false),
+	
+	/*
+	 * Other recent NSHMs
+	 */
 
 	/** National Seismic Hazard Model 2023 Western US ERF */
 	NSHM23_WUS_BRANCH_AVG(NSHM23_BranchAveragedERF.class, NSHM23_BranchAveragedERF.NAME, PRODUCTION, false),
 	
 	/** National Seismic Hazard Model 2025 Puerto Rico and Virgin Islands ERF */
 	NHSM25_PRVI_BRANCH_AVG(NSHM25_PRVI_BranchAveragedERF.class, NSHM25_PRVI_BranchAveragedERF.NAME, PRODUCTION, false),
+	
+	/*
+	 * Other
+	 */
+
+	/** Yucca Mountain ERF */
+	YUCCA_MOUNTAIN(YuccaMountainERF.class, YuccaMountainERF.NAME, PRODUCTION, false),
+
+	/** Yucca Mountain ERF List */
+	YUCCA_MOUNTAIN_LIST(YuccaMountainERF_List.class, YuccaMountainERF_List.NAME, PRODUCTION, false),
 
 	// DEVELOPMENT
 

--- a/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
@@ -5,7 +5,10 @@ import static org.opensha.commons.util.DevStatus.EXPERIMENTAL;
 import static org.opensha.commons.util.DevStatus.PRODUCTION;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -43,24 +46,24 @@ import scratch.UCERF3.erf.mean.MeanUCERF3;
 import scratch.UCERF3.utils.ModUCERF2.ModMeanUCERF2_FM2pt1;
 
 public enum ERF_Ref {
-	
-	
+
+
 	/* 
 	 * ********************
 	 * LOCAL ERFS
 	 * ********************
 	 */
-	
+
 	// PRODUCTION
-	
+
 	/** Frankel/USGS 1996 Adjustable ERF */
 	FRANKEL_ADJUSTABLE_96(Frankel96_AdjustableEqkRupForecast.class,
 			Frankel96_AdjustableEqkRupForecast.NAME, PRODUCTION, false),
-	
+
 	// should we include this?
-			//			erf_Classes.add(POINT_SRC_TO_LINE_ERF_CLASS_NAME);
-			//			erf_Classes.add(POINT_SRC_TO_LINE_ERF_LIST_TEST_CLASS_NAME);
-	
+	//			erf_Classes.add(POINT_SRC_TO_LINE_ERF_CLASS_NAME);
+	//			erf_Classes.add(POINT_SRC_TO_LINE_ERF_LIST_TEST_CLASS_NAME);
+
 	/** Frankel/USGS 1996 ERF */
 	FRANKEL_96(Frankel96_EqkRupForecast.class,
 			Frankel96_EqkRupForecast.NAME, PRODUCTION, false),
@@ -68,17 +71,17 @@ public enum ERF_Ref {
 	/** Frankel/USGS 2002 Adjustable ERF */
 	FRANKEL_02(Frankel02_AdjustableEqkRupForecast.class,
 			Frankel02_AdjustableEqkRupForecast.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP 2002 ERF */
 	WGCEP_02(WG02_EqkRupForecast.class, WG02_EqkRupForecast.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP 2002 ERF Epistemic List */
 	WGCEP_02_LIST(WG02_ERF_Epistemic_List.class, WG02_ERF_Epistemic_List.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP 2002 Fortran Wrapped ERF */
 	//WGCEP_02_WRAPPED_LIST(WG02_FortranWrappedERF_EpistemicList.class,
 	//		WG02_FortranWrappedERF_EpistemicList.NAME, PRODUCTION, true),
-	
+
 	/** WGCEP UCERF 1 */
 	WGCEP_UCERF_1(WGCEP_UCERF1_EqkRupForecast.class, WGCEP_UCERF1_EqkRupForecast.NAME, PRODUCTION, false),
 
@@ -95,17 +98,17 @@ public enum ERF_Ref {
 	PEER_LOGIC_TREE(PEER_LogicTreeERF_List.class, PEER_LogicTreeERF_List.NAME, PRODUCTION, false),
 
 	// include this?
-		//erf_Classes.add(STEP_FORECAST_CLASS_NAME);
-	
+	//erf_Classes.add(STEP_FORECAST_CLASS_NAME);
+
 	/** Floating Poisson Fault ERF */
 	POISSON_FLOATING_FAULT(FloatingPoissonFaultERF.class, FloatingPoissonFaultERF.NAME, PRODUCTION, true),
-	
+
 	/** Poisson Fault ERF */
 	POISSON_FAULT(PoissonFaultERF.class, PoissonFaultERF.NAME, PRODUCTION, true),
-	
+
 	/**  Point Source ERF */
 	POINT_SOURCE(PointSourceERF.class, PointSourceERF.NAME, PRODUCTION, true),
-	
+
 	/**  Point Source Multi Vert ERF */
 	POINT_SOURCE_MULTI_VERT(Point2MultVertSS_FaultERF.class, Point2MultVertSS_FaultERF.NAME, PRODUCTION, true),
 
@@ -115,70 +118,70 @@ public enum ERF_Ref {
 
 	/** WGCEP UCERF 2 ERF */
 	UCERF_2(UCERF2.class, UCERF2.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP UCERF 2 Time Independent Epistemic List */
 	UCERF_2_TIME_INDEP_LIST(UCERF2_TimeIndependentEpistemicList.class,
 			UCERF2_TimeIndependentEpistemicList.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP Mean UCERF 2 */
 	MEAN_UCERF_2(MeanUCERF2.class, MeanUCERF2.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP Mean2 */
 	MEAN_UCERF_2_Mod(ModMeanUCERF2_FM2pt1.class, ModMeanUCERF2_FM2pt1.NAME, PRODUCTION, false),
-	
+
 	/** Fault System Solution ERF */
 	INVERSION_SOLUTION_ERF(FaultSystemSolutionERF.class, FaultSystemSolutionERF.NAME,
 			PRODUCTION, true),
-	
+
 	/** WGCEP Mean UCERF 3 */
 	MEAN_UCERF3(MeanUCERF3.class, MeanUCERF3.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP Single Branch UCERF 3 */
 	UCERF3_COMPOUND(UCERF3_CompoundSol_ERF.class, UCERF3_CompoundSol_ERF.NAME, PRODUCTION, false),
 
 	/** Yucca Mountain ERF */
 	YUCCA_MOUNTAIN(YuccaMountainERF.class, YuccaMountainERF.NAME, PRODUCTION, false),
-	
+
 	/** Yucca Mountain ERF List */
 	YUCCA_MOUNTAIN_LIST(YuccaMountainERF_List.class, YuccaMountainERF_List.NAME, PRODUCTION, false),
-	
+
 	/** WGCEP UCERF3List */
 	UCERF3_EPISTEMIC(UCERF3EpistemicListERF.class, UCERF3EpistemicListERF.NAME, PRODUCTION, false),
-	
+
 	/** National Seismic Hazard Model 2023 Western US ERF */
 	NSHM23_WUS_BRANCH_AVG(NSHM23_BranchAveragedERF.class, NSHM23_BranchAveragedERF.NAME, PRODUCTION, false),
 
 	// DEVELOPMENT
 
-    /** National Seismic Hazard Model 2025 Puerto Rico and Virgin Islands ERF */
-    NHSM25_PRVI_BRANCH_AVG(NSHM25_PRVI_BranchAveragedERF.class, NSHM25_PRVI_BranchAveragedERF.NAME, DEVELOPMENT, false),
+	/** National Seismic Hazard Model 2025 Puerto Rico and Virgin Islands ERF */
+	NHSM25_PRVI_BRANCH_AVG(NSHM25_PRVI_BranchAveragedERF.class, NSHM25_PRVI_BranchAveragedERF.NAME, DEVELOPMENT, false),
 
 
-    /** STEP Alaska Forecast */
+	/** STEP Alaska Forecast */
 	STEP_ALASKA(STEP_AlaskanPipeForecast.class, STEP_AlaskanPipeForecast.NAME, DEVELOPMENT, false),
-		
+
 	// EXPERIMENTAL
-	
+
 	/** NSHMP CEUS 2008 ERF */
-//	NSHMP_CEUS_08(NSHMP08_CEUS_ERF.class, NSHMP08_CEUS_ERF.NAME, EXPERIMENTAL, false),
-		
-//	TEST_ETAS1_ERF(TestModel1_ERF.class, TestModel1_ERF.NAME, EXPERIMENTAL, false),
-	
+	//	NSHMP_CEUS_08(NSHMP08_CEUS_ERF.class, NSHMP08_CEUS_ERF.NAME, EXPERIMENTAL, false),
+
+	//	TEST_ETAS1_ERF(TestModel1_ERF.class, TestModel1_ERF.NAME, EXPERIMENTAL, false),
+
 	;
 
-	
+
 	private Class<? extends BaseERF> clazz;
 	private String name;
 	private DevStatus status;
-    private boolean interactiveParams;
+	private boolean interactiveParams;
 	private boolean erfList;
 
 	ERF_Ref(Class<? extends BaseERF> clazz,
-            String name, DevStatus status, boolean interactiveParams) {
+			String name, DevStatus status, boolean interactiveParams) {
 		this.clazz = clazz;
 		this.name = name;
 		this.status = status;
-        this.interactiveParams = interactiveParams;
+		this.interactiveParams = interactiveParams;
 	}
 
 	@Override
@@ -194,20 +197,20 @@ public enum ERF_Ref {
 	public DevStatus status() {
 		return status;
 	}
-	
+
 	/**
 	 * @return true if this is an ERF Epistemic List, false otherwise
 	 */
 	public boolean isERFList() {
-        return EpistemicListERF.class.isAssignableFrom(clazz);
+		return EpistemicListERF.class.isAssignableFrom(clazz);
 	}
 
-    /**
-     * @return true if this ERF requires interactive parameterization to be useful
-     */
-    public boolean needsInteractiveParams() {
-        return interactiveParams;
-    }
+	/**
+	 * @return true if this ERF requires interactive parameterization to be useful
+	 */
+	public boolean needsInteractiveParams() {
+		return interactiveParams;
+	}
 
 	/**
 	 * Returns a new instance of the ERF represented by
@@ -217,14 +220,14 @@ public enum ERF_Ref {
 	public BaseERF instance() {
 		try {
 			Constructor<? extends BaseERF> con = clazz
-				.getConstructor();
+					.getConstructor();
 			return con.newInstance();
 		} catch (Exception e) {
 			// TODO init logging
 			throw ExceptionUtils.asRuntimeException(e);
 		}
 	}
-	
+
 	public Class<? extends BaseERF> getERFClass() {
 		return clazz;
 	}
@@ -236,30 +239,30 @@ public enum ERF_Ref {
 	 * or experimental. The <code>Set</code> of references returned does not
 	 * include deprecated references.
 	 * @param includeListERFs if true, Epistemic List ERFs will be included,
-     *                           otherwise they will be excluded
-     * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
-     *                          otherwise they will be excluded
+	 *                           otherwise they will be excluded
+	 * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
+	 *                          otherwise they will be excluded
 	 * @return reference <code>Set</code> of all non-deprecated
 	 *         <code>EqkRupForecastBaseAPI</code>s
 	 * @see DevStatus
 	 */
-    public static Set<ERF_Ref> get(boolean includeListERFs, boolean interactiveParams) {
-        return get(includeListERFs, interactiveParams, PRODUCTION, DEVELOPMENT, EXPERIMENTAL);
-    }
+	public static Set<ERF_Ref> get(boolean includeListERFs, boolean interactiveParams) {
+		return get(includeListERFs, interactiveParams, PRODUCTION, DEVELOPMENT, EXPERIMENTAL);
+	}
 
 
-    /**
-     * Convenience method to return references for all
-     * <code>EqkRupForecastBaseAPI</code> implementations that are currently
-     * production quality (i.e. fully tested and documented), under development,
-     * or experimental. The <code>Set</code> of references returned does not
-     * include deprecated references.
-     * ERFs requiring interactive parameters are included by default.
-     * @param includeListERFs if true, Epistemic List ERFs will be included,
-     *                        otherwise they will be excluded
-     * @return reference <code>Set</code> of all non-deprecated
-     *         <code>EqkRupForecastBaseAPI</code>s
-     */
+	/**
+	 * Convenience method to return references for all
+	 * <code>EqkRupForecastBaseAPI</code> implementations that are currently
+	 * production quality (i.e. fully tested and documented), under development,
+	 * or experimental. The <code>Set</code> of references returned does not
+	 * include deprecated references.
+	 * ERFs requiring interactive parameters are included by default.
+	 * @param includeListERFs if true, Epistemic List ERFs will be included,
+	 *                        otherwise they will be excluded
+	 * @return reference <code>Set</code> of all non-deprecated
+	 *         <code>EqkRupForecastBaseAPI</code>s
+	 */
 	public static Set<ERF_Ref> get(boolean includeListERFs) {
 		return get(includeListERFs, true);
 	}
@@ -272,35 +275,35 @@ public enum ERF_Ref {
 	 * production IMRs, and development applications include everything but
 	 * deprecated IMRs.
 	 * @param includeListERFs if true, Epistemic List ERFs will be included,
-     *                        otherwise they will be excluded
-     * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
-     *                          otherwise they will be excluded
+	 *                        otherwise they will be excluded
+	 * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
+	 *                          otherwise they will be excluded
 	 * @param prefs <code>ServerPrefs</code> instance for which IMRs should be selected
 	 * @return
 	 */
-    public static Set<ERF_Ref> get(boolean includeListERFs, boolean interactiveParams, ServerPrefs prefs) {
-        if (prefs == ServerPrefs.DEV_PREFS)
-            return get(includeListERFs, interactiveParams, PRODUCTION, DEVELOPMENT, EXPERIMENTAL);
-        else if (prefs == ServerPrefs.PRODUCTION_PREFS)
-            return get(includeListERFs, interactiveParams, PRODUCTION);
-        else
-            throw new IllegalArgumentException("Unknown ServerPrefs instance: "+prefs);
-    }
+	public static Set<ERF_Ref> get(boolean includeListERFs, boolean interactiveParams, ServerPrefs prefs) {
+		if (prefs == ServerPrefs.DEV_PREFS)
+			return get(includeListERFs, interactiveParams, PRODUCTION, DEVELOPMENT, EXPERIMENTAL);
+		else if (prefs == ServerPrefs.PRODUCTION_PREFS)
+			return get(includeListERFs, interactiveParams, PRODUCTION);
+		else
+			throw new IllegalArgumentException("Unknown ServerPrefs instance: "+prefs);
+	}
 
-    /**
-     * Convenience method to return references for all
-     * <code>EqkRupForecastBaseAPI</code> implementations that should be included
-     * in applications with the given ServerPrefs. Production applications only include
-     * production IMRs, and development applications include everything but
-     * deprecated IMRs.
-     * ERFs requiring interactive parameters are included by default.
-     * @param includeListERFs if true, Epistemic List ERFs will be included, otherwise
-     * they will be excluded
-     * @param prefs <code>ServerPrefs</code> instance for which IMRs should be selected
-     * @return
-     */
+	/**
+	 * Convenience method to return references for all
+	 * <code>EqkRupForecastBaseAPI</code> implementations that should be included
+	 * in applications with the given ServerPrefs. Production applications only include
+	 * production IMRs, and development applications include everything but
+	 * deprecated IMRs.
+	 * ERFs requiring interactive parameters are included by default.
+	 * @param includeListERFs if true, Epistemic List ERFs will be included, otherwise
+	 * they will be excluded
+	 * @param prefs <code>ServerPrefs</code> instance for which IMRs should be selected
+	 * @return
+	 */
 	public static Set<ERF_Ref> get(boolean includeListERFs, ServerPrefs prefs) {
-            return get(includeListERFs, true, prefs);
+		return get(includeListERFs, true, prefs);
 	}
 
 	/**
@@ -308,9 +311,9 @@ public enum ERF_Ref {
 	 * <code>EqkRupForecastBaseAPI</code> implementations at the specified
 	 * levels of development.
 	 * @param includeListERFs if true, Epistemic List ERFs will be included,
-     *                           otherwise they will be excluded
-     * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
-     *                          otherwise they will be excluded
+	 *                           otherwise they will be excluded
+	 * @param interactiveParams if true, ERFs requiring interactive parameters will be included,
+	 *                          otherwise they will be excluded
 	 * @param stati the development level(s) of the
 	 *        <code>EqkRupForecastBaseAPI</code> references to be retrieved
 	 * @return a <code>Set</code> of <code>EqkRupForecastBaseAPI</code>
@@ -318,36 +321,49 @@ public enum ERF_Ref {
 	 * @see DevStatus
 	 */
 	public static Set<ERF_Ref> get(boolean includeListERFs,
-                                   boolean interactiveParams,
-                                   DevStatus... stati) {
+			boolean interactiveParams,
+			DevStatus... stati) {
 		EnumSet<ERF_Ref> erfSet = EnumSet.allOf(ERF_Ref.class);
 		for (ERF_Ref erf : erfSet) {
 			if (!ArrayUtils.contains(stati, erf.status))
 				erfSet.remove(erf);
 			if (erf.isERFList() && !includeListERFs)
 				erfSet.remove(erf);
-            if (erf.needsInteractiveParams() && !interactiveParams)
-                erfSet.remove(erf);
+			if (erf.needsInteractiveParams() && !interactiveParams)
+				erfSet.remove(erf);
 		}
 		return erfSet;
 	}
 
-    /**
-     * Convenience method to return references to
-     * <code>EqkRupForecastBaseAPI</code> implementations at the specified
-     * levels of development.
-     * ERFs requiring interactive parameters are included by default.
-     * @param includeListERFs if true, Epistemic List ERFs will be included,
-     *                           otherwise they will be excluded
-     * @param stati the development level(s) of the
-     *        <code>EqkRupForecastBaseAPI</code> references to be retrieved
-     * @return a <code>Set</code> of <code>EqkRupForecastBaseAPI</code>
-     *         references
-     * @see DevStatus
-     */
-    public static Set<ERF_Ref> get(boolean includeListERFs,
-                                   DevStatus... stati) {
-        return get(includeListERFs, true, stati);
-    }
+	/**
+	 * Convenience method to return references to
+	 * <code>EqkRupForecastBaseAPI</code> implementations at the specified
+	 * levels of development.
+	 * ERFs requiring interactive parameters are included by default.
+	 * @param includeListERFs if true, Epistemic List ERFs will be included,
+	 *                           otherwise they will be excluded
+	 * @param stati the development level(s) of the
+	 *        <code>EqkRupForecastBaseAPI</code> references to be retrieved
+	 * @return a <code>Set</code> of <code>EqkRupForecastBaseAPI</code>
+	 *         references
+	 * @see DevStatus
+	 */
+	public static Set<ERF_Ref> get(boolean includeListERFs,
+			DevStatus... stati) {
+		return get(includeListERFs, true, stati);
+	}
+
+	/**
+	 * This returns a sorted view of the given ERF Refs, sorted first by DevStatus and then by name
+	 */
+	public static List<ERF_Ref> getSorted(Set<ERF_Ref> erfs) {
+		List<ERF_Ref> refs = new ArrayList<>(erfs);
+		Collections.sort(refs, (R1,R2) -> {
+			if (R1.status != R2.status)
+				return Integer.compare(R1.status.priority(), R2.status.priority());
+			return R1.name.compareTo(R2.name);
+		});
+		return refs;
+	}
 
 }

--- a/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
+++ b/src/main/java/org/opensha/sha/earthquake/ERF_Ref.java
@@ -387,7 +387,7 @@ public enum ERF_Ref {
 				System.out.println(ref.status);
 				prevStatus = ref.status;
 			}
-			System.out.println("\t"+ref.name+"\t\t\t\t("+(ref.name())+")");
+			System.out.println("\t"+ref.name);
 		}
 	}
 

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/Point2MultVertSS_Fault/Point2MultVertSS_FaultERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/Point2MultVertSS_Fault/Point2MultVertSS_FaultERF.java
@@ -40,7 +40,7 @@ public class Point2MultVertSS_FaultERF extends AbstractERF{
 	private boolean D = false;
 
 	//name for this classs
-	public final static String  NAME = "Point 2 Mult Vertical SS Fault ERF";
+	public final static String  NAME = "Point2Mult Vertical SS Fault ERF";
 
 	// this is the source (only 1 for this ERF)
 	private Point2MultVertSS_FaultSource source;

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WG02/WG02_ERF_Epistemic_List.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WG02/WG02_ERF_Epistemic_List.java
@@ -32,7 +32,7 @@ public class WG02_ERF_Epistemic_List extends AbstractEpistemicListERF{
   private static final String  C = new String("WG02 ERF List");
   private boolean D = false;
 
-  public static final String  NAME = new String("WG02 ERF List");
+  public static final String  NAME = new String("WGCEP (2002) ERF List");
 
   /**
    * Static variable for input file name

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WG02/WG02_EqkRupForecast.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WG02/WG02_EqkRupForecast.java
@@ -38,7 +38,7 @@ public class WG02_EqkRupForecast extends AbstractERF{
 
   //for Debug purposes
   private final static String  C = new String("WG02_EqkRupForecast");
-  public final static String NAME ="WG02 Eqk Rup Forecast";
+  public final static String NAME ="WGCEP (2002) Eqk Rup Forecast";
   private boolean D = false;
 
   /**

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF1/WGCEP_UCERF1_EqkRupForecast.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF1/WGCEP_UCERF1_EqkRupForecast.java
@@ -58,7 +58,7 @@ public class WGCEP_UCERF1_EqkRupForecast extends AbstractERF{
   private boolean D = false;
 
   // name of this ERF
-  public final static String NAME = new String("WGCEP (2005) UCERF 1.0");
+  public final static String NAME = new String("WGCEP (2005) UCERF1");
 
 //  ArrayList allSourceNames;
 

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF1/WGCEP_UCERF1_EqkRupForecast.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF1/WGCEP_UCERF1_EqkRupForecast.java
@@ -58,7 +58,7 @@ public class WGCEP_UCERF1_EqkRupForecast extends AbstractERF{
   private boolean D = false;
 
   // name of this ERF
-  public final static String NAME = new String("WGCEP UCERF 1.0 (2005)");
+  public final static String NAME = new String("WGCEP (2005) UCERF 1.0");
 
 //  ArrayList allSourceNames;
 

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF_2_Final/UCERF2.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF_2_Final/UCERF2.java
@@ -61,7 +61,7 @@ public class UCERF2 extends AbstractERF {
 	private boolean D = true;
 
 	// name of this ERF
-	public final static String NAME = new String("WGCEP Eqk Rate Model 2 ERF");
+	public final static String NAME = new String("WGCEP (2007) UCERF2 - Adjustable ERF");
 
 //	ArrayList allSourceNames;
 

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF_2_Final/UCERF2_TimeIndependentEpistemicList.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/WGCEP_UCERF_2_Final/UCERF2_TimeIndependentEpistemicList.java
@@ -23,7 +23,7 @@ import org.opensha.sha.earthquake.rupForecastImpl.WGCEP_UCERF_2_Final.analysis.P
  *
  */
 public class UCERF2_TimeIndependentEpistemicList extends AbstractEpistemicListERF {
-	public static final String  NAME = new String("UCERF2 ERF Epistemic List");
+	public static final String  NAME = new String("WGCEP (2007) UCERF2 - Epistemic List");
 	private ArrayList<Double> weights = null;
 	private ArrayList<ParameterList> logicTreeParamList = null;
 	protected UCERF2 ucerf2 = new UCERF2();

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/erf/NSHM23_BranchAveragedERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/nshm23/erf/NSHM23_BranchAveragedERF.java
@@ -24,7 +24,7 @@ public class NSHM23_BranchAveragedERF extends BaseFaultSystemSolutionERF {
 	
 	// TODO updated default to R2 when file is posted
 	public static final ModelVersions MODEL_DEFAULT = ModelVersions.WUS_R1;
-	public static final String NAME = "USGS NSHM23 Branch Averaged ERF";
+	public static final String NAME = "USGS NSHM23 - Branch Averaged ERF";
 	private static final boolean D = false;
 	
 	private NSHM23_Downloader downloader;

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
@@ -17,7 +17,7 @@ import java.util.Set;
  */
 public class NSHM25_PRVI_BranchAveragedERF extends BaseFaultSystemSolutionERF {
     private static final String MODEL = "2025_PRVI_NSHM_Fault-System_Solution";
-    public static final String NAME = "NSHM25-PRVI Branch Avg ERF";
+    public static final String NAME = "USGS NSHM25-PRVI Branch Avg ERF";
     private static final boolean D = false;
     private NSHM25_Downloader downloader;
     /**

--- a/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
+++ b/src/main/java/org/opensha/sha/earthquake/rupForecastImpl/prvi25/erf/NSHM25_PRVI_BranchAveragedERF.java
@@ -17,7 +17,7 @@ import java.util.Set;
  */
 public class NSHM25_PRVI_BranchAveragedERF extends BaseFaultSystemSolutionERF {
     private static final String MODEL = "2025_PRVI_NSHM_Fault-System_Solution";
-    public static final String NAME = "USGS NSHM25-PRVI Branch Avg ERF";
+    public static final String NAME = "USGS NSHM25-PRVI - Branch Averaged ERF";
     private static final boolean D = false;
     private NSHM25_Downloader downloader;
     /**

--- a/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
@@ -96,24 +96,7 @@ ParameterChangeListener, ChangeListener {
 	private HashMap<ERF_Ref, BaseERF> erfInstanceMap = new HashMap<ERF_Ref, BaseERF>();
 	
 	protected static List<ERF_Ref> asList(Set<ERF_Ref> erfRefSet) {
-		List<ERF_Ref> list = new ArrayList<ERF_Ref>();
-		for (ERF_Ref erf : erfRefSet) {
-			list.add(erf);
-		}
-		// sort by name, dev status
-//		Collections.sort(list, new ERF_RefComparator());
-		return list;
-	}
-	private static class ERF_RefComparator implements Comparator<ERF_Ref> {
-
-		@Override
-		public int compare(ERF_Ref o1, ERF_Ref o2) {
-			int priorityComp = Integer.valueOf(o1.status().priority()).compareTo(o2.status().priority());
-			if (priorityComp != 0)
-				return priorityComp;
-			return o1.toString().compareTo(o2.toString());
-		}
-		
+		return ERF_Ref.getSorted(erfRefSet);
 	}
 	
 	public ERF_GuiBean(ERF_Ref... erfRefs) throws InvocationTargetException {

--- a/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
@@ -159,7 +159,6 @@ ParameterChangeListener, ChangeListener {
 		erfSelectionParam = new EnumParameter<>(ERF_PARAM_NAME,
 				EnumSet.copyOf(erfRefs), erf, null);
 		erfSelectionParam.addParameterChangeListener(this);
-		System.out.println("Setting comparator on erf selector");
 		erfSelectionParam.setComparator(ERF_Ref.PRIORITY_NAME_COMPARATOR);
 		parameterList.addParameter(erfSelectionParam);
 	}

--- a/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/ERF_GuiBean.java
@@ -6,7 +6,8 @@ import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.opensha.commons.param.event.ParameterChangeEvent;
 import org.opensha.commons.param.event.ParameterChangeFailEvent;
 import org.opensha.commons.param.event.ParameterChangeFailListener;
 import org.opensha.commons.param.event.ParameterChangeListener;
+import org.opensha.commons.param.impl.EnumParameter;
 import org.opensha.commons.param.impl.StringParameter;
 import org.opensha.commons.util.ApplicationVersion;
 import org.opensha.commons.util.bugReports.BugReport;
@@ -59,9 +61,7 @@ public class ERF_GuiBean extends JPanel implements ParameterChangeFailListener,
 ParameterChangeListener, ChangeListener {
 
 	private final static String C = "ERF_GuiBean";
-
-	//this vector saves the names of all the supported Eqk Rup Forecasts
-	protected ArrayList<String> erfNamesVector = new ArrayList<String>();
+	
 	//this vector holds the references to all included ERFs
 	private List<ERF_Ref> erfRefs;
 
@@ -69,7 +69,7 @@ ParameterChangeListener, ChangeListener {
 	public final static String ERF_PARAM_NAME = "Eqk Rup Forecast";
 	// these are to store the list of independ params for chosen ERF
 	public final static String ERF_EDITOR_TITLE =  "Set Forecast";
-	StringParameter erfSelectionParam;
+	EnumParameter<ERF_Ref> erfSelectionParam;
 	// boolean for telling whether to show a progress bar
 	boolean showProgressBar = true;
 	
@@ -96,7 +96,9 @@ ParameterChangeListener, ChangeListener {
 	private HashMap<ERF_Ref, BaseERF> erfInstanceMap = new HashMap<ERF_Ref, BaseERF>();
 	
 	protected static List<ERF_Ref> asList(Set<ERF_Ref> erfRefSet) {
-		return ERF_Ref.getSorted(erfRefSet);
+		List<ERF_Ref> refs = new ArrayList<>(erfRefSet);
+		Collections.sort(refs);
+		return refs;
 	}
 	
 	public ERF_GuiBean(ERF_Ref... erfRefs) throws InvocationTargetException {
@@ -135,34 +137,30 @@ ParameterChangeListener, ChangeListener {
 		}
 		return erfInstanceMap.get(erfRef);
 	}
+	
+	private ERF_Ref getDefaultERF_Ref() {
+		Preconditions.checkNotNull(erfRefs, "ERF list cannot be null!");
+		Preconditions.checkArgument(!erfRefs.isEmpty(), "ERF list cannot be empty!");
+		return erfRefs.contains(ERF_Ref.APP_DEFAULT_ERF) ? ERF_Ref.APP_DEFAULT_ERF : erfRefs.get(0);
+	}
 
 	/**
 	 * init erf_IndParamList. List of all available forecasts at this time
 	 */
 	protected void init_erf_IndParamListAndEditor() throws InvocationTargetException{
-		Preconditions.checkNotNull(erfRefs, "ERF list cannot be null!");
-		Preconditions.checkArgument(!erfRefs.isEmpty(), "ERF list cannot be empty!");
-
 		this.parameterList = new ParameterList();
 
-		for (ERF_Ref erfRef : erfRefs) {
-			String name = erfRef.toString();
-			Preconditions.checkState(!erfNamesVector.contains(name),
-					"ERF list cannot contain 2 ERFs with the same name! Duplicate: "+name);
-			erfNamesVector.add(name);
-		}
-
-		// first ERF class that is to be shown as the default ERF in the ERF Pick List
-		ERF_Ref erf = erfRefs.get(0);
+		// ERF class that is to be shown as the default ERF in the ERF Pick List
+		ERF_Ref erf = getDefaultERF_Ref();
 		// make the ERF objects to get their adjustable parameters
 		eqkRupForecast = getERFInstance(erf);
 
-
-
 		// make the forecast selection parameter
-		erfSelectionParam = new StringParameter(ERF_PARAM_NAME,
-				erfNamesVector, (String)erfNamesVector.get(0));
+		erfSelectionParam = new EnumParameter<>(ERF_PARAM_NAME,
+				EnumSet.copyOf(erfRefs), erf, null);
 		erfSelectionParam.addParameterChangeListener(this);
+		System.out.println("Setting comparator on erf selector");
+		erfSelectionParam.setComparator(ERF_Ref.PRIORITY_NAME_COMPARATOR);
 		parameterList.addParameter(erfSelectionParam);
 	}
 	
@@ -320,7 +318,6 @@ ParameterChangeListener, ChangeListener {
 		return eqkRupForecast;
 	}
 
-
 	/**
 	 * get the selected ERF instance.
 	 * It returns the ERF after updating its forecast
@@ -354,11 +351,11 @@ ParameterChangeListener, ChangeListener {
 	
 			try {
 				isNewERF_Instance = false;
-				ERF_Ref fallbackRef = erfRefs.get(0);
+				ERF_Ref fallbackRef = getDefaultERF_Ref();
 				if (fallbackERF != null && fallbackERF.getName().equals(fallbackRef.toString()))
 					erfInstanceMap.put(fallbackRef, fallbackERF);
 				System.gc();
-				erfSelectionParam.setValue(fallbackRef.toString());
+				erfSelectionParam.setValue(fallbackRef);
 				erfSelectionParam.getEditor().refreshParamEditor();
 			} catch (Exception e1) {}
 			throw e;
@@ -441,7 +438,7 @@ ParameterChangeListener, ChangeListener {
 
 	}
 	
-	private void showERFInstantiationError(Throwable t, String erfName) {
+	private void showERFInstantiationError(Throwable t, ERF_Ref erf) {
 		t.printStackTrace();
 		ApplicationVersion version;
 		try {
@@ -450,10 +447,10 @@ ParameterChangeListener, ChangeListener {
 			version = null;
 		}
 		BugReport bug = new BugReport(t, "Problem occured in ERF_GuiBean" +
-				" when "+erfName+" is selected.", erfName, version, this);
-		String title = "Error instantiating "+erfName;
+				" when "+erf+" is selected.", erf.toString(), version, this);
+		String title = "Error instantiating "+erf;
 		
-		String message = "An error occured when instantiating "+erfName+
+		String message = "An error occured when instantiating "+erf+
 					"\n\nIt will be removed from the list. If you wish, you can submit" +
 					" a bug report by clicking below. To receive updates on the bug report, it" +
 					" is important that you leave your e-mail address in the 'reporter' field.";
@@ -472,29 +469,21 @@ ParameterChangeListener, ChangeListener {
 	 */
 	public void parameterChange(ParameterChangeEvent event) {
 
-
-		String name1 = event.getParameterName();
-
 		// if ERF selected by the user  changes
-		if (name1.equals(ERF_PARAM_NAME) && !isNewERF_Instance) {
-			String value = event.getNewValue().toString();
-			int size = this.erfNamesVector.size();
+		if (event.getParameter() == erfSelectionParam && !isNewERF_Instance) {
 			try {
-				for (int i=0;i<size;++i) {
-					if(value.equalsIgnoreCase((String)erfNamesVector.get(i))) {
-						try {
-							eqkRupForecast = getERFInstance(erfRefs.get(i));
-						} catch (Exception e) {
-							showERFInstantiationError(e, value);
-							ArrayList<ERF_Ref> removed = new ArrayList<ERF_Ref>();
-							removed.add(erfRefs.get(i));
-							removeERFs_FromList(removed);
-							erfSelectionParam.setValue((String)event.getOldValue());
-							erfSelectionParam.getEditor().refreshParamEditor();
-							return;
-						}
-						break;
-					}
+				ERF_Ref ref = (ERF_Ref)event.getNewValue();
+				try {
+					eqkRupForecast = getERFInstance(ref);
+				} catch (Exception e) {
+					showERFInstantiationError(e, ref);
+					int index = erfRefs.indexOf(ref);
+					ArrayList<ERF_Ref> removed = new ArrayList<ERF_Ref>();
+					removed.add(erfRefs.get(index));
+					removeERFs_FromList(removed);
+					erfSelectionParam.setValue((ERF_Ref)event.getOldValue());
+					erfSelectionParam.getEditor().refreshParamEditor();
+					return;
 				}
 			} catch (Exception e) {
 				e.printStackTrace();
@@ -534,12 +523,10 @@ ParameterChangeListener, ChangeListener {
 	 */
 	public void addERFs_ToList(ArrayList<ERF_Ref> newRefs) throws InvocationTargetException{
 
-		int size = newRefs.size();
 		for (ERF_Ref erfRef : newRefs)
 			if(!erfRefs.contains(erfRef))
 				newRefs.add(erfRef);
 		// create the instance of ERFs
-		erfNamesVector.clear();
 		init_erf_IndParamListAndEditor();
 		setParamsInForecast();
 	}
@@ -570,7 +557,6 @@ ParameterChangeListener, ChangeListener {
 			if (erfRefs.contains(erf))
 				erfRefs.remove(erf);
 		// create the instance of ERFs
-		erfNamesVector.clear();
 		init_erf_IndParamListAndEditor();
 		setParamsInForecast();
 	}
@@ -599,11 +585,11 @@ ParameterChangeListener, ChangeListener {
 		this.eqkRupForecast = eqkRupForecast;
 		isNewERF_Instance = true;
 		String erfName = eqkRupForecast.getName();
-		int size = erfNamesVector.size();
-		for(int i=0;i<size;++i){
-			if(erfName.equalsIgnoreCase( (String) erfNamesVector.get(i))) {
+//		int size = erf.size();
+		for (ERF_Ref ref : erfRefs) {
+			if(erfName.equalsIgnoreCase(ref.toString())) {
 				try{
-					listEditor.getParameterEditor(ERF_PARAM_NAME).setValue(erfName);
+					erfSelectionParam.setValue(ref);
 					setParamsInForecast();
 				}catch(Exception e){
 					e.printStackTrace();

--- a/src/main/java/org/opensha/sha/gui/controls/PEER_TestCaseSelectorControlPanel.java
+++ b/src/main/java/org/opensha/sha/gui/controls/PEER_TestCaseSelectorControlPanel.java
@@ -26,6 +26,7 @@ import org.opensha.sha.calc.sourceFilters.SourceFilterManager;
 import org.opensha.sha.calc.sourceFilters.SourceFilters;
 import org.opensha.sha.calc.sourceFilters.params.MaxDistanceParam;
 import org.opensha.sha.calc.sourceFilters.params.SourceFiltersParam;
+import org.opensha.sha.earthquake.ERF_Ref;
 import org.opensha.sha.earthquake.rupForecastImpl.FloatingPoissonFaultERF;
 import org.opensha.sha.earthquake.rupForecastImpl.PEER_TestCases.PEER_AreaForecast;
 import org.opensha.sha.earthquake.rupForecastImpl.PEER_TestCases.PEER_LogicTreeERF_List;
@@ -417,7 +418,7 @@ public class PEER_TestCaseSelectorControlPanel extends ControlPanel {
 		if(!selectedTest.equalsIgnoreCase(TEST_CASE_TEN) && !selectedTest.equalsIgnoreCase(TEST_CASE_ELEVEN)) {
 
 			// set the ERF
-			erfGuiBean.getERFParameterList().getParameter(ERF_GuiBean.ERF_PARAM_NAME).setValue(FloatingPoissonFaultERF.NAME);
+			erfGuiBean.getERFParameterList().getParameter(ERF_GuiBean.ERF_PARAM_NAME).setValue(ERF_Ref.POISSON_FLOATING_FAULT);
 
 			// set offset and fault grid spacing (these were determined by trial and error)
 			double gridSpacing;
@@ -640,7 +641,7 @@ public class PEER_TestCaseSelectorControlPanel extends ControlPanel {
 
 		//if test case -1
 		if(selectedTest.equalsIgnoreCase(TEST_CASE_ONE)){
-			erfGuiBean.getERFParameterList().getParameter(ERF_GuiBean.ERF_PARAM_NAME).setValue(PEER_NonPlanarFaultForecast.NAME);
+			erfGuiBean.getERFParameterList().getParameter(ERF_GuiBean.ERF_PARAM_NAME).setValue(ERF_Ref.PEER_NON_PLANAR_FAULT);
 			// add sigma for maglength(0-1)
 			erfGuiBean.getERFParameterList().getParameter(PEER_NonPlanarFaultForecast.SIGMA_PARAM_NAME).setValue(Double.valueOf(0));
 			timeSpanGuiBean.getParameterList().getParameter(TimeSpan.DURATION).setValue(Double.valueOf(1.0));

--- a/src/main/java/scratch/UCERF3/erf/UCERF3_CompoundSol_ERF.java
+++ b/src/main/java/scratch/UCERF3/erf/UCERF3_CompoundSol_ERF.java
@@ -62,7 +62,7 @@ public class UCERF3_CompoundSol_ERF extends FaultSystemSolutionERF {
 
 	private static final boolean D = false;
 	
-	public static final String NAME = "UCERF3 Single Branch ERF";
+	public static final String NAME = "WGCEP (2014) UCERF3 - Individual Branch";
 	
 	private Map<Class<? extends U3LogicTreeBranchNode<?>>, EnumParameter<?>> enumParamsMap;
 	

--- a/src/main/java/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
+++ b/src/main/java/scratch/UCERF3/erf/epistemic/UCERF3EpistemicListERF.java
@@ -64,7 +64,7 @@ import scratch.UCERF3.utils.UCERF3_Downloader;
 
 public class UCERF3EpistemicListERF implements EpistemicListERF, ParameterChangeListener {
 	
-	public static final String NAME = "UCERF3 Epistemic List ERF";
+	public static final String NAME = "WGCEP (2014) UCERF3 - Epistemic List";
 	
 	private CompletableFuture<SolutionLogicTree> fetchFuture;
 	private LogicTree<?> tree;

--- a/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
+++ b/src/main/java/scratch/UCERF3/erf/mean/MeanUCERF3.java
@@ -62,7 +62,7 @@ public class MeanUCERF3 extends FaultSystemSolutionERF {
 	
 	 private static final boolean D = false;
 	
-	public static final String NAME = "Mean UCERF3";
+	public static final String NAME = "WGCEP (2014) UCERF3 - Mean/Branch Averaged";
 	
 	static final String RAKE_BASIS_FILE_NAME = "rake_basis.zip";
 	static final String TRUE_MEAN_FILE_NAME = "mean_ucerf3_sol.zip";

--- a/src/main/java/scratch/UCERF3/utils/ModUCERF2/ModMeanUCERF2_FM2pt1.java
+++ b/src/main/java/scratch/UCERF3/utils/ModUCERF2/ModMeanUCERF2_FM2pt1.java
@@ -32,7 +32,7 @@ public class ModMeanUCERF2_FM2pt1 extends ModMeanUCERF2 {
 	//for Debug purposes
 	protected static String  C = new String("MeanUCERF2 Modified, FM 2.1");
 	// name of this ERF
-	public final static String NAME = new String("WGCEP (2007) UCERF2 - Single Branch, Modified, Fault Model 2.1 only");
+	public final static String NAME = new String("WGCEP (2007) UCERF2 - Single Branch (Mod: FM 2.1 only)");
 
 	/**
 	 * Make B-Faults sources and caluculate B-Faults Total Summed MFD


### PR DESCRIPTION
The ERF list in our apps has been sorted according to the order declared in `ERF_Ref`, largely to force Frankel '96 to be first (because it loads/calculates instantly). This PR introduces sorting and renames many ERFs.

First, I add support for `EnumParameter` and `EnumParameterEditor` to accept a `Comparator` for sorting the displayed enums. If omitted, the current (ordinal) sorting is used.

Then I update `ERF_GuiBean` to use an `EnumParameter` (instead of the current `StringParamter` that was used/configured before `EnumParameter` existed), and enable sorting first by `DevStatus`, then by name.

Finally, I renamed many of the ERFs to follow consistent naming structures for better sorting and to make them easier to find in the list. Here is the updated sorted list:

```
Production
	Fault System Solution ERF
	Floating Poisson Fault ERF
	PEER Area Forecast
	PEER Logic Tree ERF List
	PEER Multi Source
	PEER Non Planar Fault Forecast
	Point Source ERF
	Point2Mult Vertical SS Fault ERF
	Point2Mult Vertical SS Fault ERF List
	Poisson Fault ERF
	USGS NSHM23 - Branch Averaged ERF
	USGS NSHM25-PRVI - Branch Averaged ERF
	USGS/CGS 1996 Adj. Cal. ERF
	USGS/CGS 1996 Cal. ERF
	USGS/CGS 2002 Adj. Cal. ERF
	WGCEP (2002) ERF List
	WGCEP (2002) Eqk Rup Forecast
	WGCEP (2005) UCERF1
	WGCEP (2007) UCERF2 - Adjustable ERF
	WGCEP (2007) UCERF2 - Epistemic List
	WGCEP (2007) UCERF2 - Single Branch
	WGCEP (2007) UCERF2 - Single Branch (Mod: FM 2.1 only)
	WGCEP (2014) UCERF3 - Epistemic List
	WGCEP (2014) UCERF3 - Individual Branch
	WGCEP (2014) UCERF3 - Mean/Branch Averaged
	Yucca Mountain ERF Epistemic List
	Yucca mountain Adj. ERF
Development
	STEP Alaskan Pipeline ERF
```

When launched, the application defaults to `USGS/CGS 1996 Adj. Cal. ERF` as before. Here is how the chooser GUI now looks:

<img width="1017" height="877" alt="image" src="https://github.com/user-attachments/assets/293d0358-b07a-4f29-a8e9-3dd03b8f9c9a" />

We will need to update the tutorials (visible [here](https://opensha.org/Tutorials) and editable [here](https://github.com/opensha/opensha/wiki/Tutorials)) once the names are finalized. @field-usgs, can you take a look at the updated names and let me know if you would like me to make any changes?

This PR builds upon (and should not be merged prior to) #241.