### PR TITLE
Loosen gradle java version restrictions

### DIFF
--- a/build-common.gradle
+++ b/build-common.gradle
@@ -5,12 +5,25 @@
  * This file requires that the 'parentProject' property be defined (should be null for top level project)
  */
 
+
+/*
+ * Modern gradle recommends using toolchains but they come with an annoyance: you must have exactly the specified java
+ * version installed, or it fails. So if we specify Java 21 but you have 25, it will fail. That can be overcome by
+ * having gradle download it's own Java 21 (or whatever we're on), but that's unecessary and requires a separate plugin
+ * be configured in each downstream project's settings.gradle.  
+ * 
+ * Instead, we just keep the old source/target compatibility flags, but also now supply the JavaCompile release option
+ * which prevents accidentally using new APIs.
+ */
 java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
-compileJava.options.encoding = "UTF-8"
+
+tasks.withType(JavaCompile).configureEach {
+	options.release = 21
+	options.encoding = "UTF-8"
+}
 
 apply plugin: 'eclipse'
 eclipse {

--- a/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
+++ b/src/main/java/org/opensha/sha/gui/HazardCurveApplication.java
@@ -1914,8 +1914,7 @@ ActionListener, ScalarIMRChangeListener, IMTChangeListener {
 
 		imrGuiBean = new IMR_MultiGuiBean(imrs);
 		imrGuiBean.addIMRChangeListener(this);
-		// imrGuiBean.setMaxChooserChars(30);
-        imrGuiBean.setChooserBoxSize(new Dimension(220, 25));
+		imrGuiBean.setChooserBoxSize(new Dimension(220, 25));
 		imrGuiBean.rebuildGUI();
 	}
 
@@ -2793,4 +2792,3 @@ ActionListener, ScalarIMRChangeListener, IMTChangeListener {
 		}
 	}
 }
-

--- a/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
+++ b/src/main/java/org/opensha/sha/gui/beans/IMR_MultiGuiBean.java
@@ -9,14 +9,14 @@ import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
-import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
 import javax.swing.*;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
 import javax.swing.plaf.basic.BasicComboBoxRenderer;
 
 import org.opensha.commons.gui.LabeledBoxPanel;
@@ -82,8 +82,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	private int defaultIMRIndex = 0;
 	
 	private Color backgroundColor;
-
-    private Dimension chooserBoxSize = null;
+	private Dimension chooserBoxSize = null;
 
 	/**
 	 * Initializes the GUI with the given list of IMRs
@@ -405,7 +404,7 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 	 * @author kevin
 	 *
 	 */
-	public class ChooserComboBox extends JComboBox {
+	public class ChooserComboBox extends JComboBox<String> {
 		/**
 		 * 
 		 */
@@ -437,12 +436,44 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 			resetRenderer();
 			
 			this.addActionListener(new ComboListener(this));
-//            Dimension imrBoxSize = new Dimension(220, 25);
-            if (chooserBoxSize != null) {
-                this.setPreferredSize(chooserBoxSize);
-                this.setMinimumSize(chooserBoxSize);
-                this.setMaximumSize(chooserBoxSize);
-            }
+			this.addPopupMenuListener(new PopupMenuListener() {
+				@Override
+				public void popupMenuWillBecomeVisible(PopupMenuEvent e) {
+					/*
+					 * Some look-and-feels, including GTK, size the popup from the combo box
+					 * while opening it. Temporarily expose the width required by the longest
+					 * rendered item so that the popup can display full IMR names, then restore
+					 * the constrained control size on the next event-queue turn. This keeps
+					 * the containing panel at its normal width while the popup remains wide.
+					 */
+					Dimension collapsedSize = getSize();
+					setSize(getPopupWidth(), collapsedSize.height);
+					SwingUtilities.invokeLater(() -> setSize(collapsedSize));
+				}
+
+				@Override
+				public void popupMenuWillBecomeInvisible(PopupMenuEvent e) {}
+
+				@Override
+				public void popupMenuCanceled(PopupMenuEvent e) {}
+			});
+			if (chooserBoxSize != null) {
+				this.setPreferredSize(chooserBoxSize);
+				this.setMinimumSize(chooserBoxSize);
+				this.setMaximumSize(chooserBoxSize);
+			}
+		}
+
+		private int getPopupWidth() {
+			ListCellRenderer<? super String> renderer = getRenderer();
+			JList<String> list = new JList<>();
+			int widestCell = getWidth();
+			for (int i=0; i<getItemCount(); i++) {
+				Component cell = renderer.getListCellRendererComponent(list, getItemAt(i), i, false, false);
+				widestCell = Integer.max(widestCell, cell.getPreferredSize().width);
+			}
+			// Space for the popup's border and vertical scrollbar, if present.
+			return widestCell + 24;
 		}
 		
 		public void resetRenderer() {
@@ -897,9 +928,9 @@ public class IMR_MultiGuiBean extends LabeledBoxPanel implements ActionListener,
 		this.maxChooserChars = maxChooserChars;
 	}
 
-    public void setChooserBoxSize(Dimension size) {
-        this.chooserBoxSize = size;
-    }
+	public void setChooserBoxSize(Dimension size) {
+		this.chooserBoxSize = size;
+	}
 
     /**
      * Demonstration of how to use IMR_MultiGuiBean


### PR DESCRIPTION
We recently switched to using the modern gradle `toolchain` option which enforces a specific version of java. It's benefit is a more consistent environment, but it's downside is  that, if we target 21, you can't build even if you have a newer version (25) but not the exact version (21).

One way around this is to allow it to download its own java version via the `foojay` plugin. The annoyance there is that it needs to be enabled separately in each project (main, dev, cybershake, oaf, NZ), and is unnecessary if you already have a modern JDK.

Instead, this PR reverts to the old source/target compatibility flags because they're used by the eclipse plugin to determine the correct JDK, and also now specifies the java compiler `release` option. The latter is stricter than the old compatibility flags and should prevent accidental use of APIs beyond the current version.

More info on the various build flags is [available here](https://docs.gradle.org/current/userguide/building_java_projects.html).