### PR TITLE
Updated fix for IMR GUI long names on Linux

### DIFF
--- a/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
+++ b/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
@@ -1914,8 +1914,7 @@ ActionListener, ScalarIMRChangeListener, IMTChangeListener {
 
 		imrGuiBean = new IMR_MultiGuiBean(imrs);
 		imrGuiBean.addIMRChangeListener(this);
-		// imrGuiBean.setMaxChooserChars(30);
-        imrGuiBean.setChooserBoxSize(new Dimension(220, 25));
+		imrGuiBean.setChooserBoxSize(new Dimension(220, 25));
 		imrGuiBean.rebuildGUI();
 	}
 
@@ -2793,4 +2792,3 @@ ActionListener, ScalarIMRChangeListener, IMTChangeListener {
 		}
 	}
 }
-

--- a/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
@@ -9,14 +9,14 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
 import javax.swing.*;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 
 import org.opensha.commons.gui.LabeledBoxPanel;
@@ -82,8 +82,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	private int defaultIMRIndex = 0;
 	
 	private Color backgroundColor;
-
-    private Dimension chooserBoxSize = null;
+	private Dimension chooserBoxSize = null;
 
 	/**
 	 * Initializes the GUI with the given list of IMRs
@@ -405,7 +404,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	 * @author kevin
 	 *
 	 */
-	public class ChooserComboBox extends JComboBox {
+	public class ChooserComboBox extends JComboBox<String> {
 		/**
 		 * 
 		 */
@@ -437,12 +436,44 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 			resetRenderer();
 			
 			this.addActionListener(new ComboListener(this));
-//            Dimension imrBoxSize = new Dimension(220, 25);
-            if (chooserBoxSize != null) {
-                this.setPreferredSize(chooserBoxSize);
-                this.setMinimumSize(chooserBoxSize);
-                this.setMaximumSize(chooserBoxSize);
-            }
+			this.addPopupMenuListener(new PopupMenuListener() {
+				@Override
+				public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+					/*
+					 * Some look-and-feels, including GTK, size the popup from the combo box
+					 * while opening it. Temporarily expose the width required by the longest
+					 * rendered item so that the popup can display full IMR names, then restore
+					 * the constrained control size on the next event-queue turn. This keeps
+					 * the containing panel at its normal width while the popup remains wide.
+					 */
+					Dimension collapsedSize = getSize();
+					setSize(getPopupWidth(), collapsedSize.height);
+					SwingUtilities.invokeLater(() -> setSize(collapsedSize));
+				}
+
+				@Override
+				public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+
+				@Override
+				public void popupMenuCanceled(PopupMenuEvent e) {}
+			});
+			if (chooserBoxSize != null) {
+				this.setPreferredSize(chooserBoxSize);
+				this.setMinimumSize(chooserBoxSize);
+				this.setMaximumSize(chooserBoxSize);
+			}
+		}
+
+		private int getPopupWidth() {
+			ListCellRenderer<? super String> renderer = getRenderer();
+			JList<String> list = new JList<>();
+			int widestCell = getWidth();
+			for (int i=0; i<getItemCount(); i++) {
+				Component cell = renderer.getListCellRendererComponent(list, getItemAt(i), i, false, false);
+				widestCell = Integer.max(widestCell, cell.getPreferredSize().width);
+			}
+			// Space for the popup's border and vertical scrollbar, if present.
+			return widestCell + 24;
 		}
 		
 		public void resetRenderer() {
@@ -897,9 +928,9 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		this.maxChooserChars = maxChooserChars;
 	}
 
-    public void setChooserBoxSize(Dimension size) {
-        this.chooserBoxSize = size;
-    }
+	public void setChooserBoxSize(Dimension size) {
+		this.chooserBoxSize = size;
+	}
 
     /**
      * Demonstration of how to use IMR_MultiGuiBean


### PR DESCRIPTION
This attempts to finish the job started by #196 and mentioned in #207.

Long IMR names have historically been clipped in the selector dropdown box in our GUI apps. #196 fixed this on Mac's, but the issue remained on Linux and Windows.

This fixes it by:

* The application still chooses the collapsed IMR chooser's fixed width
* When the user clicks on the IMR name chooser, the popup begins opening triggering `PopupMenuListener.popupMenuWillBecomeVisible(PopupMenuEvent)`
* Detect that event and calculate a temporary size large enough for all IMR names.
* Temporarily set the chooser (the full GUI component) to the larger size by calling `setSize(...)`; the new size isn't acted upon (we don't trigger a layout update)
* Immediately schedule an event to revert to the original size via `SwingUtilities.invokeLater`.
* The popup then becomes visible and the window manager sees the temporarily-larger size of the combo box when determining the size for the popup. It sizes the popup relative to that larger size.
* Once the popup is visible, the event queue processes the revert command on the combo box, leaving the panel layout unchanged while the already-created popup remains wide enough.

Here's the app before/after clicking on the IMR chooser box:

<img width="1228" height="866" alt="image" src="https://github.com/user-attachments/assets/485b966a-404e-4708-bd0b-812ab6834eb9" />

And here is it with the chooser popup:

<img width="1228" height="866" alt="image" src="https://github.com/user-attachments/assets/08ade0ba-d733-4e36-b61d-e9cb10fbdce5" />
