### PR TITLE
Fix "Get Info" in the Attenuation Relationship Plotter

### DIFF
--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/ASI_WrapperAttenRel/BA_2008_ASI_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/ASI_WrapperAttenRel/BA_2008_ASI_AttenRel.java
@@ -1,5 +1,8 @@
 package org.opensha.sha.gcim.imr.attenRelImpl.ASI_WrapperAttenRel;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
 import org.opensha.sha.gcim.imCorrRel.imCorrRelImpl.BakerJayaram08_ImCorrRel;
 import org.opensha.sha.imr.attenRelImpl.BA_2008_AttenRel;
@@ -55,6 +58,15 @@ public class BA_2008_ASI_AttenRel
    */
   public String getShortName() {
     return SHORT_NAME;
+  }
+
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.2830434");
   }
 
 

--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/BommerEtAl_2009_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/BommerEtAl_2009_AttenRel.java
@@ -426,6 +426,15 @@ public class BommerEtAl_2009_AttenRel
     return SHORT_NAME;
   }
 
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1785/0120080298");
+  }
+
   
   /**
    * 

--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/CB_2010_CAV_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/CB_2010_CAV_AttenRel.java
@@ -525,6 +525,15 @@ public class CB_2010_CAV_AttenRel
     return SHORT_NAME;
   }
 
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.3457158");
+  }
+
   
   /**
    * 

--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/DSI_WrapperAttenRel/BA_2008_DSI_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/DSI_WrapperAttenRel/BA_2008_DSI_AttenRel.java
@@ -1,5 +1,8 @@
 package org.opensha.sha.gcim.imr.attenRelImpl.DSI_WrapperAttenRel;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
 import org.opensha.sha.gcim.imCorrRel.imCorrRelImpl.BakerJayaram08_ImCorrRel;
 import org.opensha.sha.imr.attenRelImpl.SA_InterpolatedWrapperAttenRel.InterpolatedBA_2008_AttenRel;
@@ -53,6 +56,15 @@ public class BA_2008_DSI_AttenRel
    */
   public String getShortName() {
     return SHORT_NAME;
+  }
+
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.2830434");
   }
 
 

--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/KS_2006_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/KS_2006_AttenRel.java
@@ -412,6 +412,15 @@ public class KS_2006_AttenRel
     return SHORT_NAME;
   }
 
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.2358175");
+  }
+
   
   /**
    * 

--- a/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/SI_WrapperAttenRel/BA_2008_SI_AttenRel.java
+++ b/src/main/java/org/opensha/sha/gcim/imr/attenRelImpl/SI_WrapperAttenRel/BA_2008_SI_AttenRel.java
@@ -1,5 +1,8 @@
 package org.opensha.sha.gcim.imr.attenRelImpl.SI_WrapperAttenRel;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
 import org.opensha.sha.gcim.imCorrRel.imCorrRelImpl.BakerJayaram08_ImCorrRel;
 import org.opensha.sha.imr.attenRelImpl.BA_2008_AttenRel;
@@ -55,6 +58,15 @@ public class BA_2008_SI_AttenRel
    */
   public String getShortName() {
     return SHORT_NAME;
+  }
+
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.2830434");
   }
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_1997_AttenRel.java
@@ -1180,7 +1180,7 @@ public class AS_1997_AttenRel extends AttenuationRelationship {
 
 	@Override
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-ABRAHAM_SILVA_1997");
+		return new URL("https://doi.org/10.1785/gssrl.68.1.94");
 	}
 
 	/*

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_2008_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/AS_2008_AttenRel.java
@@ -111,7 +111,7 @@ public class AS_2008_AttenRel extends AttenuationRelationship implements
 	private static final long serialVersionUID = 1234567890987654358L;
 
 	// URL Info String
-	private final static String URL_INFO_STRING = "http://www.opensha.org/glossary-attenuationRelation-ABRAHAM_SILVA_2008";
+	private final static String URL_INFO_STRING = "https://doi.org/10.1193/1.2924360";
 
 	// style of faulting param options
 	public final static String FLT_TYPE_STRIKE_SLIP = "Strike-Slip";

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/Abrahamson_2000_AttenRel.java
@@ -81,8 +81,7 @@ public class Abrahamson_2000_AttenRel extends AttenuationRelationship {
 	public final static String SHORT_NAME = "Abrahamson2000";
 	private static final long serialVersionUID = 1234567890987654351L;
 
-	// URL Info String
-	private final static String URL_INFO_STRING = "http://www.opensha.org/glossary-attenuationRelation-ABRAHAM_2000";
+	// No URL_INFO_STRING: this model has no published paper or DOI (see getInfoURL()).
 
 
 
@@ -1226,12 +1225,16 @@ public class Abrahamson_2000_AttenRel extends AttenuationRelationship {
 
 
 	/**
-	 * This provides a URL where more info on this model can be obtained
-	 * @throws MalformedURLException if returned URL is not a valid URL.
-	 * @return the URL to the AttenuationRelationship document on the Web.
+	 * This model was described only in a conference presentation/proceedings
+	 * (Abrahamson, 2000) and was never published as a journal article, so it
+	 * has no DOI or web document to link to. Returns {@code null} so the
+	 * plotter intentionally reports that no information exists, rather than
+	 * linking to an unrelated page.
+	 * @return null; no information URL exists for this model.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL(URL_INFO_STRING);
+		// No DOI/paper exists for Abrahamson (2000); intentionally return null.
+		return null;
 	}
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/AfshariStewart_2016_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/AfshariStewart_2016_AttenRel.java
@@ -1,5 +1,7 @@
 package org.opensha.sha.imr.attenRelImpl;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -356,6 +358,15 @@ public class AfshariStewart_2016_AttenRel extends AttenuationRelationship {
 	 */
 	public String getShortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * This provides a URL where more info on this model can be obtained
+	 * @throws MalformedURLException if returned URL is not a valid URL.
+	 * @return the URL to the AttenuationRelationship document on the Web.
+	 */
+	public URL getInfoURL() throws MalformedURLException{
+		return new URL("https://doi.org/10.1193/063015eqs106m");
 	}
 
 	@Override

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/BA_2006_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/BA_2006_AttenRel.java
@@ -661,12 +661,15 @@ ParameterChangeListener {
 	}
 
 	/**
-	 * 
-	 * @throws MalformedURLException if returned URL is not a valid URL.
-	 * @return the URL to the AttenuationRelationship document on the Web.
+	 * This is a preliminary (pre-publication) implementation of the Boore &amp;
+	 * Atkinson (2008) model and was never published as its own paper, so it has
+	 * no DOI. Returns {@code null} so the plotter intentionally reports that no
+	 * information exists, rather than linking to the unrelated final (2008) paper.
+	 * @return null; no information URL exists for this preliminary model.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/documentation/modelsImplemented/attenRel/BA_2006.html");
+		// No DOI for this 2006 prelim model; intentionally return null.
+		return null;
 	}   
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/BA_2008_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/BA_2008_AttenRel.java
@@ -71,7 +71,7 @@ public class BA_2008_AttenRel extends AttenuationRelationship implements
 	public final static String NAME = "Boore & Atkinson (2008)";
 
 	// URL Info String
-	private final static String URL_INFO_STRING = "http://www.opensha.org/glossary-attenuationRelation-BOORE_ATKIN_2008";
+	private final static String URL_INFO_STRING = "https://doi.org/10.1193/1.2830434";
 
 
 	// coefficients:

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/BC_2004_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/BC_2004_AttenRel.java
@@ -1,5 +1,7 @@
 package org.opensha.sha.imr.attenRelImpl;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -495,6 +497,15 @@ public class BC_2004_AttenRel extends AttenuationRelationship {
 	 */
 	public String getShortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * This provides a URL where more info on this model can be obtained
+	 * @throws MalformedURLException if returned URL is not a valid URL.
+	 * @return the URL to the AttenuationRelationship document on the Web.
+	 */
+	public URL getInfoURL() throws MalformedURLException{
+		return new URL("https://doi.org/10.1785/0120030216");
 	}
 
 	/**

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/BJF_1997_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/BJF_1997_AttenRel.java
@@ -982,7 +982,7 @@ public class BJF_1997_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-BOORE_JOYNER_FUMAL_1997");
+		return new URL("https://doi.org/10.1785/gssrl.68.1.128");
 	}
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/BS_2003_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/BS_2003_AttenRel.java
@@ -1,5 +1,7 @@
 package org.opensha.sha.imr.attenRelImpl;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.DecimalFormat;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -614,6 +616,15 @@ public class BS_2003_AttenRel extends AttenuationRelationship {
 	 */
 	public String getShortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * This provides a URL where more info on this model can be obtained
+	 * @throws MalformedURLException if returned URL is not a valid URL.
+	 * @return the URL to the AttenuationRelationship document on the Web.
+	 */
+	public URL getInfoURL() throws MalformedURLException{
+		return new URL("https://doi.org/10.1785/0120020216");
 	}
 
 	/**

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2003_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2003_AttenRel.java
@@ -1135,7 +1135,7 @@ public class CB_2003_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-CAMPBELL_BOZORG_2003");
+		return new URL("https://doi.org/10.1785/0120020029");
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2006_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2006_AttenRel.java
@@ -1035,12 +1035,15 @@ public class CB_2006_AttenRel extends AttenuationRelationship implements
   }
 
   /**
-   * 
-   * @throws MalformedURLException if returned URL is not a valid URL.
-   * @return the URL to the AttenuationRelationship document on the Web.
+   * This is a preliminary (pre-publication) implementation of the Campbell &amp;
+   * Bozorgnia (2008) model and was never published as its own paper, so it has
+   * no DOI. Returns {@code null} so the plotter intentionally reports that no
+   * information exists, rather than linking to the unrelated final (2008) paper.
+   * @return null; no information URL exists for this preliminary model.
    */
   public URL getInfoURL() throws MalformedURLException{
-	  return new URL("http://www.opensha.org/documentation/modelsImplemented/attenRel/CB_2006.html");
+	  // No DOI for this 2006 prelim model; intentionally return null.
+	  return null;
   }   
   
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2008_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CB_2008_AttenRel.java
@@ -822,7 +822,7 @@ public class CB_2008_AttenRel extends AttenuationRelationship implements
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-CAMPBELL_BOZORG_2008");
+		return new URL("https://doi.org/10.1193/1.2857546");
 	}
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CS_2005_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CS_2005_AttenRel.java
@@ -1,5 +1,7 @@
 package org.opensha.sha.imr.attenRelImpl;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -504,6 +506,15 @@ public class CS_2005_AttenRel extends AttenuationRelationship {
 	 */
 	public String getShortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * This provides a URL where more info on this model can be obtained
+	 * @throws MalformedURLException if returned URL is not a valid URL.
+	 * @return the URL to the AttenuationRelationship document on the Web.
+	 */
+	public URL getInfoURL() throws MalformedURLException{
+		return new URL("https://doi.org/10.1193/1.1856535");
 	}
 
 	/**

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CY_2006_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CY_2006_AttenRel.java
@@ -893,12 +893,15 @@ public class CY_2006_AttenRel extends AttenuationRelationship implements
   }
 
   /**
-   * 
-   * @throws MalformedURLException if returned URL is not a valid URL.
-   * @return the URL to the AttenuationRelationship document on the Web.
+   * This is a preliminary (pre-publication) implementation of the Chiou &amp;
+   * Youngs (2008) model and was never published as its own paper, so it has no
+   * DOI. Returns {@code null} so the plotter intentionally reports that no
+   * information exists, rather than linking to the unrelated final (2008) paper.
+   * @return null; no information URL exists for this preliminary model.
    */
   public URL getInfoURL() throws MalformedURLException{
-	  return new URL("http://www.opensha.org/documentation/modelsImplemented/attenRel/CY_2006.html");
+	  // No DOI for this 2006 prelim model; intentionally return null.
+	  return null;
   }     
   
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/CY_2008_AttenRel.java
@@ -876,7 +876,7 @@ public class CY_2008_AttenRel extends AttenuationRelationship implements
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-CHIOU_YOUNGS_2008");
+		return new URL("https://doi.org/10.1193/1.2894832");
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/Campbell_1997_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/Campbell_1997_AttenRel.java
@@ -1053,7 +1053,7 @@ public class Campbell_1997_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-CAMPBELL_1997");
+		return new URL("https://doi.org/10.1785/gssrl.68.1.154");
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/Field_2000_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/Field_2000_AttenRel.java
@@ -754,7 +754,7 @@ public class Field_2000_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-FIELD_2000");
+		return new URL("https://doi.org/10.1785/0120000507");
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/McVerryetal_2000_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/McVerryetal_2000_AttenRel.java
@@ -91,7 +91,7 @@ public class McVerryetal_2000_AttenRel extends AttenuationRelationship implement
   public final static String NAME = "McVerry et al (2000)";
   
   // URL Info String
-  private final static String URL_INFO_STRING = "http://www.opensha.org/documentation/modelsImplemented/attenRel/McVerryetal_2000.html";
+  private final static String URL_INFO_STRING = "https://doi.org/10.5459/bnzsee.39.1.1-58";
 
 
   //Note unlike the NGA equations period=-1 here is PGA, 0.0 gives the 'primed' coefficients
@@ -780,6 +780,6 @@ public class McVerryetal_2000_AttenRel extends AttenuationRelationship implement
    * @return the URL to the AttenuationRelationship document on the Web.
    */
   public URL getInfoURL() throws MalformedURLException{
-	  return new URL("http://www.opensha.org/documentation/modelsImplemented/attenRel/McVerryetal_2000.html");
+	  return new URL("https://doi.org/10.5459/bnzsee.39.1.1-58");
   }
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/SA_InterpolatedWrapperAttenRel/InterpolatedBA_2008_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/SA_InterpolatedWrapperAttenRel/InterpolatedBA_2008_AttenRel.java
@@ -1,5 +1,8 @@
 package org.opensha.sha.imr.attenRelImpl.SA_InterpolatedWrapperAttenRel;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
 import org.opensha.sha.imr.attenRelImpl.BA_2008_AttenRel;
 
@@ -44,6 +47,15 @@ public class InterpolatedBA_2008_AttenRel
    */
   public String getShortName() {
     return SHORT_NAME;
+  }
+
+  /**
+   * This provides a URL where more info on this model can be obtained
+   * @throws MalformedURLException if returned URL is not a valid URL.
+   * @return the URL to the AttenuationRelationship document on the Web.
+   */
+  public URL getInfoURL() throws MalformedURLException{
+    return new URL("https://doi.org/10.1193/1.2830434");
   }
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/SEA_1999_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/SEA_1999_AttenRel.java
@@ -941,7 +941,7 @@ public class SEA_1999_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-SPUDICH_ETAL_1999");
+		return new URL("https://doi.org/10.1785/bssa0890051156");
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/SadighEtAl_1997_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/SadighEtAl_1997_AttenRel.java
@@ -802,7 +802,7 @@ public class SadighEtAl_1997_AttenRel extends AttenuationRelationship {
 	 * @return the URL to the AttenuationRelationship document on the Web.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-SADIGH_ETAL_1997");
+		return new URL("https://doi.org/10.1785/gssrl.68.1.180");
 	}
 
 

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/ShakeMap_2003_AttenRel.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/ShakeMap_2003_AttenRel.java
@@ -1271,12 +1271,15 @@ public class ShakeMap_2003_AttenRel extends AttenuationRelationship {
 	}
 
 	/**
-	 * This provides a URL where more info on this model can be obtained
-	 * @throws MalformedURLException if returned URL is not a valid URL.
-	 * @return the URL to the AttenuationRelationship document on the Web.
+	 * This is a hybrid/composite ShakeMap model rather than a single published
+	 * ground-motion model, so it has no DOI or web document to link to. Returns
+	 * {@code null} so the plotter intentionally reports that no information
+	 * exists, rather than linking to an unrelated page.
+	 * @return null; no information URL exists for this model.
 	 */
 	public URL getInfoURL() throws MalformedURLException{
-		return new URL("http://www.opensha.org/glossary-attenuationRelation-SHAKE_MAP_2003");
+		// No DOI/paper exists for ShakeMap (2003); intentionally return null.
+		return null;
 	}
 
 }

--- a/src/main/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_Wrappers.java
+++ b/src/main/java/org/opensha/sha/imr/attenRelImpl/ngaw2/NGAW2_Wrappers.java
@@ -1,5 +1,8 @@
 package org.opensha.sha.imr.attenRelImpl.ngaw2;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.opensha.commons.param.event.ParameterChangeWarningListener;
 
 @SuppressWarnings("javadoc")
@@ -14,6 +17,10 @@ public class NGAW2_Wrappers {
 			super(ASK_2014.SHORT_NAME, new ASK_2014(), true);
 			this.listener = l;
 		}
+
+		public URL getInfoURL() throws MalformedURLException {
+			return new URL("https://doi.org/10.1193/070913eqs198m");
+		}
 		
 	}
 	public static class BSSA_2014_Wrapper extends NGAW2_WrapperFullParam {
@@ -25,6 +32,10 @@ public class NGAW2_Wrappers {
 		public BSSA_2014_Wrapper(ParameterChangeWarningListener l) {
 			super(BSSA_2014.SHORT_NAME, new BSSA_2014(), true);
 			this.listener = l;
+		}
+
+		public URL getInfoURL() throws MalformedURLException {
+			return new URL("https://doi.org/10.1193/070113eqs184m");
 		}
 		
 	}
@@ -38,6 +49,10 @@ public class NGAW2_Wrappers {
 			super(CB_2014.SHORT_NAME, new CB_2014(), true);
 			this.listener = l;
 		}
+
+		public URL getInfoURL() throws MalformedURLException {
+			return new URL("https://doi.org/10.1193/062913eqs175m");
+		}
 		
 	}
 	public static class CY_2014_Wrapper extends NGAW2_WrapperFullParam {
@@ -49,6 +64,10 @@ public class NGAW2_Wrappers {
 		public CY_2014_Wrapper(ParameterChangeWarningListener l) {
 			super(CY_2014.SHORT_NAME, new CY_2014(), true);
 			this.listener = l;
+		}
+
+		public URL getInfoURL() throws MalformedURLException {
+			return new URL("https://doi.org/10.1193/072813eqs219m");
 		}
 		
 	}
@@ -73,6 +92,10 @@ public class NGAW2_Wrappers {
 		public Idriss_2014_Wrapper(ParameterChangeWarningListener l) {
 			super(Idriss_2014.SHORT_NAME, new Idriss_2014(), false);
 			this.listener = l;
+		}
+
+		public URL getInfoURL() throws MalformedURLException {
+			return new URL("https://doi.org/10.1193/070613eqs195m");
 		}
 		
 	}

--- a/src/main/java/org/opensha/sha/imr/mod/impl/stewartSiteSpecific/StewartAfshariGoulet2017NonergodicGMPE.java
+++ b/src/main/java/org/opensha/sha/imr/mod/impl/stewartSiteSpecific/StewartAfshariGoulet2017NonergodicGMPE.java
@@ -1,6 +1,8 @@
 package org.opensha.sha.imr.mod.impl.stewartSiteSpecific;
 
 import java.awt.Dimension;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.EnumSet;
 import java.util.ListIterator;
 
@@ -112,6 +114,15 @@ public class StewartAfshariGoulet2017NonergodicGMPE extends ModAttenuationRelati
 	@Override
 	public String getShortName() {
 		return SHORT_NAME;
+	}
+
+	/**
+	 * This provides a URL where more info on this model can be obtained
+	 * @throws MalformedURLException if returned URL is not a valid URL.
+	 * @return the URL to the AttenuationRelationship document on the Web.
+	 */
+	public URL getInfoURL() throws MalformedURLException{
+		return new URL("https://doi.org/10.1193/081716eqs135m");
 	}
 	
 	public NonErgodicSiteResponseMod getMod() {

--- a/src/test/java/org/opensha/sha/imr/attenRelImpl/gui/AttenuationRelationshipInfoURLTest.java
+++ b/src/test/java/org/opensha/sha/imr/attenRelImpl/gui/AttenuationRelationshipInfoURLTest.java
@@ -1,0 +1,124 @@
+package org.opensha.sha.imr.attenRelImpl.gui;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Constructor;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.opensha.commons.param.event.ParameterChangeWarningListener;
+import org.opensha.sha.imr.IntensityMeasureRelationship;
+
+/**
+ * Verifies the "Get Info" URL wiring for every attenuation relationship offered
+ * by the {@link AttenuationRelationshipApplet} "Attenuation Relationship
+ * Plotter".
+ * <p>
+ * Each model that has a published paper must return its paper's DOI
+ * ({@code https://doi.org/...}). The few models with no published paper or DOI
+ * of their own (conference-only, hybrid, or preliminary pre-publication models)
+ * intentionally return {@code null} from {@code getInfoURL()} so the plotter
+ * reports "No information exists for the selected Attenuation Relationship"
+ * deliberately rather than linking to an unrelated page; the missing DOI is
+ * documented in each such {@code getInfoURL()}.
+ * <p>
+ * This guards against regressions where a model with a paper falls through to
+ * the throwing default in {@code AbstractIMR.getInfoURL()}, which the plotter
+ * also reports as "No information exists".
+ *
+ * @author Akash Bhatthal
+ */
+public class AttenuationRelationshipInfoURLTest {
+
+	/**
+	 * Models that intentionally have no information URL (no published paper or
+	 * DOI of their own). These must return {@code null} from
+	 * {@code getInfoURL()}; every other plotter model must return a DOI. The
+	 * missing DOI for each is documented in its {@code getInfoURL()}.
+	 */
+	private static final Set<String> NO_PAPER_MODELS = Collections
+			.unmodifiableSet(new HashSet<>(Arrays.asList(
+					"org.opensha.sha.imr.attenRelImpl.Abrahamson_2000_AttenRel",
+					"org.opensha.sha.imr.attenRelImpl.ShakeMap_2003_AttenRel",
+					"org.opensha.sha.imr.attenRelImpl.CY_2006_AttenRel",
+					"org.opensha.sha.imr.attenRelImpl.CB_2006_AttenRel",
+					"org.opensha.sha.imr.attenRelImpl.BA_2006_AttenRel")));
+
+	/**
+	 * Every model in the plotter dropdown must return either its paper's DOI
+	 * or, for the known no-paper models, intentionally {@code null}.
+	 */
+	@Test
+	public void allPlotterModelsHaveInfoURL() throws Exception {
+		List<String> failures = new ArrayList<>();
+		Set<String> seenNoPaper = new HashSet<>();
+		int checked = 0;
+		for (String className : AttenuationRelationshipApplet.attenRelClasses) {
+			checked++;
+			try {
+				IntensityMeasureRelationship imr = instantiate(className);
+				URL url = imr.getInfoURL();
+				if (NO_PAPER_MODELS.contains(className)) {
+					seenNoPaper.add(className);
+					if (url != null) {
+						failures.add(className
+								+ ": no-paper model should return null, got "
+								+ url.toExternalForm());
+					} else {
+						System.out.println(className + " -> null (intentional)");
+					}
+					continue;
+				}
+				if (url == null) {
+					failures.add(className + ": getInfoURL() returned null");
+					continue;
+				}
+				String ext = url.toExternalForm();
+				System.out.println(className + " -> " + ext);
+				if (!ext.startsWith("https://doi.org/")) {
+					failures.add(className + ": unexpected URL " + ext);
+				}
+			} catch (Throwable t) {
+				failures.add(className + ": " + t.getClass().getSimpleName()
+						+ ": " + t.getMessage());
+			}
+		}
+		// Every declared no-paper model must actually appear in the plotter
+		// dropdown, otherwise a misspelled class name would silently skip it.
+		Set<String> missingNoPaper = new HashSet<>(NO_PAPER_MODELS);
+		missingNoPaper.removeAll(seenNoPaper);
+		for (String m : missingNoPaper) {
+			failures.add(m + ": declared no-paper model not in plotter dropdown");
+		}
+		if (!failures.isEmpty()) {
+			fail("Get Info URL wiring failures (" + failures.size() + "/" + checked
+					+ "):\n  - " + String.join("\n  - ", failures));
+		}
+		assertTrue("no plotter models were checked", checked > 0);
+	}
+
+	/**
+	 * Instantiate an attenuation relationship by class name, mirroring the
+	 * reflection path the plotter uses: prefer the constructor that accepts a
+	 * {@link ParameterChangeWarningListener} (passing {@code null}), then fall
+	 * back to the no-arg constructor.
+	 */
+	private static IntensityMeasureRelationship instantiate(String className)
+			throws Exception {
+		Class<?> clazz = Class.forName(className);
+		try {
+			Constructor<?> c = clazz
+					.getConstructor(ParameterChangeWarningListener.class);
+			return (IntensityMeasureRelationship) c
+					.newInstance((ParameterChangeWarningListener) null);
+		} catch (NoSuchMethodException e) {
+			return (IntensityMeasureRelationship) clazz.getConstructor().newInstance();
+		}
+	}
+}


### PR DESCRIPTION
## Problem

In the **Attenuation Relationship Plotter**, the **Get Info** button was broken for every model:

- Most models showed *"No information exists for the selected Attenuation Relationship"* — they don't override `getInfoURL()` and inherit `AbstractIMR.getInfoURL()`, which does `return new URL(null)` and throws, caught by the handler as the "No information exists" message. This includes all five NGA‑West2 2014 models (e.g. Boore, Stewart, Seyhan & Atkinson (2014)).
- The classic models that *did* supply a URL opened **404s**, because their URLs pointed at dead `opensha.org` per‑model WordPress glossary pages (e.g. Campbell & Bozorgnia (2003) → `https://opensha.org/glossary-attenuationRelation-CAMPBELL_BOZORG_2003`). The OpenSHA site is now generated from the [GitHub wiki](https://github.com/opensha/opensha/wiki); those per‑model pages are gone with no replacement.

## Fix

Wire every model in the plotter's dropdown (`AttenuationRelationshipApplet.attenRelClasses`, 35 entries) to a real reference:

- **30 models** return their original paper's DOI (`https://doi.org/...`), matched against Crossref to the exact journal/volume/pages cited in each model's Javadoc.
- **5 models** with no published paper or DOI of their own intentionally return `null` from `getInfoURL()` so the plotter deliberately shows *"No information exists"*, with the missing DOI documented in each `getInfoURL()`:
  - **Abrahamson (2000)** — conference presentation only, never a journal article
  - **ShakeMap (2003)** — hybrid/composite model, no single reference
  - **Chiou & Youngs (2006 prelim)**, **Campbell & Bozorgnia (2006 prelim)**, **Boore & Atkinson (2006 prelim)** — pre‑publication drafts of the 2008 papers, never published as their own papers

`AbstractIMR` and the applet handler are **unchanged** — the existing handler already does the right thing once models return a valid URL (or intentionally `null`).

Three change patterns, all localized per‑model (no shared URL builder existed):
- **A** — repoint an existing dead URL string/`URL_INFO_STRING` constant to the DOI (17 models).
- **B** — add a `getInfoURL()` override (+ `java.net` imports) where none existed (13 models; `GouletEtAl_2006` inherits `BC_2004`'s override for the same DOI).
- **C** — add `getInfoURL()` overrides to the five NGA‑West2 wrapper inner classes in `NGAW2_Wrappers.java`.

## Verification

- ✅ `./gradlew compileJava` and `compileTestJava` succeed.
- ✅ New `AttenuationRelationshipInfoURLTest` iterates all 35 entries in `AttenuationRelationshipApplet.attenRelClasses`, instantiates each via the same reflection path the plotter uses, calls `getInfoURL()`, and asserts the two‑way contract: the 5 no‑paper models return `null`, every other model returns a `https://doi.org/...` URL. It also fails if any declared no‑paper class name isn't actually in the plotter dropdown. **35/35 pass** (5 intentional `null` + 30 DOIs).
- ⏳ Manual end‑to‑end (reviewer): run the plotter, pick e.g. Boore Stewart Seyhan & Atkinson (2014) → DOI opens; Campbell & Bozorgnia (2003) → DOI opens (was 404); ShakeMap (2003) → "No information exists" dialog (was glossary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)