### PR TITLE
Update default source filters (maximum source-site distance in hazard calcs)  to TRT-dependent defaults

### DIFF
--- a/src/main/java/org/opensha/sha/calc/sourceFilters/params/SourceFiltersParam.java
+++ b/src/main/java/org/opensha/sha/calc/sourceFilters/params/SourceFiltersParam.java
@@ -12,7 +12,7 @@ public class SourceFiltersParam extends AbstractParameter<SourceFilterManager> {
 	private SourceFiltersParamEditor editor = null;
 	
 	public static SourceFilterManager getDefault() {
-		return new SourceFilterManager(SourceFilters.FIXED_DIST_CUTOFF);
+		return new SourceFilterManager(SourceFilters.TRT_DIST_CUTOFFS);
 	}
 	
 	public SourceFiltersParam() {


### PR DESCRIPTION
This updates the default maximum source-to-site distance in our GUI apps.

The prior default was 200 km for all source types. The new default uses tectonic-regime-specific values. Those TRT-specfic values are unchanged and identical to those in NSHMP-Haz:

* Active shallow: 300 km
* Stable shallow: 1000 km
* Subduction interface: 1000 km
* Subduction intraslab: 300 km
* Volcanic: 300 km

The cutoffs are adjustable via the "Calculation Settings" control panel in our applications, which was revamped in #107. Those settings are reset on every launch, and could be moved to some sort of preferences structure in the future.