### PR TITLE
Fix NPE

### DIFF
--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
@@ -228,7 +228,7 @@ public class AS_1997_AttenRel extends AttenuationRelationship {
 
 	@Override
 	public void setPropagationEffectParams(SurfaceDistances distances) {
-		distanceRupParam.setValue(distances.getDistanceRup());
+		distanceRupParam.setValueIgnoreWarning(distances.getDistanceRup());
 
 		// here is the hanging wall term.  This should really be implemented as a
 		// formal propagation-effect parameter.

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
@@ -233,7 +233,7 @@ public class Abrahamson_2000_AttenRel extends AttenuationRelationship {
 
 	@Override
 	public void setPropagationEffectParams(SurfaceDistances distances) {
-		distanceRupParam.setValue(distances.getDistanceRup());
+		distanceRupParam.setValueIgnoreWarning(distances.getDistanceRup());
 		setDirectivityParams();
 	}
 


### PR DESCRIPTION
## Problem

The IM Event Set Calculator (GUI) crashes with a `NullPointerException` when a site is farther than 200 km from a rupture:

```
java.lang.NullPointerException: Cannot invoke "ParameterChangeWarningListener.parameterChangeWarning(...)" because "listener" is null
    at AbstractDoublePropEffectParam.fireParameterChangeWarning(AbstractDoublePropEffectParam.java:238)
    at AbstractDoublePropEffectParam.setValue(AbstractDoublePropEffectParam.java:186)
    at AS_1997_AttenRel.setPropagationEffectParams(AS_1997_AttenRel.java:231)
    ...
    at OriginalModCsvWriter.writeOriginalMeanSigmaFiles(OriginalModCsvWriter.java:136)
```

## Root cause

Two conditions combine to produce the crash:

1. The GUI builds its IMRs with a null warning listener (`IMR_ChooserPanel.buildValidIMRs` → `AttenRelRef.instanceList(null, …)`), so each GMM constructor calls `distanceRupParam.addParameterChangeWarningListener(null)`, storing `null` in the parameter's listener list (the `add` method does not reject null).
2. `AS_1997_AttenRel` and `Abrahamson_2000_AttenRel` set the rupture distance via the warning-firing `setValue` in `setPropagationEffectParams`. When `distanceRup` exceeds `DISTANCE_RUP_WARN_MAX` (200 km), `setValue` enters its warning branch, calls `fireParameterChangeWarning`, and the loop invokes `null.parameterChangeWarning(event)` → NPE.

Note: simply registering a listener would **not** fix this. `setValue` throws `WarningException` unconditionally *after* firing the warning, and `WarningException` is caught nowhere in the calculation path (only in GUI parameter editors), so a listener alone would convert the NPE into an uncaught `WarningException` crash.

## Fix

Set the propagation-effect distance with `setValueIgnoreWarning` instead of `setValue` in the two affected GMMs, matching the pattern already used by the modern GMMs (`CY_2008`, `CB_2008`, `AfshariStewart_2016`, `CY_2006`):

- `AS_1997_AttenRel.setPropagationEffectParams`
- `Abrahamson_2000_AttenRel.setPropagationEffectParams`

`setValueIgnoreWarning` bypasses the warning branch entirely — no fire, no `WarningException`, no NPE. The identical value is stored, so computed results are unchanged. These are the only two GMMs that set `distanceRupParam` via the warning-firing `setValue`; every other GMM already uses `setValueIgnoreWarning` for distance params, and the remaining `setValue` calls on other propagation-effect parameters (dip/width/aspect) are on parameters with no warning constraint, so they never enter the warning branch.

## Verification

- `./gradlew compileJava` → BUILD SUCCESSFUL
- `./gradlew test --tests Abrahamson_2000_test --tests ProductionIMRsBasicConsitencyTest --tests ProductionIMRsInstantiationTest` → 459 tests, 0 failures, 0 errors
- Manually validated the behavior in the IM Event Set Calculator GUI using the AS1997 IMR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)